### PR TITLE
Compatibility support for AZ CLI v2.25.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ ARG TFLINT_VERSION=0.29.1
 ARG TFLINT_AZURERM=0.10.1
 
 # Azure CLI version
-ARG AZURE_CLI_VERSION=2.22.0-1~focal
+ARG AZURE_CLI_VERSION=2.25.0-1~focal
 
 # Update distro (software-properties-common installs the add-apt-repository command)
 RUN apt-get update \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -14,7 +14,7 @@ ARG TFLINT_VERSION=0.29.1
 ARG TFLINT_AZURERM=0.10.1
 
 # Azure CLI version
-ARG AZURE_CLI_VERSION=2.22.0-1~focal
+ARG AZURE_CLI_VERSION=2.25.0-1~focal
 
 # Update distro (software-properties-common installs the add-apt-repository command)
 RUN apt-get update \


### PR DESCRIPTION
# Description

Fix an issue where checking for unique SP was not working properly.
Added support for AZ CLI 2.25.0 and it should support newer versions as well. I found a better way to get and use the AppID instead of display name.

## Issue reference

NA

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles or validates correctly
* [ ] BASH scripts have been validated using `shellcheck`
* [ ] All tests pass (manual and automated)
* [ ] The documentation is updated to cover any new or changed features
* [ ] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [ ] Relevant issues are linked to this PR
