### PR TITLE
Validate terraform in src/core

### DIFF
--- a/build/validate_tf.sh
+++ b/build/validate_tf.sh
@@ -24,31 +24,34 @@ full_path=$(realpath "${0}")
 repo_path=$(dirname "$(dirname "${full_path}")")
 core_path="${repo_path}/src/core"
 
-# Validate all .tf files
-program_log "Validating Terraform..."
-cd "${core_path}" || exit
-for i in $(find . -name "*.tf" -printf "%h\n" | sort --unique)
-do
-  cd "${i}" || exit
-  echo "validating ${i}..."
-  terraform init -backend=false >> /dev/null || exit 1
-  terraform validate >> /dev/null || exit 1
-  cd "${core_path}" || exit
-done
-program_log "Terraform validated successfully!"
-
-# Check formatting for all .tf files
-program_log "Linting Terraform..."
-cd "${repo_path}" || exit
-if terraform fmt -check -recursive >> /dev/null;
+if [ -d "$core_path" ];
 then
-  program_log "Terraform linted successfully!"
-else
-  linting_results=$(terraform fmt -check -recursive)
-  for j in $linting_results
+  # Validate all .tf and their dependencies in core_path
+  program_log "Validating Terraform..."
+  cd "${core_path}" || exit
+  for i in $(find . -name "*.tf" -printf "%h\n" | sort --unique)
   do
-    error_log "please format '${j}' with the command 'terraform fmt'"
+    cd "${i}" || exit
+    echo "validating ${i}..."
+    terraform init -backend=false >> /dev/null || exit 1
+    terraform validate >> /dev/null || exit 1
+    cd "${core_path}" || exit
   done
-  program_log "alternatively, you can run 'terraform fmt -recursive' to format all *.tf in a directory"
-  exit 1;
+  program_log "Terraform validated successfully!"
+
+  # Check formatting in all .tf files in repo
+  program_log "Linting Terraform..."
+  cd "${repo_path}" || exit
+  if terraform fmt -check -recursive >> /dev/null;
+  then
+    program_log "Terraform linted successfully!"
+  else
+    linting_results=$(terraform fmt -check -recursive)
+    for j in $linting_results
+    do
+      error_log "please format '${j}' with the command 'terraform fmt'"
+    done
+    program_log "alternatively, you can run 'terraform fmt -recursive' to format all *.tf in a directory"
+    exit 1;
+  fi
 fi


### PR DESCRIPTION
This addresses an issue where our submodules that do not declare a provider block were throwing validation errors in PR builds.

Turns out that `terraform validate` will walk all of your dependencies and validate those too.