### PR TITLE
Remove the word demo from default resource names

### DIFF
--- a/src/core/saca-hub/saca-hub.front.json
+++ b/src/core/saca-hub/saca-hub.front.json
@@ -104,7 +104,7 @@
 			{
 				"varname": "firewall_name",
 				"type": "text",
-				"default_val": "DemoFirewall",
+				"default_val": "mlzFirewall",
 				"description": "Saca Firewall Name",
 				"options": []
 			},
@@ -167,7 +167,7 @@
 			{
 				"varname": "bastion_host_name",
 				"type": "text",
-				"default_val": "mlzDemoBastionHost",
+				"default_val": "mlzBastionHost",
 				"description": "The name of the Bastion Host",
 				"options": []
 			},
@@ -181,21 +181,21 @@
 			{
 				"varname": "bastion_public_ip_name",
 				"type": "text",
-				"default_val": "mlzDemoBastionHostPip",
+				"default_val": "mlzBastionHostPip",
 				"description": "The name of the Bastion Host Public IP",
 				"options": []
 			},
 			{
 				"varname": "bastion_ipconfig_name",
 				"type": "text",
-				"default_val": "mlzDemoBastionHostIpCfg",
+				"default_val": "mlzBastionHostIpCfg",
 				"description": "The name of the Bastion Host IP Configuration",
 				"options": []
 			},
 			{
 				"varname": "jumpbox_subnet.name",
 				"type": "text",
-				"default_val": "mlzDemoJumpboxSubnet",
+				"default_val": "mlzJumpboxSubnet",
 				"description": "The name of the jumpbox subnet",
 				"options": []
 			},
@@ -211,28 +211,28 @@
 			{
 				"varname": "jumpbox_subnet.nsg_name",
 				"type": "text",
-				"default_val": "mlzDemoJumpboxSubnetNsg",
+				"default_val": "mlzJumpboxSubnetNsg",
 				"description": "The name of the jumpbox subnet route table network security group",
 				"options": []
 			},
 			{
 				"varname": "jumpbox_subnet.routetable_name",
 				"type": "text",
-				"default_val": "mlzDemoJumpboxSubnetRt",
+				"default_val": "mlzJumpboxSubnetRt",
 				"description": "The name of the jumpbox subnet route table",
 				"options": []
 			},
 			{
 				"varname": "jumpbox_keyvault_name",
 				"type": "text",
-				"default_val": "mlzDemoJumpboxVmKv",
+				"default_val": "mlzJumpboxVmKv",
 				"description": "The name of the jumpbox credentials Key Vault",
 				"options": []
 			},
 			{
 				"varname": "jumpbox_windows_vm_name",
 				"type": "text",
-				"default_val": "mlzDemoJumpboxWindowsVm",
+				"default_val": "mlzJumpboxWindowsVm",
 				"description": "The name of the Windows jumpbox virtual machine",
 				"options": []
 			},
@@ -274,7 +274,7 @@
 			{
 				"varname": "jumpbox_linux_vm_name",
 				"type": "text",
-				"default_val": "mlzDemoJumpboxLinuxVm",
+				"default_val": "mlzJumpboxLinuxVm",
 				"description": "The name of the Linux jumpbox virtual machine",
 				"options": []
 			},

