### PR TITLE
update devcontainer.json as "terminal.integrated.shell.linux" is deprecated

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,12 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "/bin/bash"
+			}
+		},
+		"terminal.integrated.defaultProfile.linux": "bash"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.


### PR DESCRIPTION
# Description

Using "terminal.integrated.profiles.linux" to define the bash profile, and "terminal.integrated.defaultProfile.linux" to set it as default.

## Issue reference

The issue this PR will close: #272 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [ ] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
