### PR TITLE
Remove Client/Client Secret/Tenant Vars from Terraform Templates

### DIFF
--- a/src/mlz.config.sample
+++ b/src/mlz.config.sample
@@ -5,7 +5,6 @@ tf_environment="{TF_ENVIRONMENT}" # https://www.terraform.io/docs/language/setti
 mlz_env_name="{MLZ_ENV_NAME}" # Unique name for MLZ environment
 mlz_config_subid="{MLZ_CONFIG_SUBID}" # Subscription ID for MissionLZ configuration resources
 mlz_config_location="{MLZ_CONFIG_LOCATION}" # Azure Region for deploying Mission LZ configuration resources
-mlz_tenantid="{MLZ_TENANTID}"
 mlz_tier0_subid="{MLZ_TIER0_SUBID}"
 mlz_tier1_subid="{MLZ_TIER1_SUBID}"
 mlz_tier2_subid="{MLZ_TIER2_SUBID}"

--- a/src/terraform/mlz/main.tf
+++ b/src/terraform/mlz/main.tf
@@ -23,10 +23,7 @@ terraform {
 provider "azurerm" {
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
-  tenant_id       = var.mlz_tenantid
   subscription_id = var.hub_subid
-  client_id       = var.mlz_clientid
-  client_secret   = var.mlz_clientsecret
 
   features {
     log_analytics_workspace {
@@ -42,10 +39,7 @@ provider "azurerm" {
   alias           = "hub"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
-  tenant_id       = var.mlz_tenantid
   subscription_id = var.hub_subid
-  client_id       = var.mlz_clientid
-  client_secret   = var.mlz_clientsecret
 
   features {
     log_analytics_workspace {
@@ -61,10 +55,7 @@ provider "azurerm" {
   alias           = "tier0"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
-  tenant_id       = var.mlz_tenantid
   subscription_id = var.tier0_subid
-  client_id       = var.mlz_clientid
-  client_secret   = var.mlz_clientsecret
 
   features {
     log_analytics_workspace {
@@ -80,10 +71,7 @@ provider "azurerm" {
   alias           = "tier1"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
-  tenant_id       = var.mlz_tenantid
   subscription_id = var.tier1_subid
-  client_id       = var.mlz_clientid
-  client_secret   = var.mlz_clientsecret
 
   features {
     log_analytics_workspace {
@@ -99,10 +87,7 @@ provider "azurerm" {
   alias           = "tier2"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
-  tenant_id       = var.mlz_tenantid
   subscription_id = var.tier2_subid
-  client_id       = var.mlz_clientid
-  client_secret   = var.mlz_clientsecret
 
   features {
     log_analytics_workspace {
@@ -205,8 +190,8 @@ resource "azurerm_log_analytics_workspace" "laws" {
 }
 
 resource "azurerm_log_analytics_solution" "laws_sentinel" {
-  provider   = azurerm.tier1
-  count = var.create_sentinel ? 1 : 0
+  provider = azurerm.tier1
+  count    = var.create_sentinel ? 1 : 0
 
   solution_name         = "SecurityInsights"
   location              = azurerm_resource_group.tier1.location
@@ -492,7 +477,6 @@ module "jumpbox" {
   location             = var.mlz_location
 
   keyvault_name = var.jumpbox_keyvault_name
-  tenant_id     = var.mlz_tenantid
   object_id     = var.mlz_objectid
 
   windows_name          = var.jumpbox_windows_vm_name

--- a/src/terraform/mlz/minimum.tfvars.sample
+++ b/src/terraform/mlz/minimum.tfvars.sample
@@ -1,10 +1,7 @@
 tf_environment   = ""
 deploymentname   = ""
-mlz_tenantid     = ""
 mlz_location     = ""
 mlz_metadatahost = ""
-mlz_clientid     = ""
-mlz_clientsecret = ""
 mlz_objectid     = ""
 
 hub_subid      = ""

--- a/src/terraform/mlz/mlz.tfvars.sample
+++ b/src/terraform/mlz/mlz.tfvars.sample
@@ -7,11 +7,8 @@
 
 tf_environment   ="{TF_ENVIRONMENT}"
 deploymentname   ="{DEPLOYMENTNAME}"
-mlz_tenantid     ="{MLZ_TENANTID}"
 mlz_location     ="{MLZ_LOCATION}"
 mlz_metadatahost ="{MLZ_METADATAHOST}"
-mlz_clientid     ="{MLZ_CLIENTID}"
-mlz_clientsecret ="{MLZ_CLIENTSECRET}"
 mlz_objectid     ="{MLZ_OBJECTID}"
 
 #################################

--- a/src/terraform/mlz/variables.tf
+++ b/src/terraform/mlz/variables.tf
@@ -13,24 +13,12 @@ variable "deploymentname" {
   description = "A name for the deployment"
 }
 
-variable "mlz_tenantid" {
-  description = "The Azure tenant for the deployment"
-}
-
 variable "mlz_location" {
   description = "The Azure region for most Mission LZ resources"
 }
 
 variable "mlz_metadatahost" {
   description = "The metadata host for the Azure Cloud e.g. management.azure.com"
-}
-
-variable "mlz_clientid" {
-  description = "The account to deploy with"
-}
-
-variable "mlz_clientsecret" {
-  description = "The account to deploy with"
 }
 
 variable "mlz_objectid" {

--- a/src/terraform/tier3/main.tf
+++ b/src/terraform/tier3/main.tf
@@ -14,10 +14,7 @@ terraform {
 provider "azurerm" {
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
-  tenant_id       = var.mlz_tenantid
   subscription_id = var.hub_subid
-  client_id       = var.mlz_clientid
-  client_secret   = var.mlz_clientsecret
 
   features {
     log_analytics_workspace {
@@ -33,10 +30,7 @@ provider "azurerm" {
   alias           = "hub"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
-  tenant_id       = var.mlz_tenantid
   subscription_id = var.hub_subid
-  client_id       = var.mlz_clientid
-  client_secret   = var.mlz_clientsecret
 
   features {
     log_analytics_workspace {
@@ -52,10 +46,7 @@ provider "azurerm" {
   alias           = "tier1"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
-  tenant_id       = var.mlz_tenantid
   subscription_id = var.tier1_subid
-  client_id       = var.mlz_clientid
-  client_secret   = var.mlz_clientsecret
 
   features {
     log_analytics_workspace {
@@ -71,10 +62,7 @@ provider "azurerm" {
   alias           = "tier3"
   environment     = var.tf_environment
   metadata_host   = var.mlz_metadatahost
-  tenant_id       = var.mlz_tenantid
   subscription_id = var.tier3_subid
-  client_id       = var.mlz_clientid
-  client_secret   = var.mlz_clientsecret
 
   features {
     log_analytics_workspace {

--- a/src/terraform/tier3/minimum.tfvars.sample
+++ b/src/terraform/tier3/minimum.tfvars.sample
@@ -1,10 +1,8 @@
 tf_environment   = ""
 deploymentname   = ""
-mlz_tenantid     = ""
 mlz_location     = ""
 mlz_metadatahost = ""
-mlz_clientid     = ""
-mlz_clientsecret = ""
+
 
 hub_subid      = ""
 hub_rgname     = ""

--- a/src/terraform/tier3/tier3.tfvars.sample
+++ b/src/terraform/tier3/tier3.tfvars.sample
@@ -7,11 +7,8 @@
 
 tf_environment   = "{TF_ENVIRONMENT}"
 deploymentname   = "{DEPLOYMENTNAME}"
-mlz_tenantid     = "{MLZ_TENANTID}"
 mlz_location     = "{MLZ_LOCATION}"
 mlz_metadatahost = "{MLZ_METADATAHOST}"
-mlz_clientid     = "{MLZ_CLIENTID}"
-mlz_clientsecret = "{MLZ_CLIENTSECRET}"
 mlz_objectid     = "{MLZ_OBJECTID}"
 
 #################################

--- a/src/terraform/tier3/variables.tf
+++ b/src/terraform/tier3/variables.tf
@@ -12,24 +12,12 @@ variable "deploymentname" {
   description = "A name for the deployment"
 }
 
-variable "mlz_tenantid" {
-  description = "The Azure tenant for the deployment"
-}
-
 variable "mlz_location" {
   description = "The Azure region for most Mission LZ resources"
 }
 
 variable "mlz_metadatahost" {
   description = "The metadata host for the Azure Cloud e.g. management.azure.com"
-}
-
-variable "mlz_clientid" {
-  description = "The account to deploy with"
-}
-
-variable "mlz_clientsecret" {
-  description = "The account to deploy with"
 }
 
 variable "mlz_objectid" {


### PR DESCRIPTION
# Description

Removed all variables instances in Terraform Template of: mlz_clientid, mlz_clientsecret, mlz_tenantid

## Issue reference

The issue this PR will close: #378 
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles or validates correctly
* [ ] BASH scripts have been validated using `shellcheck`
* [ ] All tests pass (manual and automated)
* [X] The documentation is updated to cover any new or changed features
* [X] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [X] Relevant issues are linked to this PR