--- a/src/core/saca-hub/variables.tf
+++ b/src/core/saca-hub/variables.tf
@@ -83,7 +83,7 @@ variable "management_address_space" {
 
 variable "firewall_name" {
   description = "Name of the Hub Firewall"
-  default     = "mlzDemoFirewall"
+  default     = "mlzFirewall"
 }
 
 variable "firewall_policy_name" {
@@ -93,27 +93,27 @@ variable "firewall_policy_name" {
 
 variable "client_ipconfig_name" {
   description = "The name of the Firewall Client IP Configuration"
-  default     = "mlzDemoFWClientIpCfg"
+  default     = "mlzFWClientIpCfg"
 }
 
 variable "client_publicip_name" {
   description = "The name of the Firewall Client Public IP"
-  default     = "mlzDemoFWClientPip"
+  default     = "mlzFWClientPip"
 }
 
 variable "management_ipconfig_name" {
   description = "The name of the Firewall Management IP Configuration"
-  default     = "mlzDemoFWMgmtIpCfg"
+  default     = "mlzFWMgmtIpCfg"
 }
 
 variable "management_publicip_name" {
   description = "The name of the Firewall Management Public IP"
-  default     = "mlzDemoFWMgmtPip"
+  default     = "mlzFWMgmtPip"
 }
 
 variable "management_routetable_name" {
   description = "The name of the route table applied to the management subnet"
-  default     = "mlzDemoFirewallMgmtRT"
+  default     = "mlzFirewallMgmtRT"
 }
 
 variable "create_network_watcher" {
@@ -134,7 +134,7 @@ variable "create_bastion_jumpbox" {
 
 variable "bastion_host_name" {
   description = "The name of the Bastion Host"
-  default     = "mlzDemoBastionHost"
+  default     = "mlzBastionHost"
   type        = string
 }
 
@@ -146,13 +146,13 @@ variable "bastion_address_space" {
 
 variable "bastion_public_ip_name" {
   description = "The name of the Bastion Host Public IP"
-  default     = "mlzDemoBastionHostPip"
+  default     = "mlzBastionHostPip"
   type        = string
 }
 
 variable "bastion_ipconfig_name" {
   description = "The name of the Bastion Host IP Configuration"
-  default     = "mlzDemoBastionHostIpCfg"
+  default     = "mlzBastionHostIpCfg"
   type        = string
 }
 
@@ -186,14 +186,14 @@ variable "jumpbox_subnet" {
     routetable_name = string
   })
   default = {
-    name              = "mlzDemoJumpboxSubnet"
+    name              = "mlzJumpboxSubnet"
     address_prefixes  = ["10.0.100.160/27"]
     service_endpoints = ["Microsoft.Storage"]
 
     enforce_private_link_endpoint_network_policies = false
     enforce_private_link_service_network_policies  = false
 
-    nsg_name = "mlzDemoJumpboxSubnetNsg"
+    nsg_name = "mlzJumpboxSubnetNsg"
     nsg_rules = {
       "allow_ssh" = {
         name                       = "allow_ssh"
@@ -219,19 +219,19 @@ variable "jumpbox_subnet" {
       }
     }
 
-    routetable_name = "mlzDemoJumpboxSubnetRt"
+    routetable_name = "mlzJumpboxSubnetRt"
   }
 }
 
 variable "jumpbox_keyvault_name" {
   description = "The name of the jumpbox virtual machine keyvault"
-  default     = "mlzDemoJumpboxVmKv"
+  default     = "mlzJumpboxVmKv"
   type        = string
 }
 
 variable "jumpbox_windows_vm_name" {
   description = "The name of the Windows jumpbox virtual machine"
-  default     = "mlzDemoJumpboxWindowsVm"
+  default     = "mlzJumpboxWindowsVm"
   type        = string
 }
 
@@ -267,7 +267,7 @@ variable "jumpbox_windows_vm_version" {
 
 variable "jumpbox_linux_vm_name" {
   description = "The name of the Linux jumpbox virtual machine"
-  default     = "mlzDemoJumpboxLinuxVm"
+  default     = "mlzJumpboxLinuxVm"
   type        = string
 }
 

--- a/src/core/tier-0/tier-0.front.json
+++ b/src/core/tier-0/tier-0.front.json
@@ -28,7 +28,7 @@
 			{
 				"varname": "firewall_name",
 				"type": "text",
-				"default_val": "DemoFirewall",
+				"default_val": "mlzFirewall",
 				"description": "Saca Firewall Name",
 				"options": []
 			},

--- a/src/core/tier-1/tier-1.front.json
+++ b/src/core/tier-1/tier-1.front.json
@@ -28,7 +28,7 @@
 			{
 				"varname": "firewall_name",
 				"type": "text",
-				"default_val": "DemoFirewall",
+				"default_val": "mlzFirewall",
 				"description": "Saca Firewall Name",
 				"options": []
 			},

--- a/src/core/tier-2/tier-2.front.json
+++ b/src/core/tier-2/tier-2.front.json
@@ -28,7 +28,7 @@
 			{
 				"varname": "firewall_name",
 				"type": "text",
-				"default_val": "DemoFirewall",
+				"default_val": "mlzFirewall",
 				"description": "Saca Firewall Name",
 				"options": []
 			},

--- a/src/core/tier-3/tier-3.front.json
+++ b/src/core/tier-3/tier-3.front.json
@@ -28,7 +28,7 @@
 			{
 				"varname": "firewall_name",
 				"type": "text",
-				"default_val": "DemoFirewall",
+				"default_val": "mlzFirewall",
 				"description": "Saca Firewall Name",
 				"options": []
 			},


### PR DESCRIPTION
# Description

Removes the word demo from default resource names.

## Issue reference

The issue this PR will close: #249 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [ ] ~~The documentation is updated to cover any new or changed features~~
* [ ] ~~Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)~~
* [x] Relevant issues are linked to this PR
