### PR TITLE
[abandoned for #84] use azurerm 2.50 in src/core to hard delete Log Analytics Workspaces

### DIFF
--- a/src/core/saca-hub/main.tf
+++ b/src/core/saca-hub/main.tf
@@ -2,19 +2,10 @@
 # Licensed under the MIT License.
 terraform {
   backend "azurerm" {}
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "2.45.1"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.1.0"
-    }
-  }
 }
 
 provider "azurerm" {
+  version         = "~> 2.50.0"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
   tenant_id       = var.mlz_tenantid
@@ -22,7 +13,15 @@ provider "azurerm" {
   client_id       = var.mlz_clientid
   client_secret   = var.mlz_clientsecret
 
-  features {}
+  features {
+    log_analytics_workspace {
+      permanently_delete_on_destroy = true
+    }
+  }
+}
+
+provider "random" {
+  version = "3.1.0"
 }
 
 resource "azurerm_resource_group" "hub" {

--- a/src/core/tier-0/main.tf
+++ b/src/core/tier-0/main.tf
@@ -2,19 +2,10 @@
 # Licensed under the MIT License.
 terraform {
   backend "azurerm" {}
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "2.45.1"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.1.0"
-    }
-  }
 }
 
 provider "azurerm" {
+  version         = "~> 2.50.0"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
   tenant_id       = var.mlz_tenantid
@@ -26,6 +17,7 @@ provider "azurerm" {
 }
 
 provider "azurerm" {
+  version         = "~> 2.50.0"
   alias           = "hub"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
@@ -35,6 +27,10 @@ provider "azurerm" {
   client_secret   = var.mlz_clientsecret
 
   features {}
+}
+
+provider "random" {
+  version = "3.1.0"
 }
 
 data "azurerm_resource_group" "hub" {

--- a/src/core/tier-1/main.tf
+++ b/src/core/tier-1/main.tf
@@ -2,19 +2,10 @@
 # Licensed under the MIT License.
 terraform {
   backend "azurerm" {}
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "2.45.1"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.1.0"
-    }
-  }
 }
 
 provider "azurerm" {
+  version         = "~> 2.50.0"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
   tenant_id       = var.mlz_tenantid
@@ -26,6 +17,7 @@ provider "azurerm" {
 }
 
 provider "azurerm" {
+  version         = "~> 2.50.0"
   alias           = "hub"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
@@ -35,6 +27,10 @@ provider "azurerm" {
   client_secret   = var.mlz_clientsecret
 
   features {}
+}
+
+provider "random" {
+  version = "3.1.0"
 }
 
 data "azurerm_resource_group" "hub" {

--- a/src/core/tier-2/main.tf
+++ b/src/core/tier-2/main.tf
@@ -2,15 +2,10 @@
 # Licensed under the MIT License.
 terraform {
   backend "azurerm" {}
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "2.45.1"
-    }
-  }
 }
 
 provider "azurerm" {
+  version         = "~> 2.50.0"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
   tenant_id       = var.mlz_tenantid
@@ -22,6 +17,7 @@ provider "azurerm" {
 }
 
 provider "azurerm" {
+  version         = "~> 2.50.0"
   alias           = "hub"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
@@ -31,6 +27,10 @@ provider "azurerm" {
   client_secret   = var.mlz_clientsecret
 
   features {}
+}
+
+provider "random" {
+  version = "3.1.0"
 }
 
 data "azurerm_resource_group" "hub" {


### PR DESCRIPTION
# !!! do not merge (yet) !!!

This change is dependent upon completion of #61

# Description

Update the `azurerm` providers for terraform configurations under `src/core` to `~> 2.50.0` so that Log Analytics Workspaces hard-delete themselves on terraform destroy

## Issue reference

The issue this PR will close: #79
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
