### PR TITLE
add command line deployment to getting-started.md

### DIFF
--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -53,11 +53,15 @@ All other tools and resources are in the development container. The simplest pat
 
 ## Next steps
 
-### Deploy Your Workloads
+### 1. Deploy the Hub and Spoke
+
+With the environment pre-requisites out of the way, deploy the hub and spoke using the [Command Line Deployment](command-line-deployment.md) for step-by-step instructions.
+
+### 2. Deploy Your Workloads
 
 Now that you have the core hub and spoke tiers deployed (tier 0, tier 1, tier 2), the next step is to deploy one or more workload tiers. Misson LZ supports multiple workload tiers. See [Workload Deployment](workload-deployment.md) for details and step-by-step instructions.
 
-### Manage Your Deployment
+### 3. Manage Your Deployment
 
 Once you have a lab deployment of Mission Landing Zone established and have decided to move forward, you will want to start planning your production deployment. We recommend reviewing the following pages during your planning phase.
 

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -55,11 +55,15 @@ All other tools and resources are in the development container. The simplest pat
 
 ### 1. Deploy the Hub and Spoke
 
-With the environment pre-requisites out of the way, deploy the hub and spoke using the [Command Line Deployment](command-line-deployment.md) for step-by-step instructions.
+With the environment pre-requisites out of the way, deploy the hub and spoke using the [Command Line Deployment](command-line-deployment.md) for step-by-step instructions:
+
+* [Command Line Deployment](command-line-deployment.md)
 
 ### 2. Deploy Your Workloads
 
-Now that you have the core hub and spoke tiers deployed (tier 0, tier 1, tier 2), the next step is to deploy one or more workload tiers. Misson LZ supports multiple workload tiers. See [Workload Deployment](workload-deployment.md) for details and step-by-step instructions.
+Now that you have the core hub and spoke tiers deployed (tier 0, tier 1, tier 2), the next step is to deploy one or more workload tiers. Misson LZ supports multiple workload tiers. See [Workload Deployment](workload-deployment.md) for details and step-by-step instructions:
+
+* [Workload Deployment](workload-deployment.md)
 
 ### 3. Manage Your Deployment
 


### PR DESCRIPTION
# Description

The getting-started docs jumped from configuring your environment to adding workloads, missing the step to deploy the hub and spoke. This change adds a link to that documentation.

## Issue reference

The issue this PR will close: n/a

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

~~Code compiles or validates correctly~~
~~BASH scripts have been validated using `shellcheck`~~
~~All tests pass (manual and automated)~~
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)

~~Relevant issues are linked to this PR~~
