### PR TITLE
update .gitattributes to use LF endings for *.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,7 @@
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.
 *.tf text
-*.sh text
+*.sh text eol=lf
 
 # Declare files that will always have CRLF line endings on checkout.
 # *.sln text eol=crlf


### PR DESCRIPTION
# Description

Update the .gitattributes in the repo to treat all BASH scripts with LF endings so that wherever someone clones the repository, when the .devcontainer interacts with these files, they'll be executable.

The issue this PR will close: #291 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
