### PR TITLE
add a Bastion Host module

### DIFF
--- a/src/core/saca-hub/main.tf
+++ b/src/core/saca-hub/main.tf
@@ -66,6 +66,21 @@ module "saca-hub-network" {
   }
 }
 
+module "bastion-host" {
+  depends_on            = [module.saca-hub-network]
+  source                = "../../modules/bastion"
+  resource_group_name   = azurerm_resource_group.hub.name
+  virtual_network_name  = var.saca_vnetname
+  bastion_host_name     = var.bastion_host_name
+  subnet_address_prefix = var.bastion_address_space
+  public_ip_name        = var.bastion_public_ip_name
+  ipconfig_name         = var.bastion_ipconfig_name
+
+  tags = {
+    DeploymentName = var.deploymentname
+  }
+}
+
 locals {
   # azurerm terraform environments where Azure Firewall Premium is supported
   firewall_premium_tf_environments = ["public"]

--- a/src/core/saca-hub/saca-hub.front.json
+++ b/src/core/saca-hub/saca-hub.front.json
@@ -149,6 +149,34 @@
 				"default_val": false,
 				"description": "Do you need to create a network watcher here?",
 				"options": []
+			},
+			{
+				"varname": "bastion_host_name",
+				"type": "text",
+				"default_val": "mlzDemoBastionHost",
+				"description": "The name of the Bastion Host",
+				"options": []
+			},
+			{
+				"varname": "bastion_address_space",
+				"type": "text",
+				"default_val": "10.0.100.128/27",
+				"description": "The address space to be used for the Bastion Host subnet (must be /27 or larger).",
+				"options": []
+			},
+			{
+				"varname": "bastion_public_ip_name",
+				"type": "text",
+				"default_val": "mlzDemoBastionHostPip",
+				"description": "The name of the Bastion Host Public IP",
+				"options": []
+			},
+			{
+				"varname": "bastion_ipconfig_name",
+				"type": "text",
+				"default_val": "mlzDemoBastionHostIpCfg",
+				"description": "The name of the Bastion Host IP Configuration",
+				"options": []
 			}
 		]
 	}

--- a/src/core/saca-hub/saca-hub.orig.tfvars.json
+++ b/src/core/saca-hub/saca-hub.orig.tfvars.json
@@ -21,5 +21,9 @@
     "management_ipconfig_name": "{FIREWALL_MANAGEMENT_IPCONFIG_NAME}",
     "management_publicip_name": "{FIREWALL_MANAGEMENT_PUBLICIP_NAME}",
     "management_routetable_name": "{FIREWALL_MANAGEMENT_ROUTE_TABLE_NAME}",
-    "create_network_watcher": false
+    "create_network_watcher": false,
+    "bastion_host_name": "{BASTION_HOST_NAME}",
+    "bastion_address_space": "{BASTION_ADDRESS_SPACE}",
+    "bastion_public_ip_name": "{BASTION_PUBLIC_IP_NAME}",
+    "bastion_ipconfig_name": "{BASTION_IPCONFIG_NAME}"
 }

--- a/src/core/saca-hub/saca-hub.tfvars.sample
+++ b/src/core/saca-hub/saca-hub.tfvars.sample
@@ -29,3 +29,12 @@ client_publicip_name       = "{FIREWALL_CLIENT_PUBLICIP_NAME}"
 management_ipconfig_name   = "{FIREWALL_MANAGEMENT_IPCONFIG_NAME}"
 management_publicip_name   = "{FIREWALL_MANAGEMENT_PUBLICIP_NAME}"
 management_routetable_name = "{FIREWALL_MANAGEMENT_ROUTE_TABLE_NAME}"
+
+#################################
+# Bastion Host Configuration
+#################################
+
+bastion_host_name      = "{BASTION_HOST_NAME}",
+bastion_address_space  = "{BASTION_ADDRESS_SPACE}",
+bastion_public_ip_name = "{BASTION_PUBLIC_IP_NAME}",
+bastion_ipconfig_name  = "{BASTION_IPCONFIG_NAME}"

