### PR TITLE
added firewalls policies for AzureCloud and MSFT Login

### DIFF
--- a/src/bicep/modules/firewall.bicep
+++ b/src/bicep/modules/firewall.bicep
@@ -27,11 +27,101 @@ resource firewallPolicy 'Microsoft.Network/firewallPolicies@2021-02-01' = {
   }
 }
 
+resource firewallAppRuleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2021-02-01' = {
+  name: '${firewallPolicyName}/DefaultApplicationRuleCollectionGroup'
+  dependsOn: [
+    firewallPolicy
+  ]
+  properties: {
+    priority: 300
+    ruleCollections: [
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        action: {
+          type: 'Allow'
+        }
+        rules: [
+          {
+            ruleType: 'ApplicationRule'
+            name: 'msftauth'
+            protocols: [
+              {
+                protocolType: 'Https'
+                port: 443
+              }
+            ]
+            fqdnTags: []
+            webCategories: []
+            targetFqdns: [
+              'aadcdn.msftauth.net'
+              'aadcdn.msauth.net'
+            ]
+            targetUrls: []
+            terminateTLS: false
+            sourceAddresses: [
+              '*'
+            ]
+            destinationAddresses: []
+            sourceIpGroups: []
+          }
+        ]
+        name: 'AzureAuth'
+        priority: 110
+      }
+    ]
+  }
+}
+
+resource firewallNetworkRuleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2021-02-01' = {
+  name: '${firewallPolicyName}/DefaultNetworkRuleCollectionGroup'
+  dependsOn: [
+    firewallPolicy
+    firewallAppRuleCollectionGroup
+  ]
+  properties: {
+    priority: 200
+    ruleCollections: [
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        action: {
+          type: 'Allow'
+        }
+        rules: [
+          {
+            ruleType: 'NetworkRule'
+            name: 'AzureCloud'
+            ipProtocols: [
+              'Any'
+            ]
+            sourceAddresses: [
+              '*'
+            ]
+            sourceIpGroups: []
+            destinationAddresses: [
+              'AzureCloud'
+            ]
+            destinationIpGroups: []
+            destinationFqdns: []
+            destinationPorts: [
+              '*'
+            ]
+          }
+        ]
+        name: 'AllowAzureCloud'
+        priority: 100
+      }
+    ]
+  }
+}
+
 resource firewall 'Microsoft.Network/azureFirewalls@2021-02-01' = {
   name: name
   location: location
   tags: tags
-
+  dependsOn: [
+    firewallNetworkRuleCollectionGroup
+    firewallAppRuleCollectionGroup
+  ]
   properties: {
     ipConfigurations: [
       {


### PR DESCRIPTION
# Description

Azure firewall blocks all internet connectivity. VMs that require access to Azure Portal or Login fail. This PR adds 'AzureCloud' tag to firewall but also adds a work around for the tags missing FQDNs which participate in logging users in,

## Issue reference

The issue this PR will close: #410 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
