### PR TITLE
Added "owner" requirement to Mission LZ pre-reqs

### DIFF
--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -25,6 +25,7 @@ The develoment container is not necessary if you want to use the Mission LZ user
 * **Docker:** Docker Desktop or Docker CE
   >*We use [Docker Desktop on Windows 10](https://docs.docker.com/docker-for-windows/install/), integrated with WSL*
 * Current version of the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
+* An Azure Subscription where you have ['Owner' RBAC permissions].
 
 All other tools and resources are in the development container and in the user interface container. The simplest path is to deploy from one of these containers, but it is not required if you want to configure your own deployment environment.
 


### PR DESCRIPTION
The quickstart scripts require a user with the owner role (e.g. to create the service account and grant it permissions on the subscription)

# Description

Added the pre-req of a user with "owner" on the subscription (this is required for the quickstart

## Issue reference

The issue this PR will close: #212

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles or validates correctly
* [ ] BASH scripts have been validated using `shellcheck`
* [ ] All tests pass (manual and automated)
* [ ] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