--- a/src/core/saca-hub/variables.tf
+++ b/src/core/saca-hub/variables.tf
@@ -112,3 +112,31 @@ variable "create_network_watcher" {
   type        = bool
   default     = false
 }
+
+#################################
+# Bastion Host Configuration
+#################################
+
+variable "bastion_host_name" {
+  description = "The name of the Bastion Host"
+  default     = "mlzDemoBastionHost"
+  type        = string
+}
+
+variable "bastion_address_space" {
+  description = "The address space to be used for the Bastion Host subnet (must be /27 or larger)."
+  default     = "10.0.100.128/27"
+  type        = string
+}
+
+variable "bastion_public_ip_name" {
+  description = "The name of the Bastion Host Public IP"
+  default     = "mlzDemoBastionHostPip"
+  type        = string
+}
+
+variable "bastion_ipconfig_name" {
+  description = "The name of the Bastion Host IP Configuration"
+  default     = "mlzDemoBastionHostIpCfg"
+  type        = string
+}

--- a/src/modules/bastion/main.tf
+++ b/src/modules/bastion/main.tf
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+data "azurerm_resource_group" "bastion_host_rg" {
+  name = var.resource_group_name
+}
+
+data "azurerm_virtual_network" "bastion_host_vnet" {
+  name                = var.virtual_network_name
+  resource_group_name = data.bastion_host_rg.name
+}
+
+resource "azurerm_subnet" "bastion_host_subnet" {
+  name                 = "AzureBastionSubnet" # the name of the subnet must be 'AzureBastionSubnet'
+  resource_group_name  = data.bastion_host_rg.name
+  virtual_network_name = data.bastion_host_vnet.name
+  address_prefixes     = var.subnet_address_prefix
+}
+
+resource "azurerm_public_ip" "bastion_host_pip" {
+  name                = var.public_ip_name
+  location            = data.bastion_host_rg.location
+  resource_group_name = data.bastion_host_rg.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = var.tags
+}
+
+resource "azurerm_bastion_host" "bastion_host" {
+  name                = var.bastion_host_name
+  location            = data.bastion_host_rg.location
+  resource_group_name = data.bastion_host_rg.name
+
+  ip_configuration {
+    name                 = var.bastion_host_ipconfig_name
+    subnet_id            = azurerm_subnet.bastion_host_subnet.id
+    public_ip_address_id = azurerm_public_ip.bastion_host_pip.id
+  }
+
+  tags = var.tags
+}

