### PR TITLE
Fix a bug where config resources were always created in the Hub subscription

### DIFF
--- a/src/scripts/config/create_required_resources.sh
+++ b/src/scripts/config/create_required_resources.sh
@@ -42,4 +42,4 @@ mlz_path="$(realpath "${this_script_path}/../../terraform/mlz")"
 . "${this_script_path}/create_mlz_config_resources.sh" "${mlz_config}" "${mlz_env_name}" "${mlz_config_location}"
 
 # create terraform resources given a subscription ID and terraform configuration folder
-. "${this_script_path}/create_terraform_backend_resources.sh" "${mlz_config}" "${mlz_saca_subid}" "${mlz_path}"
+. "${this_script_path}/create_terraform_backend_resources.sh" "${mlz_config}" "${mlz_config_subid}" "${mlz_path}"

--- a/src/scripts/terraform/init_terraform.sh
+++ b/src/scripts/terraform/init_terraform.sh
@@ -56,7 +56,7 @@ init_args+=("-backend-config=\"storage_account_name=${tf_sa_name}\"")
 init_args+=("-backend-config=\"container_name=${container_name}\"")
 init_args+=("-backend-config=\"environment=${environment}\"")
 init_args+=("-backend-config=\"tenant_id=${tenant_id}\"")
-init_args+=("-backend-config=\"subscription_id=${sub_id}\"")
+init_args+=("-backend-config=\"subscription_id=${mlz_config_subid}\"")
 init_args+=("-backend-config=\"client_id=${client_id}\"")
 init_args+=("-backend-config=\"client_secret=${client_secret}\"")
 


### PR DESCRIPTION
# Description

Fixes a bug where deploy.sh will fail because it will always look in the hub subscription for the Terraform state storage account:

```bash
src/scripts/deploy.sh -s {config_sub_id} \
-u {hub_sub_id} \
-0 {t0_sub_id} \
-1 {t1_sub_id} \
-2 {t2_sub_id} \
-3 {t3_sub_id}
```

Would result in a Terraform initialization that specified the `hub_sub_id` as the place to search for Terraform state regardless of where it was actually deployed.

## Issue reference

The issue this PR will close: #302 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
