### PR TITLE
report only errors in Bicep lint output

### DIFF
--- a/src/bicep/bicepconfig.json
+++ b/src/bicep/bicepconfig.json
@@ -1,7 +1,7 @@
 {
     "analyzers": {
       "core": {
-        "verbose": true,
+        "verbose": false,
         "enabled": true,
         "rules": {
           "no-hardcoded-env-urls": {


### PR DESCRIPTION
# Description

Toggles the verbosity of the Bicep linter to report only errors. Mostly useful to omit the `Info Bicep Linter Configuration: Custom bicepconfig.json file found` on each module that uses the linter:

The first command is before `verbose: true`, the second command is after `verbose: false`:

![image](https://user-images.githubusercontent.com/4622125/132533488-00dfe528-d007-463e-99c3-0ec2dcb8d91e.png)

## Issue reference

The issue this PR will close: #360

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

~~[ ] Code compiles or validates correctly~~
~~[ ] BASH scripts have been validated using `shellcheck`~~
~~[ ] All tests pass (manual and automated)~~
~~[ ] The documentation is updated to cover any new or changed features~~
~~[ ] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)~~
~~[ ] Relevant issues are linked to this PR~~