--- a/src/modules/bastion/main.tf
+++ b/src/modules/bastion/main.tf
@@ -7,20 +7,20 @@ data "azurerm_resource_group" "bastion_host_rg" {
 
 data "azurerm_virtual_network" "bastion_host_vnet" {
   name                = var.virtual_network_name
-  resource_group_name = data.bastion_host_rg.name
+  resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_subnet" "bastion_host_subnet" {
   name                 = "AzureBastionSubnet" # the name of the subnet must be 'AzureBastionSubnet'
-  resource_group_name  = data.bastion_host_rg.name
-  virtual_network_name = data.bastion_host_vnet.name
-  address_prefixes     = var.subnet_address_prefix
+  resource_group_name  = data.azurerm_resource_group.bastion_host_rg.name
+  virtual_network_name = data.azurerm_virtual_network.bastion_host_vnet.name
+  address_prefixes     = [cidrsubnet(var.subnet_address_prefix, 0, 0)]
 }
 
 resource "azurerm_public_ip" "bastion_host_pip" {
   name                = var.public_ip_name
-  location            = data.bastion_host_rg.location
-  resource_group_name = data.bastion_host_rg.name
+  location            = data.azurerm_resource_group.bastion_host_rg.location
+  resource_group_name = data.azurerm_resource_group.bastion_host_rg.name
   allocation_method   = "Static"
   sku                 = "Standard"
   tags                = var.tags
@@ -28,11 +28,11 @@ resource "azurerm_public_ip" "bastion_host_pip" {
 
 resource "azurerm_bastion_host" "bastion_host" {
   name                = var.bastion_host_name
-  location            = data.bastion_host_rg.location
-  resource_group_name = data.bastion_host_rg.name
+  location            = data.azurerm_resource_group.bastion_host_rg.location
+  resource_group_name = data.azurerm_resource_group.bastion_host_rg.name
 
   ip_configuration {
-    name                 = var.bastion_host_ipconfig_name
+    name                 = var.ipconfig_name
     subnet_id            = azurerm_subnet.bastion_host_subnet.id
     public_ip_address_id = azurerm_public_ip.bastion_host_pip.id
   }

--- a/src/modules/bastion/variables.tf
+++ b/src/modules/bastion/variables.tf
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+variable "resource_group_name" {
+  description = "The name of the resource group the Bastion Host resides in"
+  type        = string
+}
+
+variable "virtual_network_name" {
+  description = "The name of the virtual network the Bastion Host resides in"
+  type        = string
+}
+
+variable "subnet_address_prefix" {
+  description = "The address prefix for the Bastion Host (must be a /27 or larger)"
+  type        = string
+}
+
+variable "public_ip_name" {
+  description = "The name of the Bastion Host public IP address resource"
+  type        = string
+}
+
+variable "bastion_host_ipconfig_name" {
+  description = "The name of the Bastion Host IP configuration resource"
+  type        = string
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/src/modules/bastion/variables.tf
+++ b/src/modules/bastion/variables.tf
@@ -11,6 +11,11 @@ variable "virtual_network_name" {
   type        = string
 }
 
+variable "bastion_host_name" {
+  description = "The name of the Bastion Host"
+  type        = string
+}
+
 variable "subnet_address_prefix" {
   description = "The address prefix for the Bastion Host (must be a /27 or larger)"
   type        = string
@@ -21,7 +26,7 @@ variable "public_ip_name" {
   type        = string
 }
 
-variable "bastion_host_ipconfig_name" {
+variable "ipconfig_name" {
   description = "The name of the Bastion Host IP configuration resource"
   type        = string
 }

--- a/src/scripts/clean.sh
+++ b/src/scripts/clean.sh
@@ -98,7 +98,7 @@ destroy_mlz() {
   }
 
   # clean up files
-  delete_files_in_directory_by_name "{$this_script_path}" "${tfvars_file_name}"
+  delete_files_in_directory_by_name "{$src_path}" "${tfvars_file_name}"
   rm -rf "${configuration_output_path}/${mlz_env_name}.mlzconfig" "${configuration_output_path:?}/${tfvars_file_name}"
 }
 
@@ -107,6 +107,7 @@ destroy_mlz() {
 ##########
 
 this_script_path=$(realpath "${BASH_SOURCE%/*}")
+src_path="${this_script_path}/../"
 configuration_output_path="${this_script_path}/../generated-configurations"
 
 mlz_env_name="notset"

--- a/src/scripts/clean.sh
+++ b/src/scripts/clean.sh
@@ -98,7 +98,7 @@ destroy_mlz() {
   }
 
   # clean up files
-  delete_files_in_directory_by_name "{$src_path}" "${tfvars_file_name}"
+  delete_files_in_directory_by_name "${src_path}" "${tfvars_file_name}"
   rm -rf "${configuration_output_path}/${mlz_env_name}.mlzconfig" "${configuration_output_path:?}/${tfvars_file_name}"
 }
 
@@ -107,7 +107,7 @@ destroy_mlz() {
 ##########
 
 this_script_path=$(realpath "${BASH_SOURCE%/*}")
-src_path="${this_script_path}/../"
+src_path="$(realpath "${this_script_path}/../")"
 configuration_output_path="${this_script_path}/../generated-configurations"
 
 mlz_env_name="notset"


### PR DESCRIPTION
# Description

Adds an Azure Bastion Host module that can be added to any virtual network given a valid subnet larger than /27.

To know this is working deploy an instance of MLZ and inspect the SACA Hub resource group. With the supplied defaults you should see a `mlzDemoBastionHost` resource and its accompanying public IP address `mlzDemoBastionHostPip` reside in a `AzureBastionSubnet` of `10.0.100.128/27`.

## Issue reference

The issue this PR will close: #186 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
