### PR TITLE
allow for empty az cloud show results when building .mlzconfig files

### DIFF
--- a/src/scripts/clean.sh
+++ b/src/scripts/clean.sh
@@ -108,7 +108,7 @@ destroy_mlz() {
 
 this_script_path=$(realpath "${BASH_SOURCE%/*}")
 src_path="$(realpath "${this_script_path}/../")"
-configuration_output_path="${this_script_path}/../generated-configurations"
+configuration_output_path=$(realpath "${this_script_path}/../generated-configurations")
 
 mlz_env_name="notset"
 

--- a/src/scripts/config/append_prereq_endpoints.sh
+++ b/src/scripts/config/append_prereq_endpoints.sh
@@ -40,7 +40,10 @@ append_cloud_value() {
 
   local cloud_key_value
   cloud_key_value=$(az cloud show --query "${cloud_key_name}" --output tsv)
-  printf "%s=%s\n" "${mlz_key_name}" "${cloud_key_value}" >> "${file}"
+
+  if [[ $cloud_key_value ]]; then
+    printf "%s=%s\n" "${mlz_key_name}" "${cloud_key_value}" >> "${file}"
+  fi
 }
 
 # for each member of the dictionary, write "key=$(az cloud show...)" to a file

--- a/src/scripts/config/append_prereq_endpoints.sh
+++ b/src/scripts/config/append_prereq_endpoints.sh
@@ -32,7 +32,7 @@ mlz_az_cloud_keys['mlz_cloudname']='name'
 mlz_az_cloud_keys['mlz_activeDirectory']='endpoints.activeDirectory'
 
 # since we cannot guarantee the results of `az cloud show` for each value we want,
-# we query for them individually when printing to the file and allow for empty results
+# we query for them individually when printing to the file to accommodate for empty results
 append_cloud_value() {
   local mlz_key_name=$1
   local cloud_key_name=$2

--- a/src/scripts/config/append_prereq_endpoints.sh
+++ b/src/scripts/config/append_prereq_endpoints.sh
@@ -23,21 +23,26 @@ fi
 
 file_to_append=$1
 
-cloudEndpoints=($(az cloud show \
-  --query '[endpoints.resourceManager, suffixes.acrLoginServerEndpoint, suffixes.keyvaultDns, name, endpoints.activeDirectory]' \
-  --output tsv))
+# create a dictionary of mlz_* values we want from an `az cloud show` result
+declare -A mlz_az_cloud_keys
+mlz_az_cloud_keys['mlz_metadatahost']='endpoints.resourceManager'
+mlz_az_cloud_keys['mlz_acrLoginServerEndpoint']='suffixes.acrLoginServerEndpoint'
+mlz_az_cloud_keys['mlz_keyvaultDns']='suffixes.keyvaultDns'
+mlz_az_cloud_keys['mlz_cloudname']='name'
+mlz_az_cloud_keys['mlz_activeDirectory']='endpoints.activeDirectory'
 
-append_if_not_empty() {
-  key_name=$1
-  key_value=$2
-  file=$3
-  if [[ $key_value ]]; then
-    printf "${key_name}=${key_value}\n" >> "${file}"
-  fi
+# since we cannot guarantee the results of `az cloud show` for each value we want,
+# we query for them individually when printing to the file and allow for empty results
+append_cloud_value() {
+  local mlz_key_name=$1
+  local cloud_key_name=$2
+  local file=$3
+
+  local cloud_key_value=$(az cloud show --query "${cloud_key_name}" --output tsv)
+  printf "${mlz_key_name}=${cloud_key_value}\n" >> "${file}"
 }
 
-append_if_not_empty "mlz_metadatahost" ${cloudEndpoints[0]} ${file_to_append}
-append_if_not_empty "mlz_acrLoginServerEndpoint" ${cloudEndpoints[1]} ${file_to_append}
-append_if_not_empty "mlz_keyvaultDns" ${cloudEndpoints[2]} ${file_to_append}
-append_if_not_empty "mlz_cloudname" ${cloudEndpoints[3]} ${file_to_append}
-append_if_not_empty "mlz_activeDirectory" ${cloudEndpoints[4]} ${file_to_append}
+# for each member of the dictionary, write "key=$(az cloud show...)" to a file
+for mlz_key_name in "${!mlz_az_cloud_keys[@]}"; do
+    append_cloud_value "$mlz_key_name" "${mlz_az_cloud_keys[$mlz_key_name]}" "${file_to_append}"
+done

--- a/src/scripts/config/append_prereq_endpoints.sh
+++ b/src/scripts/config/append_prereq_endpoints.sh
@@ -38,8 +38,9 @@ append_cloud_value() {
   local cloud_key_name=$2
   local file=$3
 
-  local cloud_key_value=$(az cloud show --query "${cloud_key_name}" --output tsv)
-  printf "${mlz_key_name}=${cloud_key_value}\n" >> "${file}"
+  local cloud_key_value
+  cloud_key_value=$(az cloud show --query "${cloud_key_name}" --output tsv)
+  printf "%s=%s\n" "${mlz_key_name}" "${cloud_key_value}" >> "${file}"
 }
 
 # for each member of the dictionary, write "key=$(az cloud show...)" to a file

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -146,7 +146,7 @@ display_clean_hint() {
 ##########
 
 this_script_path=$(realpath "${BASH_SOURCE%/*}")
-configuration_output_path="${this_script_path}/../generated-configurations"
+configuration_output_path="$(realpath ${this_script_path}/../generated-configurations)"
 timestamp=$(date +%s)
 
 # set some defaults

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -113,6 +113,29 @@ create_mlz_configuration_file() {
   "${this_script_path}/config/generate_config_file.sh" $gen_config_args_str
 }
 
+validate_mlz_configuration_file() {
+  . "${mlz_config_file_path}"
+
+  ensure_vars_are_set()
+  {
+    local var_names=("$@")
+    local any_required_var_unset=false
+
+    for var_name in "${var_names[@]}"; do
+      if [[ -z "${!var_name}" ]]; then
+        echo "ERROR: ${var_name} is required but is not set in MLZ configuration file at ${mlz_config_file_path}"
+        any_required_var_unset=true
+      fi
+    done
+
+    if [[ "$any_required_var_unset" == true ]]; then
+      exit 1
+    fi
+  }
+
+  ensure_vars_are_set mlz_metadatahost mlz_cloudname
+}
+
 create_mlz_resources() {
   echo "INFO: creating MLZ resources using ${mlz_config_file_path}..."
   "${this_script_path}/config/create_mlz_configuration_resources.sh" "${mlz_config_file_path}"
@@ -210,6 +233,7 @@ validate_cloud_arguments
 mlz_config_file_path="${configuration_output_path}/${mlz_env_name}.mlzconfig"
 tfvars_file_path="${configuration_output_path}/${mlz_env_name}.tfvars"
 create_mlz_configuration_file
+validate_mlz_configuration_file
 create_terraform_variables
 
 # create resources

--- a/src/scripts/deploy_ui.sh
+++ b/src/scripts/deploy_ui.sh
@@ -122,8 +122,9 @@ create_mlz_configuration_file() {
   ### ignoring shellcheck for word splitting because that is the desired behavior
   # shellcheck disable=SC2086
   "${this_script_path}/config/generate_config_file.sh" $gen_config_args_str
+}
 
-  # generate MLZ configuration names
+create_mlz_configuration_names() {
   . "$mlz_config_file"
   . "${this_script_path}/config/generate_names.sh" "$mlz_config_file"
 }
@@ -131,6 +132,30 @@ create_mlz_configuration_file() {
 create_mlz_resources() {
   echo "INFO: setting up required MLZ resources using $(realpath "$mlz_config_file")..."
   "${this_script_path}/config/mlz_config_create.sh" "$mlz_config_file"
+}
+
+validate_required_cloud_args() {
+  check_required_mlz_vars()
+  {
+    local var_names=("$@")
+    local any_required_var_unset=false
+
+    for var_name in "${var_names[@]}"; do
+      if [[ -z "${!var_name}" ]]; then
+        echo "ERROR: ${var_name} is required but is not set in MLZ configuration file at ${mlz_config_file}"
+        any_required_var_unset=true
+      fi
+    done
+
+    if [[ "$any_required_var_unset" == true ]]; then
+      exit 1
+    fi
+  }
+  check_required_mlz_vars mlz_acrLoginServerEndpoint \
+    mlz_keyvaultDns \
+    mlz_metadatahost \
+    mlz_cloudname \
+    mlz_activeDirectory
 }
 
 handle_docker_image() {
@@ -182,7 +207,7 @@ create_auth_scopes() {
 ##########
 
 this_script_path=$(realpath "${BASH_SOURCE%/*}")
-src_path="${this_script_path}/../"
+src_path=$(realpath "${this_script_path}/../")
 timestamp=$(date +%s)
 
 # set defaults that can be overridden or 'notset' for mandatory input
@@ -258,12 +283,14 @@ validate_docker_strategy
 login_azcli
 validate_cloud_arguments
 
-# create mlz resources
+# create mlz resources and names
 mlz_config_file="${src_path}/mlz.config"
 create_mlz_configuration_file
+create_mlz_configuration_names
 create_mlz_resources
 
 # deploy UI
+validate_required_cloud_args
 handle_docker_image
 create_registry
 deploy_container

--- a/src/scripts/deploy_ui.sh
+++ b/src/scripts/deploy_ui.sh
@@ -124,18 +124,10 @@ create_mlz_configuration_file() {
   "${this_script_path}/config/generate_config_file.sh" $gen_config_args_str
 }
 
-create_mlz_configuration_names() {
-  . "$mlz_config_file"
-  . "${this_script_path}/config/generate_names.sh" "$mlz_config_file"
-}
+validate_mlz_configuration_file() {
+  . "${mlz_config_file}"
 
-create_mlz_resources() {
-  echo "INFO: setting up required MLZ resources using $(realpath "$mlz_config_file")..."
-  "${this_script_path}/config/mlz_config_create.sh" "$mlz_config_file"
-}
-
-validate_required_cloud_args() {
-  check_required_mlz_vars()
+  ensure_vars_are_set ()
   {
     local var_names=("$@")
     local any_required_var_unset=false
@@ -151,11 +143,22 @@ validate_required_cloud_args() {
       exit 1
     fi
   }
-  check_required_mlz_vars mlz_acrLoginServerEndpoint \
+
+  ensure_vars_are_set mlz_acrLoginServerEndpoint \
     mlz_keyvaultDns \
     mlz_metadatahost \
     mlz_cloudname \
     mlz_activeDirectory
+}
+
+create_mlz_configuration_names() {
+  . "$mlz_config_file"
+  . "${this_script_path}/config/generate_names.sh" "$mlz_config_file"
+}
+
+create_mlz_resources() {
+  echo "INFO: setting up required MLZ resources using $(realpath "$mlz_config_file")..."
+  "${this_script_path}/config/mlz_config_create.sh" "$mlz_config_file"
 }
 
 handle_docker_image() {
@@ -286,11 +289,11 @@ validate_cloud_arguments
 # create mlz resources and names
 mlz_config_file="${src_path}/mlz.config"
 create_mlz_configuration_file
+validate_mlz_configuration_file
 create_mlz_configuration_names
 create_mlz_resources
 
 # deploy UI
-validate_required_cloud_args
 handle_docker_image
 create_registry
 deploy_container


### PR DESCRIPTION
# Description

Due to the differences in clouds, we cannot guarantee each service will be available that MLZ requires.

For instance, today, in one of the clouds, `az cloud show --query suffixes.acrLoginServerEndpoint` returns no results. So I won't be able to deploy the UI to a container instance.

This change allows for an empty result to be written to a generated .mlzconfig file, and at least for the UI, catches empty values and throws an error and exits if that's the case.

## Issue reference

The issue this PR will close: #235

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
