### PR TITLE
diagnostic name with log analytics workspace name

### DIFF
--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -300,8 +300,8 @@ module hubSubscriptionCreateActivityLogging './modules/centralLogging.bicep' = {
   name: 'deploy-hub-sub-activity-logging'
   scope: subscription(hubSubscriptionId)
   params: {
+    diagnosticSettingName: 'log-hub-sub-activity-to-${logAnalyticsWorkspace.outputs.name}'
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.outputs.id
-    deploymentName: resourcePrefix
   }
 }
 
@@ -309,8 +309,8 @@ module operationsSubscriptionCreateActivityLogging './modules/centralLogging.bic
   name: 'deploy-operations-sub-activity-logging'
   scope: subscription(operationsSubscriptionId)
   params: {
+    diagnosticSettingName: 'log-operations-sub-activity-to-${logAnalyticsWorkspace.outputs.name}'
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.outputs.id
-    deploymentName: resourcePrefix
   }
 }
 
@@ -318,8 +318,8 @@ module identitySubscriptionCreateActivityLogging './modules/centralLogging.bicep
   name: 'deploy-identity-sub-activity-logging'
   scope: subscription(identitySubscriptionId)
   params: {
+    diagnosticSettingName: 'log-identity-sub-activity-to-${logAnalyticsWorkspace.outputs.name}'
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.outputs.id
-    deploymentName: resourcePrefix
   }
 }
 
@@ -327,8 +327,8 @@ module sharedServicesSubscriptionCreateActivityLogging './modules/centralLogging
   name: 'deploy-sharedServices-sub-activity-logging'
   scope: subscription(sharedServicesSubscriptionId)
   params: {
+    diagnosticSettingName: 'log-sharedServices-sub-activity-to-${logAnalyticsWorkspace.outputs.name}'
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.outputs.id
-    deploymentName: resourcePrefix
   }
 }
 

--- a/src/bicep/modules/centralLogging.bicep
+++ b/src/bicep/modules/centralLogging.bicep
@@ -1,12 +1,12 @@
 // scope
 targetScope = 'subscription'
 
+param diagnosticSettingName string
 param logAnalyticsWorkspaceId string
-param deploymentName string
 
 //// Central activity logging to LAWS
 resource centralLoggingDiagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
-  name: 'LoggingToLA-${deploymentName}'
+  name: diagnosticSettingName
   properties: {
     workspaceId: logAnalyticsWorkspaceId
     logs: [


### PR DESCRIPTION
setting the diagnostic setting name from the root module instead of at the component module and the value to be explicitly what is being logged where instead of using the generated random name