### PR TITLE
removing unnecessary background on link text

### DIFF
--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -20,7 +20,7 @@ The develoment container is not necessary if you want to use the Mission LZ user
 
 ## Pre-Requisites
 
-Operating system: Mac OS, Linux, or [`Windows 10 with Windows Subsystem for Linux (WSL)`](https://docs.microsoft.com/en-us/windows/wsl/install-win10) or a Linux virtual machine. (We developed this on Windows 10/WSL running Ubuntu 20.04.)
+Operating system: Mac OS, Linux, or [Windows 10 with Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install-win10) (We developed this on Windows 10/WSL running Ubuntu 20.04).
 
 Docker: Docker Desktop or Docker CE (We use Docker Desktop on Windows 10, integrated with WSL.)
 


### PR DESCRIPTION
# Description

The link I created in the previous pull request had a grey background on the link text that this removes. Also, the wording also had a redundant reference to "or Linux Virtual Machine" that is now removed.

## Issue reference

The issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
