### PR TITLE
include a Windows virtual machine for jumpbox access

### DIFF
--- a/src/bicep/README.md
+++ b/src/bicep/README.md
@@ -150,3 +150,25 @@ az deployment sub create \
   --parameters linuxVmAdminPasswordOrKey="$my_password" \
   --parameters windowsVmAdminPassword="$my_password"
 ```
+
+### Using an SSH Key with Remote Access via Bastion Host
+
+If you have a key pair you'd like to use for SSH connections to the Linux virtual machine that is deployed with `deployRemoteAccess=true`, specify the `linuxVmAuthenticationType` parameter to `sshPublicKey` like so:
+
+```plaintext
+my_sshkey=$(cat ~/.ssh/id_rsa.pub) # or, however you source your public key
+my_password=$(openssl rand -base64 14)
+
+az deployment sub create \
+  --name "myRemoteAccessDeployment" \
+  --location "eastus" \
+  --template-file "src/bicep/mlz.bicep" \
+  --parameters deployRemoteAccess="true" \
+  --parameters linuxVmAuthenticationType="sshPublicKey" \
+  --parameters linuxVmAdminPasswordOrKey="$my_sshkey" \
+  --parameters windowsVmAdminPassword="$my_password"
+```
+
+For more information on generating a public/private key pair see <https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-ssh-keys-detailed#generate-keys-with-ssh-keygen>.
+
+Then, once you've deployed the virtual machine and Bastion Host, use these docs to connect: <https://docs.microsoft.com/en-us/azure/bastion/bastion-connect-vm-ssh#privatekey>

--- a/src/bicep/README.md
+++ b/src/bicep/README.md
@@ -137,7 +137,7 @@ The result will be a policy assignment created for each resource group deployed 
 
 ## Adding Remote Access via Bastion Host
 
-To deploy a virtual machine as a jumpbox into the network without a Public IP Address using Azure Bastion Host, provide two parameters `deployRemoteAccess=true` and `linuxVmAdminPasswordOrKey=<your password>` to the deployment. A quick and easy way to generate a secure password from the .devcontainer is the command `openssl rand -base64 14`.
+To deploy a virtual machine as a jumpbox into the network without a Public IP Address using Azure Bastion Host, provide two parameters `deployRemoteAccess=true` and `linuxVmAdminPasswordOrKey=<your password>` and `windowsVmAdminPassword=<your password>` to the deployment. A quick and easy way to generate a secure password from the .devcontainer is the command `openssl rand -base64 14`.
 
 ```plaintext
 my_password=$(openssl rand -base64 14)
@@ -147,5 +147,6 @@ az deployment sub create \
   --location "eastus" \
   --template-file "src/bicep/mlz.bicep" \
   --parameters deployRemoteAccess="true" \
