### PR TITLE
optionally deploy Azure Sentinel solution into Tier 1 Log Analytics Workspace

### DIFF
--- a/src/docs/command-line-deployment.md
+++ b/src/docs/command-line-deployment.md
@@ -100,6 +100,7 @@ deploy.sh: create all the configuration and deploy Terraform resources with mini
       --tier3-sub-id -3 [OPTIONAL] subscription ID for tier 3 network and resources (defaults to the value provided for -s --subscription-id), input is used in conjunction with deploy_t3.sh
       --write-output -w [OPTIONAL] Tier 3 Deployment requires Terraform output, use this flag to write terraform output
         --no-bastion    [OPTIONAL] when present, do not create a Bastion Host and Jumpbox VM
+        --no-sentinel   [OPTIONAL] when present, do not create an Azure Sentinel solution
               --help -h Print this message
 ```
 

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -32,6 +32,7 @@ show_help() {
   print_formatted "--tier3-sub-id" "-3" "[OPTIONAL] subscription ID for tier 3 network and resources (defaults to the value provided for -s --subscription-id), input is used in conjunction with deploy_t3.sh"
   print_formatted "--write-output" "-w" "[OPTIONAL] Tier 3 Deployment requires Terraform output, use this flag to write terraform output"
   print_formatted "--no-bastion" "" "[OPTIONAL] when present, do not create a Bastion Host and Jumpbox VM"
+  print_formatted "--no-sentinel" "" "[OPTIONAL] when present, do not create an Azure Sentinel solution"
   print_formatted "--help" "-h" "Print this message"
 }
 
@@ -145,7 +146,7 @@ create_mlz_resources() {
 
 create_terraform_variables() {
   echo "INFO: creating terraform variables at ${tfvars_file_path}..."
-  "${this_script_path}/terraform/create_tfvars_from_config.sh" "${tfvars_file_path}" "${mlz_config_file_path}" "${create_bastion_jumpbox}"
+  "${this_script_path}/terraform/create_tfvars_from_config.sh" "${tfvars_file_path}" "${mlz_config_file_path}" "${create_bastion_jumpbox}" "${create_sentinel}"
 }
 
 apply_terraform() {
@@ -182,6 +183,7 @@ default_config_location="eastus"
 default_tf_environment="public"
 default_env_name="mlz${timestamp}"
 create_bastion_jumpbox=true
+create_sentinel=true
 
 mlz_config_subid="${default_config_subid}"
 mlz_config_location="${default_config_location}"
@@ -219,10 +221,12 @@ while [ $# -gt 0 ] ; do
     -3 | --tier3-sub-id)
       shift
       subs_args+=("-3 ${1}") ;;
-    -w | --write-output)      
+    -w | --write-output)
       write_output="true" ;;
     --no-bastion)
       create_bastion_jumpbox=false ;;
+    --no-sentinel)
+      create_sentinel=false ;;
     -h | --help)
       show_help
       exit 0 ;;

--- a/src/scripts/terraform/create_tfvars_from_config.sh
+++ b/src/scripts/terraform/create_tfvars_from_config.sh
@@ -17,7 +17,7 @@ error_log() {
 
 usage() {
   echo "create_tfvars_from_config.sh: generate a terraform tfvars file given an MLZ config and a desired tfvars file name"
-  echo "create_tfvars_from_config.sh: <destination file path> <mlz config file path> <create bastion host>"
+  echo "create_tfvars_from_config.sh: <destination file path> <mlz config file path> <create bastion host> <create sentinel>"
   show_help
 }
 
@@ -29,6 +29,7 @@ fi
 file_to_create=$1
 mlz_config=$2
 create_bastion_jumpbox=${3:-true}
+create_sentinel=${4:-true}
 
 # source config
 . "${mlz_config}"
@@ -68,6 +69,7 @@ append_kvp "tier1_subid" "${mlz_tier1_subid}"
 append_kvp "tier1_rgname" "rg-t1-${mlz_env_name}"
 append_kvp "tier1_vnetname" "vn-t1-${mlz_env_name}"
 append_kvp "mlz_lawsname" "laws-${mlz_env_name}"
+append_kvp "create_sentinel" "${create_sentinel}"
 
 append_kvp "tier2_subid" "${mlz_tier2_subid}"
 append_kvp "tier2_rgname" "rg-t2-${mlz_env_name}"

--- a/src/terraform/mlz/main.tf
+++ b/src/terraform/mlz/main.tf
@@ -203,9 +203,28 @@ resource "azurerm_log_analytics_workspace" "laws" {
   }
 }
 
-################################
-### STAGE 2: Networking      ###
-################################
+resource "azurerm_log_analytics_solution" "laws_sentinel" {
+  count = var.create_sentinel ? 1 : 0
+
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.tier1.location
+  resource_group_name   = azurerm_resource_group.tier1.name
+  workspace_resource_id = azurerm_log_analytics_workspace.laws.id
+  workspace_name        = azurerm_log_analytics_workspace.laws.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+
+  tags = {
+    DeploymentName = var.deploymentname
+  }
+}
+
+###############################
+## STAGE 2: Networking      ###
+###############################
 
 module "hub-network" {
   providers  = { azurerm = azurerm.hub }

--- a/src/terraform/mlz/minimum.tfvars.sample
+++ b/src/terraform/mlz/minimum.tfvars.sample
@@ -20,5 +20,3 @@ mlz_lawsname   = ""
 tier2_subid    = ""
 tier2_rgname   = ""
 tier2_vnetname = ""
-
-create_bastion_jumpbox = false

--- a/src/terraform/mlz/mlz.tfvars.sample
+++ b/src/terraform/mlz/mlz.tfvars.sample
@@ -154,10 +154,11 @@ tier0_subnets = {
 # Tier 1 Network configuration section
 #################################
 
-tier1_subid    = "{TIER1_SUBID}"
-tier1_rgname   = "{TIER1_RGNAME}"
-tier1_vnetname = "{TIER1_VNETNAME}"
-mlz_lawsname   = "{MLZ_LAWSNAME}
+tier1_subid     = "{TIER1_SUBID}"
+tier1_rgname    = "{TIER1_RGNAME}"
+tier1_vnetname  = "{TIER1_VNETNAME}"
+mlz_lawsname    = "{MLZ_LAWSNAME}
+create_sentinel = "{CREATE_SENTINEL}"
 
 tier1_vnet_address_space = ["{TIER1_VNET_ADDRESS_SPACE}"]
 

--- a/src/terraform/mlz/variables.tf
+++ b/src/terraform/mlz/variables.tf
@@ -391,6 +391,12 @@ variable "mlz_lawsname" {
   description = "Log Analytics Workspace Name for the deployment"
 }
 
+variable "create_sentinel" {
+  description = "Create an Azure Sentinel Log Analytics Workspace Solution"
+  type        = bool
+  default     = true
+}
+
 variable "tier1_vnet_address_space" {
   description = "Address space prefixes for the virtual network"
   type        = list(string)


### PR DESCRIPTION
# Description

Adds an Azure Sentinel deployment to the Tier 1 Log Analytics Workspace by default.

Users can opt-out of this in two ways:
1. when invoking Terraform manually, supply a Terraform variable `create_sentinel = false`
2. or, when using the `deploy.sh` script, passing the `--no-sentinel` flag.

To demo this, deploy as you usually would: `src/scripts/deploy.sh -s ${my_sub_id}`

To deploy without Azure Sentinel: `src/scripts/deploy.sh -s ${my_sub_id} --no-sentinel`

## Issue reference

The issue this PR will close: #256

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
