### PR TITLE
update Terraform CI validation and CI trigger

### DIFF
--- a/.github/workflows/validate-terraform.yml
+++ b/.github/workflows/validate-terraform.yml
@@ -2,7 +2,11 @@
 # Licensed under the MIT License.
 
 name: validate-terraform
-on: [pull_request, workflow_dispatch]
+on: 
+  pull_request:
+    paths: 
+    - '**.tf'
+  workflow_dispatch:
 jobs:
   validate-terraform:
     runs-on: ubuntu-latest
@@ -18,4 +22,9 @@ jobs:
     - shell: bash
       name: validate and lint terraform
       run: |
-        src/build/validate_tf.sh
+        src/build/validate_tf.sh src/terraform/mlz src/terraform/tier3
+    - shell: bash
+      name: check terraform formatting
+      run: |
+        src/build/check_tf_format.sh src/terraform
+

--- a/.github/workflows/validate-terraform.yml
+++ b/.github/workflows/validate-terraform.yml
@@ -5,7 +5,7 @@ name: validate-terraform
 on: 
   pull_request:
     paths: 
-    - '**.tf'
+    - 'src/terraform'
   workflow_dispatch:
 jobs:
   validate-terraform:

--- a/.github/workflows/validate-terraform.yml
+++ b/.github/workflows/validate-terraform.yml
@@ -5,7 +5,7 @@ name: validate-terraform
 on: 
   pull_request:
     paths: 
-    - 'src/terraform'
+    - 'src/terraform/**'
   workflow_dispatch:
 jobs:
   validate-terraform:

--- a/.github/workflows/validate-terraform.yml
+++ b/.github/workflows/validate-terraform.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.13.4
+        terraform_version: 1.0.3
     - shell: bash
       name: check tooling versions
       run: |
@@ -27,4 +27,3 @@ jobs:
       name: check terraform formatting
       run: |
         src/build/check_tf_format.sh src/terraform
-

--- a/src/build/check_tf_format.sh
+++ b/src/build/check_tf_format.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Check Terraform formatting for 1:M directories, exiting if any errors are produced
+
+program_log () {
+  echo "${0}: ${1}"
+}
+
+error_log () {
+  echo "Error: ${1}"
+}
+
+# Check for Terraform
+if ! command -v terraform &> /dev/null; then
+    error_log "Terraform could not be found. This script requires the Terraform CLI."
+    echo "See https://learn.hashicorp.com/tutorials/terraform/install-cli for installation instructions."
+    exit 1
+fi
+
+format_tf() {
+  local tf_dir=$1
+  cd "$tf_dir" || exit 1
+  program_log "checking formatting at $tf_dir..."
+  if terraform fmt -check -recursive >> /dev/null;
+  then
+    program_log "successful check with 'terraform fmt -check -recursive ${tf_dir}'"
+  else
+    linting_results=$(terraform fmt -check -recursive)
+    for j in $linting_results
+    do
+      error_log "'${j}' is not formatted correctly. Format with the command 'terraform fmt ${j}'"
+    done
+    program_log "run 'terraform fmt -recursive' to format all Terraform components in a directory"
+    exit 1;
+  fi
+}
+
+working_dir=$(pwd)
+
+for arg in "$@"
+do
+  cd "$working_dir" || exit 1
+  format_tf "$(realpath "$arg")"
+done
+
+program_log "done!"

--- a/src/build/validate_tf.sh
+++ b/src/build/validate_tf.sh
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Validates and lints terraform, exiting if any errors are produced
+# Validates and lints Terraform for 1:M directories, exiting if any errors are produced
 
 program_log () {
   echo "${0}: ${1}"
@@ -20,38 +20,20 @@ if ! command -v terraform &> /dev/null; then
     exit 1
 fi
 
-full_path=$(realpath "${0}")
-repo_path=$(dirname "$(dirname "${full_path}")")
-core_path="${repo_path}/core"
+validate_tf() {
+  local tf_dir=$1
+  cd "$tf_dir" || exit 1
+  program_log "validating at $tf_dir..."
+  terraform init -backend=false >> /dev/null || exit 1
+  terraform validate >> /dev/null || exit 1
+}
 
-if [ -d "$core_path" ];
-then
-  # Validate all .tf and their dependencies in core_path
-  program_log "Validating Terraform..."
-  cd "${core_path}" || exit
-  for i in $(find . -name "*.tf" -printf "%h\n" | sort --unique)
-  do
-    cd "${i}" || exit
-    echo "validating ${i}..."
-    terraform init -backend=false >> /dev/null || exit 1
-    terraform validate >> /dev/null || exit 1
-    cd "${core_path}" || exit
-  done
-  program_log "Terraform validated successfully!"
+working_dir=$(pwd)
 
-  # Check formatting in all .tf files in repo
-  program_log "Linting Terraform..."
-  cd "${repo_path}" || exit
-  if terraform fmt -check -recursive >> /dev/null;
-  then
-    program_log "Terraform linted successfully!"
-  else
-    linting_results=$(terraform fmt -check -recursive)
-    for j in $linting_results
-    do
-      error_log "please format '${j}' with the command 'terraform fmt'"
-    done
-    program_log "alternatively, you can run 'terraform fmt -recursive' to format all *.tf in a directory"
-    exit 1;
-  fi
-fi
+for arg in "$@"
+do
+  cd "$working_dir" || exit 1
+  validate_tf "$(realpath "$arg")"
+done
+
+program_log "done!"

--- a/src/terraform/modules/firewall/variables.tf
+++ b/src/terraform/modules/firewall/variables.tf
@@ -78,5 +78,5 @@ variable "tags" {
 variable "disable_snat_ip_range" {
   description = "The address space to be used to ensure that SNAT is disabled."
   default     = ["0.0.0.0/0"]
-  type        = list
+  type        = list(any)
 }


### PR DESCRIPTION
# Description

This changes the terraform validation triggered on Pull Requests to only occur with modifications to things at `/src/terraform/**` and updates the validation and formatting checks to accept N number of directories.

## Issue reference

The issue this PR will close #407

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles or validates correctly
* [x] BASH scripts have been validated using `shellcheck`
* [x] All tests pass (manual and automated)
~~The documentation is updated to cover any new or changed features~~
~~Markdown files have been linted using the recommended linter. (See `.vscode/extensions.json`.)~~
* [x] Relevant issues are linked to this PR
