### PR TITLE
Disable SNAT regardless of the destination IP address (Firewall) since forced tunneling is turned on

### DIFF
--- a/src/modules/firewall/main.tf
+++ b/src/modules/firewall/main.tf
@@ -29,7 +29,7 @@ resource "azurerm_firewall" "firewall" {
   location            = data.azurerm_resource_group.hub.location
   resource_group_name = data.azurerm_resource_group.hub.name
   sku_tier            = var.firewall_sku
-  private_ip_ranges   = var.firewall_disable_snat
+  private_ip_ranges   = var.disable_snat_ip_range
   tags                = var.tags
 
   ip_configuration {

--- a/src/modules/firewall/main.tf
+++ b/src/modules/firewall/main.tf
@@ -29,6 +29,7 @@ resource "azurerm_firewall" "firewall" {
   location            = data.azurerm_resource_group.hub.location
   resource_group_name = data.azurerm_resource_group.hub.name
   sku_tier            = var.firewall_sku
+  private_ip_ranges   = var.firewall_disable_snat
   tags                = var.tags
 
   ip_configuration {

--- a/src/modules/firewall/variables.tf
+++ b/src/modules/firewall/variables.tf
@@ -50,7 +50,11 @@ variable "tags" {
   default     = {}
 }
 
-variable "firewall_disable_snat" {
+# With forced tunneling on, Configure Azure Firewall to never SNAT regardless of the destination IP address, 
+# use 0.0.0.0/0 as your private IP address range. 
+# With this configuration, Azure Firewall can never route traffic directly to the Internet.
+# see: https://docs.microsoft.com/en-us/azure/firewall/snat-private-range
+variable "disable_snat_ip_range" {
   description = "The address space to be used to ensure that SNAT is disabled."
   default     = ["0.0.0.0/0"]
   type        = list

--- a/src/modules/firewall/variables.tf
+++ b/src/modules/firewall/variables.tf
@@ -52,6 +52,6 @@ variable "tags" {
 
 variable "firewall_disable_snat" {
   description = "The address space to be used to ensure that SNAT is disabled."
-  default     = "0.0.0.0/0"
+  default     = ["0.0.0.0/0"]
   type        = string
 }

--- a/src/modules/firewall/variables.tf
+++ b/src/modules/firewall/variables.tf
@@ -53,5 +53,5 @@ variable "tags" {
 variable "firewall_disable_snat" {
   description = "The address space to be used to ensure that SNAT is disabled."
   default     = ["0.0.0.0/0"]
-  type        = string
+  type        = list
 }

--- a/src/modules/firewall/variables.tf
+++ b/src/modules/firewall/variables.tf
@@ -49,3 +49,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "firewall_disable_snat" {
+  description = "The address space to be used to ensure that SNAT is disabled."
+  default     = "0.0.0.0/0"
+  type        = string
+}


### PR DESCRIPTION
# Description

 Configure the firewall to never SNAT regardless of the destination IP address, preventing Azure Firewall from routing traffic directly to the internet

## Issue reference

The issue this PR will close: #118 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x ] Code compiles or validates correctly
* [ ] BASH scripts have been validated using `shellcheck`
* [x ] All tests pass (manual and automated)
* [ ] The documentation is updated to cover any new or changed features
* [ ] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x ] Relevant issues are linked to this PR
