### PR TITLE
use MLZ_LOCATION instead of reserved term Location

### DIFF
--- a/src/core/globals.front.json
+++ b/src/core/globals.front.json
@@ -32,7 +32,7 @@
 			{
 				"varname": "mlz_location",
 				"type": "text",
-				"default_val": "env:LOCATION",
+				"default_val": "env:MLZ_LOCATION",
 				"description": "The location that you're deploying to.",
 				"options": []
 			}

--- a/src/front/main.py
+++ b/src/front/main.py
@@ -146,9 +146,9 @@ async def home(request: Request):
             })
             $('#promptModal').modal('show')
         }
-    
+
         var interval = null
-        function retrieve_results() { 
+        function retrieve_results() {
           $.ajax({
            type: "GET",
            url: "/poll",
@@ -157,23 +157,23 @@ async def home(request: Request):
            }
          });
         }
-        
+
         function submitForm(){
             interval = setInterval(retrieve_results, 2000);
         }
-        
+
         $(document).ready(function(){
             $('#showTenant').click(function(){
                 promptTenant()
             })
-               
+
             logged_in = readCookie("user")
-        
+
             if(!logged_in || $.trim(logged_in) == ""){
               promptLogin()
             }
         })
-        
+
         $(document).on('submit', '#terraform_config', function(e) {
             $('#promptModal').on('show.bs.modal', function (event) {
               var modal = $(this)
@@ -327,7 +327,7 @@ async def process_input(request: Request):
         f.writelines("tf_environment=\"" + os.getenv("TF_ENV") + "\"\n" +
                      "mlz_env_name=\"" + os.getenv("MLZ_ENV") + "\"\n" +
                      "mlz_config_subid=\"" + os.getenv("SUBSCRIPTION_ID") + "\"\n" +
-                     "mlz_config_location=\"" + os.getenv("LOCATION") + "\"\n" +
+                     "mlz_config_location=\"" + os.getenv("MLZ_LOCATION") + "\"\n" +
                      "mlz_tenantid=\"" + os.getenv("TENANT_ID") + "\"\n" +
                      "mlz_tier0_subid=\"" + form_values["tier0_subid"] + "\"\n" +
                      "mlz_tier1_subid=\"" + form_values["tier1_subid"] + "\"\n" +
@@ -348,8 +348,8 @@ async def process_input(request: Request):
     tier2 = os.path.join(os.getcwd(), "config_output", "tier-2.tfvars.json")
 
     if keyVaultName:
-        sp_id = secret_client.get_secret("login-app-clientid").value
-        sp_pwd = secret_client.get_secret("login-app-clientid").value
+        sp_id = secret_client.get_secret("serviceprincipal-clientid").value
+        sp_pwd = secret_client.get_secret("serviceprincipal-pwd").value
     else:
         sp_id = os.getenv("MLZCLIENTID", "NotSet")
         sp_pwd = os.getenv("MLZCLIENTSECRET", "NotSet")

--- a/src/scripts/setup_ezdeploy.sh
+++ b/src/scripts/setup_ezdeploy.sh
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# shellcheck disable=SC1090,SC1091
+# shellcheck disable=SC1090,SC1091,2154
 # SC1090: Can't follow non-constant source. Use a directive to specify location.
 # SC1091: Not following. Shellcheck can't follow non-constant source.
 # SC2154: "var is referenced but not assigned". These values come from an external file.
@@ -109,7 +109,7 @@ if [[ $docker_strategy != "local" ]]; then
   az acr login --name "${mlz_acr_name}"
 
   ACR_REGISTRY_ID=$(az acr show --name "${mlz_acr_name}" --query id --output tsv)
-  az role assignment create --assignee "$(az keyvault secret show --name "${mlz_sp_kv_name}" --vault-name "${mlz_kv_name}" --query value --output tsv)" --scope $ACR_REGISTRY_ID --role acrpull
+  az role assignment create --assignee "$(az keyvault secret show --name "${mlz_sp_kv_name}" --vault-name "${mlz_kv_name}" --query value --output tsv)" --scope "${ACR_REGISTRY_ID}" --role acrpull
 
   echo "INFO: pushing docker container"
   docker tag lzfront:latest "${mlz_acr_name}".azurecr.io/lzfront:latest

--- a/src/scripts/setup_ezdeploy.sh
+++ b/src/scripts/setup_ezdeploy.sh
@@ -38,7 +38,7 @@ while getopts "d:s:t:l:e:m:p:0:1:2:3:4:" opts; do
     s) export mlz_config_subid=${OPTARG}
       subs+=("${OPTARG}")
       ;;
-    t) export mlz_tenantid=${OPTARG} 
+    t) export mlz_tenantid=${OPTARG}
       ;;
     l) export mlz_config_location=${OPTARG}
       ;;
@@ -95,7 +95,7 @@ if [[ $docker_strategy != "local" ]]; then
   az acr create \
   --resource-group "${mlz_rg_name}" \
   --name "${mlz_acr_name}" \
-  --sku Basic 
+  --sku Basic
 
   echo "Waiting for registry completion and running post process to enable admin on ACR"
   sleep 60
@@ -122,7 +122,7 @@ if [[ $docker_strategy != "local" ]]; then
   --name "${mlz_instance_name}" \
   --image "$ACR_LOGIN_SERVER"/lzfront:latest \
   --dns-name-label "${mlz_dns_name}" \
-  --environment-variables KEYVAULT_ID="${mlz_kv_name}" TENANT_ID="${mlz_tenantid}" LOCATION="${mlz_config_location}" SUBSCRIPTION_ID="${mlz_config_subid}" TF_ENV="${tf_environment}" MLZ_ENV="${mlz_env_name}" \
+  --environment-variables KEYVAULT_ID="${mlz_kv_name}" TENANT_ID="${mlz_tenantid}" MLZ_LOCATION="${mlz_config_location}" SUBSCRIPTION_ID="${mlz_config_subid}" TF_ENV="${tf_environment}" MLZ_ENV="${mlz_env_name}" \
   --registry-username "$(az keyvault secret show --name "${mlz_sp_kv_name}" --vault-name "${mlz_kv_name}" --query value --output tsv)" \
   --registry-password "$(az keyvault secret show --name "${mlz_sp_kv_password}" --vault-name "${mlz_kv_name}" --query value --output tsv)" \
   --ports 80 \
@@ -177,6 +177,7 @@ az keyvault secret set \
 
 echo "KeyVault updated with Login App Registration secret!"
 echo "All steps have been completed you will need the following to access the configuration utility:"
+
 if [[ $docker_strategy == "local" ]]; then
   echo "Your environment variables for local execution are:"
   echo "Copy-Paste:"
@@ -200,7 +201,6 @@ if [[ $docker_strategy == "local" ]]; then
   echo "\$env:MLZ_ENV='$mlz_env_name'"
   echo "\$env:MLZCLIENTID='$(az keyvault secret show --name "${mlz_sp_kv_name}" --vault-name "${mlz_kv_name}" --query value --output tsv)'"
   echo "\$env:MLZCLIENTSECRET='$(az keyvault secret show --name "${mlz_sp_kv_password}" --vault-name "${mlz_kv_name}" --query value --output tsv)'"
- 
 else
   echo "You can access the front end at http://$fqdn"
 fi


### PR DESCRIPTION
# Description

As noted in #138 , the UI will return 500's when trying to execute terraform because the environment variable `Location` is a reserved key. This change uses `MLZ_LOCATION` instead.

## Issue reference

The issue this PR will close: #138

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
