### PR TITLE
remove URI components from metadata host service endpoint when generating .mlzconfig

### DIFF
--- a/src/scripts/config/append_prereq_endpoints.sh
+++ b/src/scripts/config/append_prereq_endpoints.sh
@@ -43,7 +43,7 @@ format_if_metadatahost() {
 
     # 1) awk -F/ '{print $3}'
     #
-    #   -F/ is "using the charactrer / as a field separator"
+    #   -F/ is "using the character / as a field separator"
     #
     #   '{print $3}' is "print me the third field"
     #

--- a/src/scripts/config/append_prereq_endpoints.sh
+++ b/src/scripts/config/append_prereq_endpoints.sh
@@ -38,7 +38,7 @@ format_if_metadatahost() {
   local cloud_key_value=$2
 
   if [[ $mlz_key_name != "mlz_metadatahost" ]]; then
-    echo $cloud_key_value
+    echo "$cloud_key_value"
   else
 
     # 1) awk -F/ '{print $3}'
@@ -47,9 +47,7 @@ format_if_metadatahost() {
     #
     #   '{print $3}' is "print me the third field"
     #
-    # 2) for example
-    #
-    #   https://management.azure.com/
+    # 2) for example on https://management.azure.com/
     #
     #   $1      $2 $3                    $4
     #   https: / / management.azure.com /
@@ -59,7 +57,7 @@ format_if_metadatahost() {
     #   $3 is management.azure.com
     #   $4 is
 
-    echo $(echo "$cloud_key_value" | awk -F/ '{print $3}')
+    echo "$cloud_key_value" | awk -F/ '{print $3}'
   fi
 }
 

--- a/src/scripts/config/append_prereq_endpoints.sh
+++ b/src/scripts/config/append_prereq_endpoints.sh
@@ -31,8 +31,40 @@ mlz_az_cloud_keys['mlz_keyvaultDns']='suffixes.keyvaultDns'
 mlz_az_cloud_keys['mlz_cloudname']='name'
 mlz_az_cloud_keys['mlz_activeDirectory']='endpoints.activeDirectory'
 
-# since we cannot guarantee the results of `az cloud show` for each value we want,
-# we query for them individually when printing to the file to accommodate for empty results
+# if it's the metadatahost, strip it of URI components
+# in some clouds, Terraform allows only the domain name
+format_if_metadatahost() {
+  local mlz_key_name=$1
+  local cloud_key_value=$2
+
+  if [[ $mlz_key_name != "mlz_metadatahost" ]]; then
+    echo $cloud_key_value
+  else
+
+    # 1) awk -F/ '{print $3}'
+    #
+    #   -F/ is "using the charactrer / as a field separator"
+    #
+    #   '{print $3}' is "print me the third field"
+    #
+    # 2) for example
+    #
+    #   https://management.azure.com/
+    #
+    #   $1      $2 $3                    $4
+    #   https: / / management.azure.com /
+    #
+    #   $1 is https:
+    #   $2 is
+    #   $3 is management.azure.com
+    #   $4 is
+
+    echo $(echo "$cloud_key_value" | awk -F/ '{print $3}')
+  fi
+}
+
+# since we cannot guarantee the results of `az cloud show` for each value we require,
+# query for values individually and skip printing any empty results
 append_cloud_value() {
   local mlz_key_name=$1
   local cloud_key_name=$2
@@ -42,7 +74,11 @@ append_cloud_value() {
   cloud_key_value=$(az cloud show --query "${cloud_key_name}" --output tsv)
 
   if [[ $cloud_key_value ]]; then
+    cloud_key_value=$(format_if_metadatahost "$mlz_key_name" "$cloud_key_value")
     printf "%s=%s\n" "${mlz_key_name}" "${cloud_key_value}" >> "${file}"
+  else
+    echo "INFO: Oops! Did not find a value for 'az cloud show --query ${cloud_key_name}'..."
+    echo "INFO: There will not be a value for ${mlz_key_name} on the MLZ config file at ${file}..."
   fi
 }
 


### PR DESCRIPTION
# Description

Today, users in air-gapped clouds have issues initializing terraform backends when using the full ARM Metadata Host Service Endpoint URI (e.g. "https://management.azure.com/") and instead require just the host name (e.g. "management.azure.com")

This change, when using the `deploy.sh` quickstart, removes the URI components from the result of `az cloud show --query endpoints.resourceManager` when the .mlzconfig file is generated so that just the hostname value is passed as a `metadata_host` argument during terraform backend initialization. See #241 for more information.

Before, a .mlzconfig generated from `deploy.sh` used to generate a key value pair like this:

```plaintext
mlz_metadatahost=https://management.azure.com/
```

Now, it should generate a value like this:

```plaintext
mlz_metadatahost=management.azure.com
```

...and that plays nicer across clouds and azurerm providers.

You can test this manually with the `generate_config_file.sh` script:

```bash
my_tenant_id=$(az account show --query tenantId --output tsv)
my_sub_id=$(az account show --query id --output tsv)
src/scripts/config/generate_config_file.sh -f mytest.mlzconfig -e public -z mytestenvname -l eastus -s $my_sub_id -t $my_tenant_id
```

## Issue reference

The issue this PR will close: #241 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
