### PR TITLE
use the common diagnosticSettings provider version in central logging

### DIFF
--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "11625881222170284328"
+      "templateHash": "12997432989008627632"
     }
   },
   "parameters": {
@@ -5983,7 +5983,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "10501865331857601559"
+              "templateHash": "8810160807544413438"
             }
           },
           "parameters": {
@@ -5998,7 +5998,7 @@
           "resources": [
             {
               "type": "Microsoft.Insights/diagnosticSettings",
-              "apiVersion": "2021-05-01-preview",
+              "apiVersion": "2017-05-01-preview",
               "name": "[parameters('diagnosticSettingName')]",
               "properties": {
                 "workspaceId": "[parameters('logAnalyticsWorkspaceId')]",
@@ -6072,7 +6072,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "10501865331857601559"
+              "templateHash": "8810160807544413438"
             }
           },
           "parameters": {
@@ -6087,7 +6087,7 @@
           "resources": [
             {
               "type": "Microsoft.Insights/diagnosticSettings",
-              "apiVersion": "2021-05-01-preview",
+              "apiVersion": "2017-05-01-preview",
               "name": "[parameters('diagnosticSettingName')]",
               "properties": {
                 "workspaceId": "[parameters('logAnalyticsWorkspaceId')]",
@@ -6161,7 +6161,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "10501865331857601559"
+              "templateHash": "8810160807544413438"
             }
           },
           "parameters": {
@@ -6176,7 +6176,7 @@
           "resources": [
             {
               "type": "Microsoft.Insights/diagnosticSettings",
-              "apiVersion": "2021-05-01-preview",
+              "apiVersion": "2017-05-01-preview",
               "name": "[parameters('diagnosticSettingName')]",
               "properties": {
                 "workspaceId": "[parameters('logAnalyticsWorkspaceId')]",
@@ -6250,7 +6250,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "10501865331857601559"
+              "templateHash": "8810160807544413438"
             }
           },
           "parameters": {
@@ -6265,7 +6265,7 @@
           "resources": [
             {
               "type": "Microsoft.Insights/diagnosticSettings",
-              "apiVersion": "2021-05-01-preview",
+              "apiVersion": "2017-05-01-preview",
               "name": "[parameters('diagnosticSettingName')]",
               "properties": {
                 "workspaceId": "[parameters('logAnalyticsWorkspaceId')]",

--- a/src/bicep/modules/centralLogging.bicep
+++ b/src/bicep/modules/centralLogging.bicep
@@ -5,7 +5,7 @@ param diagnosticSettingName string
 param logAnalyticsWorkspaceId string
 
 //// Central activity logging to LAWS
-resource centralLoggingDiagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+resource centralLoggingDiagnosticSettings 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = {
   name: diagnosticSettingName
   properties: {
     workspaceId: logAnalyticsWorkspaceId


### PR DESCRIPTION
# Description

Updates the `centralLogging.bicep` module to use the provider version common across the solution and known to work in as many clouds as possible.

## Issue reference

The issue this PR will close: #452 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
