### PR TITLE
use hashicorp Action in validate-terraform workflow instead of devcontainer

### DIFF
--- a/.github/workflows/validate-terraform.yml
+++ b/.github/workflows/validate-terraform.yml
@@ -6,18 +6,15 @@ on: [pull_request, workflow_dispatch]
 jobs:
   validate-terraform:
     runs-on: ubuntu-latest
-    container:
-      image: acrmlzcicd.azurecr.io/missionlzdev
-      credentials:
-        username: ${{ secrets.acr_username }}
-        password: ${{ secrets.acr_password }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 0.13.4
     - shell: bash
       name: check tooling versions
       run: |
-        az version
         terraform -version
+    - uses: actions/checkout@v2
     - shell: bash
       name: validate and lint terraform
       run: |


### PR DESCRIPTION
# Description

Use [hashicorp's setup-terraform GitHub Action](https://github.com/hashicorp/setup-terraform) to download Terraform CLI and add it to the agent for the validate-terraform.yml workflow instead of using our dev container.

## Issue reference

The issue this PR will close: #103

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
