### PR TITLE
Removing some extra auto-generated configurations and terraform related files and folders

### DIFF
--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -53,11 +53,19 @@ All other tools and resources are in the development container. The simplest pat
 
 ## Next steps
 
-### Deploy Your Workloads
+### 1. Deploy the Hub and Spoke
 
-Now that you have the core hub and spoke tiers deployed (tier 0, tier 1, tier 2), the next step is to deploy one or more workload tiers. Misson LZ supports multiple workload tiers. See [Workload Deployment](workload-deployment.md) for details and step-by-step instructions.
+With the environment pre-requisites out of the way, deploy the hub and spoke using the [Command Line Deployment](command-line-deployment.md) for step-by-step instructions:
 
-### Manage Your Deployment
+* [Command Line Deployment](command-line-deployment.md)
+
+### 2. Deploy Your Workloads
+
+Now that you have the core hub and spoke tiers deployed (tier 0, tier 1, tier 2), the next step is to deploy one or more workload tiers. Misson LZ supports multiple workload tiers. See [Workload Deployment](workload-deployment.md) for details and step-by-step instructions:
+
+* [Workload Deployment](workload-deployment.md)
+
+### 3. Manage Your Deployment
 
 Once you have a lab deployment of Mission Landing Zone established and have decided to move forward, you will want to start planning your production deployment. We recommend reviewing the following pages during your planning phase.
 

--- a/src/scripts/clean.sh
+++ b/src/scripts/clean.sh
@@ -95,7 +95,13 @@ destroy_mlz() {
 
   # clean up files
   delete_files_in_directory_by_name "${src_path}" "${tfvars_file_name}"
-  rm -rf "${configuration_output_path}/${mlz_env_name}.mlzconfig" "${configuration_output_path:?}/${tfvars_file_name}"
+  echo "INFO: deleting ${configuration_output_path}/${mlz_env_name}.mlzconfig ..."
+  rm -rf "${configuration_output_path}/${mlz_env_name}.mlzconfig"
+  echo "INFO: deleting ${tf_mlz_main_path}/config.vars ..."
+  rm -rf "${tf_mlz_main_path}/config.vars"
+  echo "INFO: deleting terraform.lock file and .terraform folder ..."
+  rm -rf "${tf_mlz_main_path}/.terraform.lock.hcl"
+  rm -rf "${tf_mlz_main_path}/.terraform"
 }
 
 ##########
@@ -131,6 +137,7 @@ check_dependencies
 mlz_config_file_path="${configuration_output_path}/${mlz_env_name}.mlzconfig"
 tfvars_file_name="${mlz_env_name}.tfvars"
 tfvars_file_path="${configuration_output_path}/${tfvars_file_name}"
+tf_mlz_main_path=$(realpath "${configuration_output_path}/../terraform/mlz")
 
 # teardown resources
 # if terraform destroy fails, notify and continue to destroy mlz


### PR DESCRIPTION
# Description

I noticed the clean script does not remove these:
/src/terraform/mlz/config.vars
/src/terraform/mlz/.terraform.lock.hcl
/src/terraform/mlz/.terraform

## Issue reference

NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ x] Code compiles or validates correctly
* [ x] BASH scripts have been validated using `shellcheck`
* [ x] All tests pass (manual and automated)
* [x ] The documentation is updated to cover any new or changed features
* [x ] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x ] Relevant issues are linked to this PR
