### PR TITLE
use arguments for build scripts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -75,6 +75,7 @@ For more on workflows: <https://docs.github.com/en/actions/reference/workflow-sy
 
     Secret Name | Value
     ------------ | -------------
+    MLZTENANTID | The Tenant to deploy MLZ into
     MLZCLIENTID | The Service Principal Authorized to deploy resources into MLZ Terraform Subscriptions
     MLZCLIENTSECRET | The credential for the Service Principal above
     STORAGEACCOUNT | The Azure Storage Account for the files in the previous step

--- a/.github/workflows/apply-and-destroy-terraform.yml
+++ b/.github/workflows/apply-and-destroy-terraform.yml
@@ -28,12 +28,12 @@ jobs:
     - name: get vars
       run : |
         cd src/build
-        ./get_vars.sh
+        ./get_vars.sh "$STORAGEACCOUNT" "$STORAGETOKEN" "$STORAGECONTAINER"
 
     - name: login
       run : |
         cd src/build
-        ./login_azcli.sh vars/mlz_tf_cfg.var
+        ./login_azcli.sh "$MLZTENANTID" "$MLZCLIENTID" "$MLZCLIENTSECRET"
 
     - name: apply terraform
       run : |

--- a/src/build/get_vars.sh
+++ b/src/build/get_vars.sh
@@ -7,15 +7,33 @@
 
 set -e
 
+error_log() {
+  echo "${1}" 1>&2;
+}
+
+usage() {
+  echo "get_vars.sh: login using known Service Principal credentials into a given tenant"
+  error_log "usage: get_vars.sh.sh <storage account name> <storage account token> <storage account container>"
+}
+
+if [[ "$#" -lt 3 ]]; then
+   usage
+   exit 1
+fi
+
+sa_name=$1
+sa_token=$2
+sa_container=$3
+
 # create some place to hold the configuration and TF vars
 rm -rf "vars"
 mkdir "vars"
 
 # download everything in the container to that place
 az storage blob download-batch \
-  --account-name "${STORAGEACCOUNT}" \
-  --sas-token "${STORAGETOKEN}" \
-  --source "${STORAGECONTAINER}" \
+  --account-name "${sa_name}" \
+  --sas-token "${sa_token}" \
+  --source "${sa_container}" \
   --pattern "*" \
   --destination "vars" \
   --output "none" \

--- a/src/build/login_azcli.sh
+++ b/src/build/login_azcli.sh
@@ -16,27 +16,23 @@ error_log() {
 }
 
 usage() {
-  echo "login_azcli.sh: Get the tenant ID from some MLZ configuration file and login using known Service Principal credentials"
-  error_log "usage: login_azcli.sh <mlz config> <SP_ID> <SP_PW>"
+  echo "login_azcli.sh: login using known Service Principal credentials into a given tenant"
+  error_log "usage: login_azcli.sh <tenant ID> <service principal ID> <service principal password>"
 }
 
-if [[ "$#" -lt 1 ]]; then
+if [[ "$#" -lt 3 ]]; then
    usage
    exit 1
 fi
 
-mlz_config=$1
-
-# source the variables from MLZ config
-source "${mlz_config}"
-
-sp_id=${2:-$MLZCLIENTID}
-sp_pw=${3:-$MLZCLIENTSECRET}
+tenant_id=$1
+sp_id=$2
+sp_pw=$3
 
 # login with known credentials
 az login --service-principal \
   --user "${sp_id}" \
   --password="${sp_pw}" \
-  --tenant "${mlz_tenantid}" \
+  --tenant "${tenant_id}" \
   --allow-no-subscriptions \
   --output json


### PR DESCRIPTION
# Description

As mentioned in #136, to support other types of CI technology, this change updates the automation scripts in /build (specifically those to get .tfvars files, an MLZ config file, and to login to az cli) to pass arguments instead of relying on keyvault values mapped to the environment and updates the sample workflow with these new arguments.

## Issue reference

The issue this PR will close: #136

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