-  --parameters linuxVmAdminPasswordOrKey="$my_password"
+  --parameters linuxVmAdminPasswordOrKey="$my_password" \
+  --parameters windowsVmAdminPassword="$my_password"
 ```

--- a/src/bicep/examples/remoteAccess/main.bicep
+++ b/src/bicep/examples/remoteAccess/main.bicep
@@ -12,6 +12,10 @@ param bastionHostPublicIPAddressAllocationMethod string = 'Static'
 param bastionHostPublicIPAddressAvailabilityZones array = []
 param bastionHostIPConfigurationName string = 'bastionHostIPConfiguration'
 
+param linuxNetworkInterfaceName string = 'linuxVmNetworkInterface'
+param linuxNetworkInterfaceIpConfigurationName string = 'linuxVmIpConfiguration'
+param linuxNetworkInterfacePrivateIPAddressAllocationMethod string = 'Dynamic'
+
 param linuxVmName string = 'linuxVirtualMachine'
 param linuxVmSize string = 'Standard_B2s'
 param linuxVmOsDiskCreateOption string = 'FromImage'
@@ -21,7 +25,6 @@ param linuxVmImageOffer string = 'UbuntuServer'
 param linuxVmImageSku string = '18.04-LTS'
 param linuxVmImageVersion string = 'latest'
 param linuxVmAdminUsername string = 'azureuser'
-
 @allowed([
   'sshPublicKey'
   'password'
@@ -31,9 +34,21 @@ param linuxVmAuthenticationType string = 'password'
 @minLength(14)
 param linuxVmAdminPasswordOrKey string
 
-param linuxVmNetworkInterfaceName string = 'linuxVmNetworkInterface'
-param linuxVmNetworkInterfaceIpConfigurationName string = 'linuxVmIpConfiguration'
-param linuxVmNetworkInterfacePrivateIPAddressAllocationMethod string = 'Dynamic'
+param windowsNetworkInterfaceName string = 'windowsVmNetworkInterface'
+param windowsNetworkInterfaceIpConfigurationName string = 'windowsVmIpConfiguration'
+param windowsNetworkInterfacePrivateIPAddressAllocationMethod string = 'Dynamic'
+param windowsVmName string = 'windowsVm'
+param windowsVmSize string = 'Standard_DS1_v2'
+param windowsVmAdminUsername string = 'azureuser'
+@secure()
+@minLength(14)
+param windowsVmAdminPassword string
+param windowsVmPublisher string = 'MicrosoftWindowsServer'
+param windowsVmOffer string = 'WindowsServer'
+param windowsVmSku string = '2019-datacenter-gensecond'
+param windowsVmVersion string = 'latest'
+param windowsVmCreateOption string = 'FromImage'
+param windowsVmStorageAccountType string = 'StandardSSD_LRS'
 
 param nowUtc string = utcNow()
 
@@ -54,8 +69,9 @@ module remoteAccess '../../modules/remoteAccess.bicep' = {
     bastionHostPublicIPAddressAvailabilityZones: bastionHostPublicIPAddressAvailabilityZones
     bastionHostIPConfigurationName: bastionHostIPConfigurationName
 
-    linuxNetworkInterfaceIpConfigurationName: linuxVmNetworkInterfaceIpConfigurationName
-    linuxNetworkInterfacePrivateIPAddressAllocationMethod: linuxVmNetworkInterfacePrivateIPAddressAllocationMethod
+    linuxNetworkInterfaceName: linuxNetworkInterfaceName
+    linuxNetworkInterfaceIpConfigurationName: linuxNetworkInterfaceIpConfigurationName
+    linuxNetworkInterfacePrivateIPAddressAllocationMethod: linuxNetworkInterfacePrivateIPAddressAllocationMethod
 
     linuxVmName: linuxVmName
     linuxVmSize: linuxVmSize
@@ -68,6 +84,20 @@ module remoteAccess '../../modules/remoteAccess.bicep' = {
     linuxVmAdminUsername: linuxVmAdminUsername
     linuxVmAuthenticationType: linuxVmAuthenticationType
     linuxVmAdminPasswordOrKey: linuxVmAdminPasswordOrKey
-    linuxVmNetworkInterfaceName: linuxVmNetworkInterfaceName
+
+    windowsNetworkInterfaceName: windowsNetworkInterfaceName
+    windowsNetworkInterfaceIpConfigurationName: windowsNetworkInterfaceIpConfigurationName
+    windowsNetworkInterfacePrivateIPAddressAllocationMethod: windowsNetworkInterfacePrivateIPAddressAllocationMethod
+
+    windowsVmName: windowsVmName
+    windowsVmSize: windowsVmSize
+    windowsVmAdminUsername: windowsVmAdminUsername
+    windowsVmAdminPassword: windowsVmAdminPassword
+    windowsVmPublisher: windowsVmPublisher
+    windowsVmOffer: windowsVmOffer
+    windowsVmSku: windowsVmSku
+    windowsVmVersion: windowsVmVersion
+    windowsVmCreateOption: windowsVmCreateOption
+    windowsVmStorageAccountType: windowsVmStorageAccountType
   }
 }

--- a/src/bicep/examples/remoteAccess/main.json
+++ b/src/bicep/examples/remoteAccess/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "12135705171876165812"
+      "templateHash": "10649862739162036164"
     }
   },
   "parameters": {
@@ -49,6 +49,18 @@
     "bastionHostIPConfigurationName": {
       "type": "string",
       "defaultValue": "bastionHostIPConfiguration"
+    },
+    "linuxNetworkInterfaceName": {
+      "type": "string",
+      "defaultValue": "linuxVmNetworkInterface"
+    },
+    "linuxNetworkInterfaceIpConfigurationName": {
+      "type": "string",
+      "defaultValue": "linuxVmIpConfiguration"
+    },
+    "linuxNetworkInterfacePrivateIPAddressAllocationMethod": {
+      "type": "string",
+      "defaultValue": "Dynamic"
     },
     "linuxVmName": {
       "type": "string",
@@ -98,17 +110,57 @@
       "type": "secureString",
       "minLength": 14
     },
-    "linuxVmNetworkInterfaceName": {
+    "windowsNetworkInterfaceName": {
       "type": "string",
-      "defaultValue": "linuxVmNetworkInterface"
+      "defaultValue": "windowsVmNetworkInterface"
     },
-    "linuxVmNetworkInterfaceIpConfigurationName": {
+    "windowsNetworkInterfaceIpConfigurationName": {
       "type": "string",
-      "defaultValue": "linuxVmIpConfiguration"
+      "defaultValue": "windowsVmIpConfiguration"
     },
-    "linuxVmNetworkInterfacePrivateIPAddressAllocationMethod": {
+    "windowsNetworkInterfacePrivateIPAddressAllocationMethod": {
       "type": "string",
       "defaultValue": "Dynamic"
+    },
+    "windowsVmName": {
+      "type": "string",
+      "defaultValue": "windowsVm"
+    },
+    "windowsVmSize": {
+      "type": "string",
+      "defaultValue": "Standard_DS1_v2"
+    },
+    "windowsVmAdminUsername": {
+      "type": "string",
+      "defaultValue": "azureuser"
+    },
+    "windowsVmAdminPassword": {
+      "type": "secureString",
+      "minLength": 14
+    },
+    "windowsVmPublisher": {
+      "type": "string",
+      "defaultValue": "MicrosoftWindowsServer"
+    },
+    "windowsVmOffer": {
+      "type": "string",
+      "defaultValue": "WindowsServer"
+    },
+    "windowsVmSku": {
+      "type": "string",
+      "defaultValue": "2019-datacenter-gensecond"
+    },
+    "windowsVmVersion": {
+      "type": "string",
+      "defaultValue": "latest"
+    },
+    "windowsVmCreateOption": {
+      "type": "string",
+      "defaultValue": "FromImage"
+    },
+    "windowsVmStorageAccountType": {
+      "type": "string",
+      "defaultValue": "StandardSSD_LRS"
     },
     "nowUtc": {
       "type": "string",
@@ -160,11 +212,14 @@
           "bastionHostIPConfigurationName": {
             "value": "[parameters('bastionHostIPConfigurationName')]"
           },
+          "linuxNetworkInterfaceName": {
+            "value": "[parameters('linuxNetworkInterfaceName')]"
+          },
           "linuxNetworkInterfaceIpConfigurationName": {
-            "value": "[parameters('linuxVmNetworkInterfaceIpConfigurationName')]"
+            "value": "[parameters('linuxNetworkInterfaceIpConfigurationName')]"
           },
           "linuxNetworkInterfacePrivateIPAddressAllocationMethod": {
-            "value": "[parameters('linuxVmNetworkInterfacePrivateIPAddressAllocationMethod')]"
+            "value": "[parameters('linuxNetworkInterfacePrivateIPAddressAllocationMethod')]"
           },
           "linuxVmName": {
             "value": "[parameters('linuxVmName')]"
@@ -199,8 +254,44 @@
           "linuxVmAdminPasswordOrKey": {
             "value": "[parameters('linuxVmAdminPasswordOrKey')]"
           },
-          "linuxVmNetworkInterfaceName": {
-            "value": "[parameters('linuxVmNetworkInterfaceName')]"
+          "windowsNetworkInterfaceName": {
+            "value": "[parameters('windowsNetworkInterfaceName')]"
+          },
+          "windowsNetworkInterfaceIpConfigurationName": {
+            "value": "[parameters('windowsNetworkInterfaceIpConfigurationName')]"
+          },
+          "windowsNetworkInterfacePrivateIPAddressAllocationMethod": {
+            "value": "[parameters('windowsNetworkInterfacePrivateIPAddressAllocationMethod')]"
+          },
+          "windowsVmName": {
+            "value": "[parameters('windowsVmName')]"
+          },
+          "windowsVmSize": {
+            "value": "[parameters('windowsVmSize')]"
+          },
+          "windowsVmAdminUsername": {
+            "value": "[parameters('windowsVmAdminUsername')]"
+          },
+          "windowsVmAdminPassword": {
+            "value": "[parameters('windowsVmAdminPassword')]"
+          },
+          "windowsVmPublisher": {
+            "value": "[parameters('windowsVmPublisher')]"
+          },
+          "windowsVmOffer": {
+            "value": "[parameters('windowsVmOffer')]"
+          },
+          "windowsVmSku": {
+            "value": "[parameters('windowsVmSku')]"
+          },
+          "windowsVmVersion": {
+            "value": "[parameters('windowsVmVersion')]"
+          },
+          "windowsVmCreateOption": {
+            "value": "[parameters('windowsVmCreateOption')]"
+          },
+          "windowsVmStorageAccountType": {
+            "value": "[parameters('windowsVmStorageAccountType')]"
           }
         },
         "template": {
@@ -210,7 +301,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "1598061819862701326"
+              "templateHash": "9206703012100649755"
             }
           },
           "parameters": {
@@ -251,6 +342,15 @@
             "bastionHostIPConfigurationName": {
               "type": "string"
             },
+            "linuxNetworkInterfaceName": {
+              "type": "string"
+            },
+            "linuxNetworkInterfaceIpConfigurationName": {
+              "type": "string"
+            },
+            "linuxNetworkInterfacePrivateIPAddressAllocationMethod": {
+              "type": "string"
+            },
             "linuxVmName": {
               "type": "string"
             },
@@ -286,15 +386,47 @@
               ]
             },
             "linuxVmAdminPasswordOrKey": {
-              "type": "secureString"
+              "type": "secureString",
+              "minLength": 14
             },
-            "linuxVmNetworkInterfaceName": {
+            "windowsNetworkInterfaceName": {
               "type": "string"
             },
-            "linuxNetworkInterfaceIpConfigurationName": {
+            "windowsNetworkInterfaceIpConfigurationName": {
               "type": "string"
             },
-            "linuxNetworkInterfacePrivateIPAddressAllocationMethod": {
+            "windowsNetworkInterfacePrivateIPAddressAllocationMethod": {
+              "type": "string"
+            },
+            "windowsVmName": {
+              "type": "string"
+            },
+            "windowsVmSize": {
+              "type": "string"
+            },
+            "windowsVmAdminUsername": {
+              "type": "string"
+            },
+            "windowsVmAdminPassword": {
+              "type": "secureString",
+              "minLength": 14
+            },
+            "windowsVmPublisher": {
+              "type": "string"
+            },
+            "windowsVmOffer": {
+              "type": "string"
+            },
+            "windowsVmSku": {
+              "type": "string"
+            },
+            "windowsVmVersion": {
+              "type": "string"
+            },
+            "windowsVmCreateOption": {
+              "type": "string"
+            },
+            "windowsVmStorageAccountType": {
               "type": "string"
             }
           },
@@ -452,7 +584,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "name": {
-                    "value": "[parameters('linuxVmNetworkInterfaceName')]"
+                    "value": "[parameters('linuxNetworkInterfaceName')]"
                   },
                   "location": {
                     "value": "[parameters('location')]"
@@ -606,7 +738,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.613.9944",
-                      "templateHash": "3696027585532491981"
+                      "templateHash": "9484732926763055555"
                     }
                   },
                   "parameters": {
@@ -655,7 +787,8 @@
                       ]
                     },
                     "adminPasswordOrKey": {
-                      "type": "secureString"
+                      "type": "secureString",
+                      "minLength": 14
                     }
                   },
                   "functions": [],
@@ -673,11 +806,6 @@
                     }
                   },
                   "resources": [
-                    {
-                      "type": "Microsoft.Network/networkInterfaces",
-                      "apiVersion": "2021-02-01",
-                      "name": "[parameters('networkInterfaceName')]"
-                    },
                     {
                       "type": "Microsoft.Compute/virtualMachines",
                       "apiVersion": "2020-06-01",
@@ -715,10 +843,7 @@
                           "adminPassword": "[parameters('adminPasswordOrKey')]",
                           "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), null(), variables('linuxConfiguration'))]"
                         }
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceName'))]"
-                      ]
+                      }
                     }
                   ],
                   "outputs": {
@@ -735,6 +860,261 @@
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', 'remoteAccess-linuxNetworkInterface')]"
+              ]
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2019-10-01",
+              "name": "remoteAccess-windowsNetworkInterface",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[parameters('windowsNetworkInterfaceName')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "tags": {
+                    "value": "[parameters('tags')]"
+                  },
+                  "ipConfigurationName": {
+                    "value": "[parameters('windowsNetworkInterfaceIpConfigurationName')]"
+                  },
+                  "networkSecurityGroupId": {
+                    "value": "[parameters('hubNetworkSecurityGroupResourceId')]"
+                  },
+                  "privateIPAddressAllocationMethod": {
+                    "value": "[parameters('windowsNetworkInterfacePrivateIPAddressAllocationMethod')]"
+                  },
+                  "subnetId": {
+                    "value": "[parameters('hubSubnetResourceId')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.4.613.9944",
+                      "templateHash": "14459425343428091407"
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "tags": {
+                      "type": "object",
+                      "defaultValue": {}
+                    },
+                    "ipConfigurationName": {
+                      "type": "string"
+                    },
+                    "subnetId": {
+                      "type": "string"
+                    },
+                    "networkSecurityGroupId": {
+                      "type": "string"
+                    },
+                    "privateIPAddressAllocationMethod": {
+                      "type": "string"
+                    }
+                  },
+                  "functions": [],
+                  "resources": [
+                    {
+                      "type": "Microsoft.Network/networkInterfaces",
+                      "apiVersion": "2021-02-01",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "ipConfigurations": [
+                          {
+                            "name": "[parameters('ipConfigurationName')]",
+                            "properties": {
+                              "subnet": {
+                                "id": "[parameters('subnetId')]"
+                              },
+                              "privateIPAllocationMethod": "[parameters('privateIPAddressAllocationMethod')]"
+                            }
+                          }
+                        ],
+                        "networkSecurityGroup": {
+                          "id": "[parameters('networkSecurityGroupId')]"
+                        }
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "id": {
+                      "type": "string",
+                      "value": "[resourceId('Microsoft.Network/networkInterfaces', parameters('name'))]"
+                    },
+                    "name": {
+                      "type": "string",
+                      "value": "[parameters('name')]"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2019-10-01",
+              "name": "remoteAccess-windowsVirtualMachine",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[parameters('windowsVmName')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "tags": {
+                    "value": "[parameters('tags')]"
+                  },
+                  "size": {
+                    "value": "[parameters('windowsVmSize')]"
+                  },
+                  "adminUsername": {
+                    "value": "[parameters('windowsVmAdminUsername')]"
+                  },
+                  "adminPassword": {
+                    "value": "[parameters('windowsVmAdminPassword')]"
+                  },
+                  "publisher": {
+                    "value": "[parameters('windowsVmPublisher')]"
+                  },
+                  "offer": {
+                    "value": "[parameters('windowsVmOffer')]"
+                  },
+                  "sku": {
+                    "value": "[parameters('windowsVmSku')]"
+                  },
+                  "version": {
+                    "value": "[parameters('windowsVmVersion')]"
+                  },
+                  "createOption": {
+                    "value": "[parameters('windowsVmCreateOption')]"
+                  },
+                  "storageAccountType": {
+                    "value": "[parameters('windowsVmStorageAccountType')]"
+                  },
+                  "networkInterfaceName": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'remoteAccess-windowsNetworkInterface'), '2019-10-01').outputs.name.value]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.4.613.9944",
+                      "templateHash": "13028397952765670280"
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "tags": {
+                      "type": "object",
+                      "defaultValue": {}
+                    },
+                    "networkInterfaceName": {
+                      "type": "string"
+                    },
+                    "size": {
+                      "type": "string"
+                    },
+                    "adminUsername": {
+                      "type": "string"
+                    },
+                    "adminPassword": {
+                      "type": "secureString",
+                      "minLength": 14
+                    },
+                    "publisher": {
+                      "type": "string"
+                    },
+                    "offer": {
+                      "type": "string"
+                    },
+                    "sku": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "createOption": {
+                      "type": "string"
+                    },
+                    "storageAccountType": {
+                      "type": "string"
+                    }
+                  },
+                  "functions": [],
+                  "resources": [
+                    {
+                      "type": "Microsoft.Compute/virtualMachines",
+                      "apiVersion": "2021-04-01",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "hardwareProfile": {
+                          "vmSize": "[parameters('size')]"
+                        },
+                        "osProfile": {
+                          "computerName": "[take(parameters('name'), 15)]",
+                          "adminUsername": "[parameters('adminUsername')]",
+                          "adminPassword": "[parameters('adminPassword')]"
+                        },
+                        "storageProfile": {
+                          "imageReference": {
+                            "publisher": "[parameters('publisher')]",
+                            "offer": "[parameters('offer')]",
+                            "sku": "[parameters('sku')]",
+                            "version": "[parameters('version')]"
+                          },
+                          "osDisk": {
+                            "createOption": "[parameters('createOption')]",
+                            "managedDisk": {
+                              "storageAccountType": "[parameters('storageAccountType')]"
+                            }
+                          }
+                        },
+                        "networkProfile": {
+                          "networkInterfaces": [
+                            {
+                              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceName'))]"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'remoteAccess-windowsNetworkInterface')]"
               ]
             }
           ]

--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -355,6 +355,7 @@ module remoteAccess './modules/remoteAccess.bicep' = if(deployRemoteAccess) {
     bastionHostPublicIPAddressAvailabilityZones: bastionHostPublicIPAddressAvailabilityZones
     bastionHostIPConfigurationName: bastionHostIPConfigurationName
 
+    linuxNetworkInterfaceName: linuxNetworkInterfaceName
     linuxNetworkInterfaceIpConfigurationName: linuxNetworkInterfaceIpConfigurationName
     linuxNetworkInterfacePrivateIPAddressAllocationMethod: linuxNetworkInterfacePrivateIPAddressAllocationMethod
 
@@ -369,7 +370,21 @@ module remoteAccess './modules/remoteAccess.bicep' = if(deployRemoteAccess) {
     linuxVmAdminUsername: linuxVmAdminUsername
     linuxVmAuthenticationType: linuxVmAuthenticationType
     linuxVmAdminPasswordOrKey: linuxVmAdminPasswordOrKey
-    linuxVmNetworkInterfaceName: linuxVmNetworkInterfaceName
+
+    windowsNetworkInterfaceName: windowsNetworkInterfaceName
+    windowsNetworkInterfaceIpConfigurationName: windowsNetworkInterfaceIpConfigurationName
+    windowsNetworkInterfacePrivateIPAddressAllocationMethod: windowsNetworkInterfacePrivateIPAddressAllocationMethod
+
+    windowsVmName: windowsVmName
+    windowsVmSize: windowsVmSize
+    windowsVmAdminUsername: windowsVmAdminUsername
+    windowsVmAdminPassword: windowsVmAdminPassword
+    windowsVmPublisher: windowsVmPublisher
+    windowsVmOffer: windowsVmOffer
+    windowsVmSku: windowsVmSku
+    windowsVmVersion: windowsVmVersion
+    windowsVmCreateOption: windowsVmCreateOption
+    windowsVmStorageAccountType: windowsVmStorageAccountType
   }
 }
 
@@ -490,6 +505,9 @@ param bastionHostPublicIPAddressSkuName string = 'Standard'
 param bastionHostPublicIPAddressAllocationMethod string = 'Static'
 param bastionHostPublicIPAddressAvailabilityZones array = []
 param bastionHostIPConfigurationName string = 'bastionHostIPConfiguration'
+param linuxNetworkInterfaceName string = 'linuxVmNetworkInterface'
+param linuxNetworkInterfaceIpConfigurationName string = 'linuxVmIpConfiguration'
+param linuxNetworkInterfacePrivateIPAddressAllocationMethod string = 'Dynamic'
 param linuxVmName string = 'linuxVirtualMachine'
 param linuxVmSize string = 'Standard_B2s'
 param linuxVmOsDiskCreateOption string = 'FromImage'
@@ -507,9 +525,21 @@ param linuxVmAuthenticationType string = 'password'
 @secure()
 @minLength(14)
 param linuxVmAdminPasswordOrKey string = deployRemoteAccess ? '' : newGuid()
-param linuxVmNetworkInterfaceName string = 'linuxVmNetworkInterface'
-param linuxNetworkInterfaceIpConfigurationName string = 'linuxVmIpConfiguration'
-param linuxNetworkInterfacePrivateIPAddressAllocationMethod string = 'Dynamic'
+param windowsNetworkInterfaceName string = 'windowsVmNetworkInterface'
+param windowsNetworkInterfaceIpConfigurationName string = 'windowsVmIpConfiguration'
+param windowsNetworkInterfacePrivateIPAddressAllocationMethod string = 'Dynamic'
+param windowsVmName string = 'windowsVm'
+param windowsVmSize string = 'Standard_DS1_v2'
+param windowsVmAdminUsername string = 'azureuser'
+@secure()
+@minLength(14)
+param windowsVmAdminPassword string = deployRemoteAccess ? '' : newGuid()
+param windowsVmPublisher string = 'MicrosoftWindowsServer'
+param windowsVmOffer string = 'WindowsServer'
+param windowsVmSku string = '2019-datacenter-gensecond'
+param windowsVmVersion string = 'latest'
+param windowsVmCreateOption string = 'FromImage'
+param windowsVmStorageAccountType string = 'StandardSSD_LRS'
 
 param tags object = {
   'resourcePrefix': resourcePrefix

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "3895776258968515169"
+      "templateHash": "11713630127386255235"
     }
   },
   "parameters": {
@@ -386,6 +386,18 @@
       "type": "string",
       "defaultValue": "bastionHostIPConfiguration"
     },
+    "linuxNetworkInterfaceName": {
+      "type": "string",
+      "defaultValue": "linuxVmNetworkInterface"
+    },
+    "linuxNetworkInterfaceIpConfigurationName": {
+      "type": "string",
+      "defaultValue": "linuxVmIpConfiguration"
+    },
+    "linuxNetworkInterfacePrivateIPAddressAllocationMethod": {
+      "type": "string",
+      "defaultValue": "Dynamic"
+    },
     "linuxVmName": {
       "type": "string",
       "defaultValue": "linuxVirtualMachine"
@@ -435,17 +447,58 @@
       "defaultValue": "[if(parameters('deployRemoteAccess'), '', newGuid())]",
       "minLength": 14
     },
-    "linuxVmNetworkInterfaceName": {
+    "windowsNetworkInterfaceName": {
       "type": "string",
-      "defaultValue": "linuxVmNetworkInterface"
+      "defaultValue": "windowsVmNetworkInterface"
     },
-    "linuxNetworkInterfaceIpConfigurationName": {
+    "windowsNetworkInterfaceIpConfigurationName": {
       "type": "string",
-      "defaultValue": "linuxVmIpConfiguration"
+      "defaultValue": "windowsVmIpConfiguration"
     },
-    "linuxNetworkInterfacePrivateIPAddressAllocationMethod": {
+    "windowsNetworkInterfacePrivateIPAddressAllocationMethod": {
       "type": "string",
       "defaultValue": "Dynamic"
+    },
+    "windowsVmName": {
+      "type": "string",
+      "defaultValue": "windowsVm"
+    },
+    "windowsVmSize": {
+      "type": "string",
+      "defaultValue": "Standard_DS1_v2"
+    },
+    "windowsVmAdminUsername": {
+      "type": "string",
+      "defaultValue": "azureuser"
+    },
+    "windowsVmAdminPassword": {
+      "type": "secureString",
+      "defaultValue": "[if(parameters('deployRemoteAccess'), '', newGuid())]",
+      "minLength": 14
+    },
+    "windowsVmPublisher": {
+      "type": "string",
+      "defaultValue": "MicrosoftWindowsServer"
+    },
+    "windowsVmOffer": {
+      "type": "string",
+      "defaultValue": "WindowsServer"
+    },
+    "windowsVmSku": {
+      "type": "string",
+      "defaultValue": "2019-datacenter-gensecond"
+    },
+    "windowsVmVersion": {
+      "type": "string",
+      "defaultValue": "latest"
+    },
+    "windowsVmCreateOption": {
+      "type": "string",
+      "defaultValue": "FromImage"
+    },
+    "windowsVmStorageAccountType": {
+      "type": "string",
+      "defaultValue": "StandardSSD_LRS"
     },
     "tags": {
       "type": "object",
@@ -5132,6 +5185,9 @@
           "bastionHostIPConfigurationName": {
             "value": "[parameters('bastionHostIPConfigurationName')]"
           },
+          "linuxNetworkInterfaceName": {
+            "value": "[parameters('linuxNetworkInterfaceName')]"
+          },
           "linuxNetworkInterfaceIpConfigurationName": {
             "value": "[parameters('linuxNetworkInterfaceIpConfigurationName')]"
           },
@@ -5171,8 +5227,44 @@
           "linuxVmAdminPasswordOrKey": {
             "value": "[parameters('linuxVmAdminPasswordOrKey')]"
           },
-          "linuxVmNetworkInterfaceName": {
-            "value": "[parameters('linuxVmNetworkInterfaceName')]"
+          "windowsNetworkInterfaceName": {
+            "value": "[parameters('windowsNetworkInterfaceName')]"
+          },
+          "windowsNetworkInterfaceIpConfigurationName": {
+            "value": "[parameters('windowsNetworkInterfaceIpConfigurationName')]"
+          },
+          "windowsNetworkInterfacePrivateIPAddressAllocationMethod": {
+            "value": "[parameters('windowsNetworkInterfacePrivateIPAddressAllocationMethod')]"
+          },
+          "windowsVmName": {
+            "value": "[parameters('windowsVmName')]"
+          },
+          "windowsVmSize": {
+            "value": "[parameters('windowsVmSize')]"
+          },
+          "windowsVmAdminUsername": {
+            "value": "[parameters('windowsVmAdminUsername')]"
+          },
+          "windowsVmAdminPassword": {
+            "value": "[parameters('windowsVmAdminPassword')]"
+          },
+          "windowsVmPublisher": {
+            "value": "[parameters('windowsVmPublisher')]"
+          },
+          "windowsVmOffer": {
+            "value": "[parameters('windowsVmOffer')]"
+          },
+          "windowsVmSku": {
+            "value": "[parameters('windowsVmSku')]"
+          },
+          "windowsVmVersion": {
+            "value": "[parameters('windowsVmVersion')]"
+          },
+          "windowsVmCreateOption": {
+            "value": "[parameters('windowsVmCreateOption')]"
+          },
+          "windowsVmStorageAccountType": {
+            "value": "[parameters('windowsVmStorageAccountType')]"
           }
         },
         "template": {
@@ -5182,7 +5274,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "15146003623826486692"
+              "templateHash": "9206703012100649755"
             }
           },
           "parameters": {
@@ -5223,6 +5315,15 @@
             "bastionHostIPConfigurationName": {
               "type": "string"
             },
+            "linuxNetworkInterfaceName": {
+              "type": "string"
+            },
+            "linuxNetworkInterfaceIpConfigurationName": {
+              "type": "string"
+            },
+            "linuxNetworkInterfacePrivateIPAddressAllocationMethod": {
+              "type": "string"
+            },
             "linuxVmName": {
               "type": "string"
             },
@@ -5258,15 +5359,47 @@
               ]
             },
             "linuxVmAdminPasswordOrKey": {
-              "type": "secureString"
+              "type": "secureString",
+              "minLength": 14
             },
-            "linuxVmNetworkInterfaceName": {
+            "windowsNetworkInterfaceName": {
               "type": "string"
             },
-            "linuxNetworkInterfaceIpConfigurationName": {
+            "windowsNetworkInterfaceIpConfigurationName": {
               "type": "string"
             },
-            "linuxNetworkInterfacePrivateIPAddressAllocationMethod": {
+            "windowsNetworkInterfacePrivateIPAddressAllocationMethod": {
+              "type": "string"
+            },
+            "windowsVmName": {
+              "type": "string"
+            },
+            "windowsVmSize": {
+              "type": "string"
+            },
+            "windowsVmAdminUsername": {
+              "type": "string"
+            },
+            "windowsVmAdminPassword": {
+              "type": "secureString",
+              "minLength": 14
+            },
+            "windowsVmPublisher": {
+              "type": "string"
+            },
+            "windowsVmOffer": {
+              "type": "string"
+            },
+            "windowsVmSku": {
+              "type": "string"
+            },
+            "windowsVmVersion": {
+              "type": "string"
+            },
+            "windowsVmCreateOption": {
+              "type": "string"
+            },
+            "windowsVmStorageAccountType": {
               "type": "string"
             }
           },
@@ -5424,7 +5557,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "name": {
-                    "value": "[parameters('linuxVmNetworkInterfaceName')]"
+                    "value": "[parameters('linuxNetworkInterfaceName')]"
                   },
                   "location": {
                     "value": "[parameters('location')]"
@@ -5578,7 +5711,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.613.9944",
-                      "templateHash": "16223346466626986050"
+                      "templateHash": "9484732926763055555"
                     }
                   },
                   "parameters": {
@@ -5627,7 +5760,8 @@
                       ]
                     },
                     "adminPasswordOrKey": {
-                      "type": "secureString"
+                      "type": "secureString",
+                      "minLength": 14
                     }
                   },
                   "functions": [],
@@ -5699,6 +5833,261 @@
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', 'remoteAccess-linuxNetworkInterface')]"
+              ]
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2019-10-01",
+              "name": "remoteAccess-windowsNetworkInterface",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[parameters('windowsNetworkInterfaceName')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "tags": {
+                    "value": "[parameters('tags')]"
+                  },
+                  "ipConfigurationName": {
+                    "value": "[parameters('windowsNetworkInterfaceIpConfigurationName')]"
+                  },
+                  "networkSecurityGroupId": {
+                    "value": "[parameters('hubNetworkSecurityGroupResourceId')]"
+                  },
+                  "privateIPAddressAllocationMethod": {
+                    "value": "[parameters('windowsNetworkInterfacePrivateIPAddressAllocationMethod')]"
+                  },
+                  "subnetId": {
+                    "value": "[parameters('hubSubnetResourceId')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.4.613.9944",
+                      "templateHash": "14459425343428091407"
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "tags": {
+                      "type": "object",
+                      "defaultValue": {}
+                    },
+                    "ipConfigurationName": {
+                      "type": "string"
+                    },
+                    "subnetId": {
+                      "type": "string"
+                    },
+                    "networkSecurityGroupId": {
+                      "type": "string"
+                    },
+                    "privateIPAddressAllocationMethod": {
+                      "type": "string"
+                    }
+                  },
+                  "functions": [],
+                  "resources": [
+                    {
+                      "type": "Microsoft.Network/networkInterfaces",
+                      "apiVersion": "2021-02-01",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "ipConfigurations": [
+                          {
+                            "name": "[parameters('ipConfigurationName')]",
+                            "properties": {
+                              "subnet": {
+                                "id": "[parameters('subnetId')]"
+                              },
+                              "privateIPAllocationMethod": "[parameters('privateIPAddressAllocationMethod')]"
+                            }
+                          }
+                        ],
+                        "networkSecurityGroup": {
+                          "id": "[parameters('networkSecurityGroupId')]"
+                        }
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "id": {
+                      "type": "string",
+                      "value": "[resourceId('Microsoft.Network/networkInterfaces', parameters('name'))]"
+                    },
+                    "name": {
+                      "type": "string",
+                      "value": "[parameters('name')]"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2019-10-01",
+              "name": "remoteAccess-windowsVirtualMachine",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[parameters('windowsVmName')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "tags": {
+                    "value": "[parameters('tags')]"
+                  },
+                  "size": {
+                    "value": "[parameters('windowsVmSize')]"
+                  },
+                  "adminUsername": {
+                    "value": "[parameters('windowsVmAdminUsername')]"
+                  },
+                  "adminPassword": {
+                    "value": "[parameters('windowsVmAdminPassword')]"
+                  },
+                  "publisher": {
+                    "value": "[parameters('windowsVmPublisher')]"
+                  },
+                  "offer": {
+                    "value": "[parameters('windowsVmOffer')]"
+                  },
+                  "sku": {
+                    "value": "[parameters('windowsVmSku')]"
+                  },
+                  "version": {
+                    "value": "[parameters('windowsVmVersion')]"
+                  },
+                  "createOption": {
+                    "value": "[parameters('windowsVmCreateOption')]"
+                  },
+                  "storageAccountType": {
+                    "value": "[parameters('windowsVmStorageAccountType')]"
+                  },
+                  "networkInterfaceName": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'remoteAccess-windowsNetworkInterface'), '2019-10-01').outputs.name.value]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.4.613.9944",
+                      "templateHash": "13028397952765670280"
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "tags": {
+                      "type": "object",
+                      "defaultValue": {}
+                    },
+                    "networkInterfaceName": {
+                      "type": "string"
+                    },
+                    "size": {
+                      "type": "string"
+                    },
+                    "adminUsername": {
+                      "type": "string"
+                    },
+                    "adminPassword": {
+                      "type": "secureString",
+                      "minLength": 14
+                    },
+                    "publisher": {
+                      "type": "string"
+                    },
+                    "offer": {
+                      "type": "string"
+                    },
+                    "sku": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "createOption": {
+                      "type": "string"
+                    },
+                    "storageAccountType": {
+                      "type": "string"
+                    }
+                  },
+                  "functions": [],
+                  "resources": [
+                    {
+                      "type": "Microsoft.Compute/virtualMachines",
+                      "apiVersion": "2021-04-01",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "hardwareProfile": {
+                          "vmSize": "[parameters('size')]"
+                        },
+                        "osProfile": {
+                          "computerName": "[take(parameters('name'), 15)]",
+                          "adminUsername": "[parameters('adminUsername')]",
+                          "adminPassword": "[parameters('adminPassword')]"
+                        },
+                        "storageProfile": {
+                          "imageReference": {
+                            "publisher": "[parameters('publisher')]",
+                            "offer": "[parameters('offer')]",
+                            "sku": "[parameters('sku')]",
+                            "version": "[parameters('version')]"
+                          },
+                          "osDisk": {
+                            "createOption": "[parameters('createOption')]",
+                            "managedDisk": {
+                              "storageAccountType": "[parameters('storageAccountType')]"
+                            }
+                          }
+                        },
+                        "networkProfile": {
+                          "networkInterfaces": [
+                            {
+                              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceName'))]"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'remoteAccess-windowsNetworkInterface')]"
               ]
             }
           ]

--- a/src/bicep/modules/linuxVirtualMachine.bicep
+++ b/src/bicep/modules/linuxVirtualMachine.bicep
@@ -11,7 +11,6 @@ param vmImagePublisher string
 param vmImageOffer string
 param vmImageSku string
 param vmImageVersion string
-
 param adminUsername string
 @allowed([
   'sshPublicKey'
@@ -19,6 +18,7 @@ param adminUsername string
 ])
 param authenticationType string
 @secure()
+@minLength(14)
 param adminPasswordOrKey string
 
 var linuxConfiguration = {

--- a/src/bicep/modules/remoteAccess.bicep
+++ b/src/bicep/modules/remoteAccess.bicep
@@ -13,6 +13,10 @@ param bastionHostPublicIPAddressAllocationMethod string
 param bastionHostPublicIPAddressAvailabilityZones array
 param bastionHostIPConfigurationName string
 
+param linuxNetworkInterfaceName string
+param linuxNetworkInterfaceIpConfigurationName string
+param linuxNetworkInterfacePrivateIPAddressAllocationMethod string
+
 param linuxVmName string
 param linuxVmSize string
 param linuxVmOsDiskCreateOption string
@@ -22,18 +26,31 @@ param linuxVmImageOffer string
 param linuxVmImageSku string
 param linuxVmImageVersion string
 param linuxVmAdminUsername string
-
 @allowed([
   'sshPublicKey'
   'password'
 ])
 param linuxVmAuthenticationType string
 @secure()
+@minLength(14)
 param linuxVmAdminPasswordOrKey string
 
-param linuxVmNetworkInterfaceName string
-param linuxNetworkInterfaceIpConfigurationName string
-param linuxNetworkInterfacePrivateIPAddressAllocationMethod string
+param windowsNetworkInterfaceName string
+param windowsNetworkInterfaceIpConfigurationName string
+param windowsNetworkInterfacePrivateIPAddressAllocationMethod string
+
+param windowsVmName string
+param windowsVmSize string
+param windowsVmAdminUsername string
+@secure()
+@minLength(14)
+param windowsVmAdminPassword string
+param windowsVmPublisher string
+param windowsVmOffer string
+param windowsVmSku string
+param windowsVmVersion string
+param windowsVmCreateOption string
+param windowsVmStorageAccountType string
 
 resource hubVirtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' existing = {
   name: hubVirtualNetworkName
@@ -60,7 +77,7 @@ module bastionHost './bastionHost.bicep' = {
 module linuxNetworkInterface './networkInterface.bicep' = {
   name: 'remoteAccess-linuxNetworkInterface'
   params: {
-    name: linuxVmNetworkInterfaceName
+    name: linuxNetworkInterfaceName
     location: location
     tags: tags
     
@@ -79,19 +96,49 @@ module linuxVirtualMachine './linuxVirtualMachine.bicep' = {
     tags: tags
 
     vmSize: linuxVmSize
-
     osDiskCreateOption: linuxVmOsDiskCreateOption
     osDiskType: linuxVmOsDiskType
-
     vmImagePublisher: linuxVmImagePublisher
     vmImageOffer: linuxVmImageOffer
     vmImageSku: linuxVmImageSku
     vmImageVersion: linuxVmImageVersion
-
     adminUsername: linuxVmAdminUsername
     authenticationType: linuxVmAuthenticationType
     adminPasswordOrKey: linuxVmAdminPasswordOrKey
-
     networkInterfaceName: linuxNetworkInterface.outputs.name
+  }
+}
+
+module windowsNetworkInterface './networkInterface.bicep' = {
+  name: 'remoteAccess-windowsNetworkInterface'
+  params: {
+    name: windowsNetworkInterfaceName
+    location: location
+    tags: tags
+    
+    ipConfigurationName: windowsNetworkInterfaceIpConfigurationName
+    networkSecurityGroupId: hubNetworkSecurityGroupResourceId
+    privateIPAddressAllocationMethod: windowsNetworkInterfacePrivateIPAddressAllocationMethod
+    subnetId: hubSubnetResourceId
+  }
+}
+
+module windowsVirtualMachine './windowsVirtualMachine.bicep' = {
+  name: 'remoteAccess-windowsVirtualMachine'
+  params: {
+    name: windowsVmName
+    location: location
+    tags: tags
+
+    size: windowsVmSize
+    adminUsername: windowsVmAdminUsername
+    adminPassword: windowsVmAdminPassword
+    publisher: windowsVmPublisher
+    offer: windowsVmOffer
+    sku: windowsVmSku
+    version: windowsVmVersion
+    createOption: windowsVmCreateOption
+    storageAccountType: windowsVmStorageAccountType
+    networkInterfaceName: windowsNetworkInterface.outputs.name
   }
 }

--- a/src/bicep/modules/windowsVirtualMachine.bicep
+++ b/src/bicep/modules/windowsVirtualMachine.bicep
@@ -1,0 +1,59 @@
+param name string
+param location string
+param tags object = {}
+
+param networkInterfaceName string
+
+param size string
+param adminUsername string
+@secure()
+@minLength(14)
+param adminPassword string
+param publisher string
+param offer string
+param sku string
+param version string
+param createOption string
+param storageAccountType string
+
+resource networkInterface 'Microsoft.Network/networkInterfaces@2021-02-01' existing = {
+  name: networkInterfaceName
+}
+
+resource windowsVirtualMachine 'Microsoft.Compute/virtualMachines@2021-04-01' = {
+  name: name
+  location: location
+  tags: tags
+
+  properties: {
+    hardwareProfile: {
+      vmSize: size 
+    }
+    osProfile: {
+      computerName: take(name, 15)
+      adminUsername: adminUsername
+      adminPassword: adminPassword
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: publisher
+        offer: offer
+        sku: sku
+        version: version 
+      }
+      osDisk: {
+        createOption: createOption
+        managedDisk: {
+          storageAccountType: storageAccountType          
+        }
+      }
+    }
+    networkProfile: {
+      networkInterfaces: [
+        { 
+          id: networkInterface.id
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Description

This change introduces a Windows Virtual Machine into the `remoteAccess` module, giving a user a remote desktop interface inside the network by specifying `deployRemoteAccess=true` and a value for `linuxVmAdminPasswordOrKey` and `windowsVmAdminPassword` at deployment time.

To demo this (it's easiest to use the .devcontainer to generate a password with `openssl`) try:

```plaintext
my_password=$(openssl rand -base64 14)

