### PR TITLE
use unique diagnostic settings names

### DIFF
--- a/src/modules/firewall/main.tf
+++ b/src/modules/firewall/main.tf
@@ -59,7 +59,7 @@ locals {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "firewall-diagnostics" {
-  name                       = "${azurerm_firewall.firewall.name}-diagnostics"
+  name                       = "${azurerm_firewall.firewall.name}-fw-diagnostics"
   target_resource_id         = azurerm_firewall.firewall.id
   storage_account_id         = azurerm_storage_account.loganalytics.id
   log_analytics_workspace_id = var.log_analytics_workspace_id
@@ -85,7 +85,7 @@ resource "azurerm_monitor_diagnostic_setting" "firewall-diagnostics" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "publicip-diagnostics" {
-  name                       = "${azurerm_public_ip.firewall.name}-diagnostics"
+  name                       = "${azurerm_public_ip.firewall.name}-pip-diagnostics"
   target_resource_id         = azurerm_public_ip.firewall.id
   storage_account_id         = azurerm_storage_account.loganalytics.id
   log_analytics_workspace_id = var.log_analytics_workspace_id

--- a/src/modules/subnet/main.tf
+++ b/src/modules/subnet/main.tf
@@ -67,7 +67,7 @@ locals {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "nsg" {
-  name                       = "${azurerm_network_security_group.nsg.name}-diagnostics"
+  name                       = "${azurerm_network_security_group.nsg.name}-nsg-diagnostics"
   target_resource_id         = azurerm_network_security_group.nsg.id
   storage_account_id         = var.log_analytics_storage_id
   log_analytics_workspace_id = var.log_analytics_workspace_id

--- a/src/modules/virtual-network/main.tf
+++ b/src/modules/virtual-network/main.tf
@@ -28,7 +28,7 @@ resource "azurerm_storage_account" "loganalytics" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "vnet" {
-  name                       = "${var.vnet_name}-diagnosticsetting"
+  name                       = "${var.vnet_name}-vn-diagnostics"
   target_resource_id         = azurerm_virtual_network.vnet.id
   storage_account_id         = azurerm_storage_account.loganalytics.id
   log_analytics_workspace_id = var.log_analytics_workspace_id


### PR DESCRIPTION
# Description

Some of the diagnostic settings can be easily confused or in some cases duplicates of each other because of variable names.

This change hardcodes some uniqueness for the diagnostic settings that are the repository today.

## Issue reference

The issue this PR will close: #81

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] The documentation is updated to cover any new or changed features
* [x] Relevant issues are linked to this PR
