### PR TITLE
Updated stated pre-reqs for local BASH

### DIFF
--- a/src/docs/command-line-deployment.md
+++ b/src/docs/command-line-deployment.md
@@ -7,8 +7,7 @@ The steps in this article assume the following pre-requisites for command-line d
 
   > As an alternative, it is possible to deploy Mission LZ via BASH running from the local workstation, but requires the following additional requirements:
   >
-  > * An Azure Subscription where you have ['Owner' RBAC permissions](<https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/>)
-  > * The current version of Azure CLI (try `az cli -v` or see <https://docs.microsoft.com/en-us/cli/azure/install-azure-cli/>)
+  > * The current version of Azure CLI (try `az version` or see <https://docs.microsoft.com/en-us/cli/azure/install-azure-cli/>)
   > * Terraform CLI version > v0.13.4 (try `terraform -v` or see <https://learn.hashicorp.com/tutorials/terraform/install-cli/>)
 
 ## Step-by-step


### PR DESCRIPTION
Updated pre-reqs for local BASH

# Description
 - Removed the "additional" pre-req of an "Owner" account because this is not an additional requirement
 - Updated the Az CLI command to check the version ("az cli -v" is not proper syntax)

## Issue reference

The issue this PR will close: #212

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles or validates correctly
* [ ] BASH scripts have been validated using `shellcheck`
* [ ] All tests pass (manual and automated)
* [ ] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
