### PR TITLE
Correctly pushing activity diagnostic settings.

### DIFF
--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -253,54 +253,82 @@ module sharedServicesVirtualNetworkPeering './modules/spokeNetworkPeering.bicep'
 }
 
 module hubPolicyAssignment './modules/policyAssignment.bicep' = {
-  name: '${hubResourceGroupName}-policyAssignement'
+  name: 'deploy-hub-policyAssignement'
   scope: resourceGroup(hubSubscriptionId, hubResourceGroupName)
-  dependsOn: [
-    hubResourceGroup
-    logAnalyticsWorkspace
-  ]
   params: {
     builtInAssignment: policy
     logAnalyticsWorkspaceName: logAnalyticsWorkspace.outputs.name
     logAnalyticsWorkspaceResourceGroupName: operationsResourceGroup.outputs.name
+    opsSubscriptionId: operationsSubscriptionId
   }
 }
 
 module operationsPolicyAssignment './modules/policyAssignment.bicep' = {
-  name: '${operationsResourceGroupName}-policyAssignment'
+  name: 'deploy-operations-policyAssignment'
   scope: resourceGroup(operationsSubscriptionId, operationsResourceGroupName)
   params: {
     builtInAssignment: policy
     logAnalyticsWorkspaceName: logAnalyticsWorkspace.outputs.name
     logAnalyticsWorkspaceResourceGroupName: operationsResourceGroup.outputs.name
+    opsSubscriptionId: operationsSubscriptionId
   }
 }
 
 module sharedServicesPolicyAssignment './modules/policyAssignment.bicep' = {
-  name: '${sharedServicesResourceGroupName}-policyAssignement'
+  name: 'deploy-shareServices-policyAssignement'
   scope: resourceGroup(sharedServicesSubscriptionId, sharedServicesResourceGroupName)
-  dependsOn: [
-    sharedServicesResourceGroup
-    logAnalyticsWorkspace
-  ]
   params: {
     builtInAssignment: policy
     logAnalyticsWorkspaceName: logAnalyticsWorkspace.outputs.name
     logAnalyticsWorkspaceResourceGroupName: operationsResourceGroup.outputs.name
+    opsSubscriptionId: operationsSubscriptionId
   }
 }
 
 module identityPolicyAssignment './modules/policyAssignment.bicep' = {
-  name: '${identityResourceGroupName}-policyAssignement'
+  name: 'deploy-identity-policyAssignement'
   scope: resourceGroup(identitySubscriptionId, identityResourceGroupName)
-  dependsOn: [
-    identityResourceGroup
-    logAnalyticsWorkspace
-  ]
   params: {
     builtInAssignment: policy
     logAnalyticsWorkspaceName: logAnalyticsWorkspace.outputs.name
     logAnalyticsWorkspaceResourceGroupName: operationsResourceGroup.outputs.name
+    opsSubscriptionId: operationsSubscriptionId
+  }
+}
+
+module hubSubscriptionCreateActivityLogging './modules/centralLogging.bicep' = {
+  name: 'deploy-hub-sub-activity-logging'
+  scope: subscription(hubSubscriptionId)
+  params: {
+    logAnalyticsWorkspaceId: logAnalyticsWorkspace.outputs.id
+    deploymentName: resourcePrefix
+  }
+}
+
+module opsSubscriptionCreateActivityLogging './modules/centralLogging.bicep' = if(!(hubSubscriptionId == operationsSubscriptionId)) {
+  name: 'deploy-ops-sub-activity-logging'
+  scope: subscription(operationsSubscriptionId)
+  params: {
+    logAnalyticsWorkspaceId: logAnalyticsWorkspace.outputs.id
+    deploymentName: resourcePrefix
+  }
+}
+
+module identSubscriptionCreateActivityLogging './modules/centralLogging.bicep' = if(!(hubSubscriptionId == identitySubscriptionId)) {
+  name: 'deploy-ident-sub-activity-logging'
+  scope: subscription(identitySubscriptionId)
+  params: {
+    logAnalyticsWorkspaceId: logAnalyticsWorkspace.outputs.id
+    deploymentName: resourcePrefix
+  }
+}
+
+module sharedSubscriptionCreateActivityLogging './modules/centralLogging.bicep' = if(!(hubSubscriptionId == sharedServicesSubscriptionId)) {
+  name: 'deploy-shared-sub-activity-logging'
+  scope: subscription(sharedServicesSubscriptionId)
+  params: {
+    logAnalyticsWorkspaceId: logAnalyticsWorkspace.outputs.id
+    deploymentName: resourcePrefix
   }
 }
 

--- a/src/bicep/modules/centralLogging.bicep
+++ b/src/bicep/modules/centralLogging.bicep
@@ -1,0 +1,48 @@
+// scope
+targetScope = 'subscription'
+
+param logAnalyticsWorkspaceId string
+param deploymentName string
+
+//// Central activity logging to LAWS
+resource somethingNew 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'LoggingToLA-${deploymentName}'
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    logs: [
+      {
+        category: 'Administrative'
+        enabled: true
+      }
+      {
+        category: 'Security'
+        enabled: true
+      }
+      {
+        category: 'ServiceHealth'
+        enabled: true
+      }
+      {
+        category: 'Alert'
+        enabled: true
+      }
+      {
+        category: 'Recommendation'
+        enabled: true
+      }
+      {
+        category: 'Policy'
+        enabled: true
+      }
+      {
+        category: 'Autoscale'
+        enabled: true
+      }
+      {
+        category: 'ResourceHealth'
+        enabled: true
+      }
+    ]
+  }
+
+}

--- a/src/bicep/modules/policyAssignment.bicep
+++ b/src/bicep/modules/policyAssignment.bicep
@@ -1,11 +1,12 @@
 param builtInAssignment string = ''
 param logAnalyticsWorkspaceName string
 param logAnalyticsWorkspaceResourceGroupName string
+param opsSubscriptionId string
 
 // Creating a symbolic name for an existing resource
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
   name: logAnalyticsWorkspaceName
-  scope: resourceGroup(logAnalyticsWorkspaceResourceGroupName)
+  scope: resourceGroup(opsSubscriptionId, logAnalyticsWorkspaceResourceGroupName)
 }
 
 var policyDefinitionID = {


### PR DESCRIPTION
# Description

Adds a diagnostic setting that pushes logs from activity logging into the operations RG's log analytics workspace. This is a subscription level deployment so it hangs around after deleting RG's and will need to be deleted.

## Issue reference

The issue this PR will close: #387 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [ ] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
