### PR TITLE
Remove symbolic link for pip in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update \
     && apt-get install -y \
     python3 \
     python3-pip \
-    && ln -s /usr/bin/python3 /usr/bin/python \
-    && ln -s /usr/bin/pip3 /usr/bin/pip
+    && ln -s /usr/bin/python3 /usr/bin/python 
+ 
 
 # Install Terraform
 RUN wget -O terraform.zip https://releases.hashicorp.com/terraform/0.13.4/terraform_0.13.4_linux_amd64.zip \


### PR DESCRIPTION
# Description

Removed the symbolic link creation for pip in the dev container.  The current Ubuntu 20.04 base image already contains this symlink and this code was failing with the error 

``` 
ln: failed to create symbolic link '/usr/bin/pip': File exists

The command '/bin/sh -c apt-get update     && 
                        apt-get install -y     python3     python3-pip     && 
                        ln -s /usr/bin/python3 /usr/bin/python     && 
                        ln -s /usr/bin/pip3 /usr/bin/pip' 
returned a non-zero code: 1

Failed to create container.
```

## Issue reference

The issue this PR will close: #207 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [ ] ~~All tests pass (manual and automated)~~
* [ ] ~~The documentation is updated to cover any new or changed features~~
* [ ] ~~Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)~~
* [x] Relevant issues are linked to this PR