az deployment sub create \
  --name "myRemoteAccessDeployment" \
  --location "eastus" \
  --template-file "src/bicep/mlz.bicep" \
  --parameters deployRemoteAccess="true" \
  --parameters linuxVmAdminPasswordOrKey="$my_password" \
  --parameters windowsVmAdminPassword="$my_password"
```

If a user attempts to set `deployRemoteAccess=true` but forgets to supply a password like this:

```plaintext
az deployment sub create \
  --name "myInvalidRemoteAccessDeployment" \
  --location "eastus" 
  --template-file "src/bicep/mlz.bicep" \
  --parameters deployRemoteAccess="true"
```

template validation will helpfully fail:
```json
{
  "error": {
    "code": "InvalidTemplate",
    "message": "Deployment template validation failed: 'The provided value for the template parameter 'windowsVmAdminPassword' at line '311' and column '21' is not valid. Length of the value should be greater than or equal to '14'. Please see https://aka.ms/arm-template/#parameters for usage details.'."
  }
}
```

## Issue reference

The issue this PR will close #343 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
~~[ ] BASH scripts have been validated using `shellcheck`~~
* [x] All tests pass (manual and automated)
* [x] The documentation is updated to cover any new or changed features
* [x] Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)
* [x] Relevant issues are linked to this PR
