### PR TITLE
pin azure cli to 2.22.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -69,7 +69,7 @@ RUN AZ_REPO=$(lsb_release -cs) \
     tee /etc/apt/sources.list.d/azure-cli.list
 
 # Install AZ CLI
-RUN apt-get update && apt-get install -y azure-cli
+RUN apt-get update && apt-get install -y azure-cli=2.22.0-1~focal
 
 # Add the vscode user
 ARG USERNAME=vscode

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -14,14 +14,14 @@ RUN apt-get update \
         unzip \
         wget \
         python3 \
-        sed \ 
+        sed \
         python3-pip
 
 
 # Install Terraform and Python
 RUN wget -O terraform.zip https://releases.hashicorp.com/terraform/0.14.3/terraform_0.14.3_linux_amd64.zip\
     && unzip ./terraform.zip -d /usr/local/bin/ \
-    && rm terraform.zip 
+    && rm terraform.zip
 
 # Download Terraform providers (plugins)
 # Setting the TF_PLUGIN_CACHE_DIR environment variable instructs Terraform to search that folder for plugins first
@@ -55,7 +55,7 @@ RUN AZ_REPO=$(lsb_release -cs) \
     tee /etc/apt/sources.list.d/azure-cli.list
 
 # Install AZ CLI
-RUN apt-get update && apt-get install -y azure-cli
+RUN apt-get update && apt-get install -y azure-cli=2.22.0-1~focal
 
 ADD ./front* /deployment/front/
 ADD ./scripts* /deployment/scripts/


### PR DESCRIPTION
# Description

Pins the Azure CLI to version 2.22.0 as that was the last known version that successfully manages KeyVaults in AzureUsGovernment.

## Issue reference

The issue this PR will close: #200

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
