### PR TITLE
fail fast on deployments by decrementing max_attempts to 1

### DIFF
--- a/src/build/apply_tf.sh
+++ b/src/build/apply_tf.sh
@@ -74,7 +74,7 @@ apply() {
   # (race conditions, transient errors etc.)
   apply_success="false"
   attempts=1
-  max_attempts=5
+  max_attempts=1
 
   apply_command="${scripts_dir}/terraform/apply_terraform.sh ${tf_dir} ${tf_vars} y"
   destroy_command="${scripts_dir}/terraform/destroy_terraform.sh ${tf_dir} ${tf_vars} y"

--- a/src/build/destroy_tf.sh
+++ b/src/build/destroy_tf.sh
@@ -74,7 +74,7 @@ destroy() {
   # (race conditions, transient errors etc.)
   destroy_success="false"
   attempts=1
-  max_attempts=5
+  max_attempts=1
 
   destroy_command="${scripts_dir}/terraform/destroy_terraform.sh ${tf_dir} ${tf_vars} y"
 


### PR DESCRIPTION
# Description

Changed the value of max_attempts to 1 so that it will fail fast as opposed to looping 5 times, leaving the retry logic in place however to allow for future debug attempts. 

## Issue reference

The issue this PR will close: #362 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [X] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] Relevant issues are linked to this PR
