### PR TITLE
Update policy assignment to be opt-in for Terraform

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -63,12 +63,12 @@ az deployment group create \
 
 ### Deploying with Terraform
 
-By default, the Terraform implementaiton at `src/terraform/mlz/main.tf` will assign the NIST 800-53 policies. You can disable this by providing a `false` value to the `create_policy_assignment` variable:
+The Terraform implementaiton at `src/terraform/mlz/main.tf` supports assigning NIST 800-53 policies. You can enable this by providing a `true` value to the `create_policy_assignment` variable:
 
 ```plaintext
 cd src/terraform/mlz
 terraform init
-terraform apply -var="create_policy_assignment=false"
+terraform apply -var="create_policy_assignment=true"
 ```
 
 After the resources are deployed, you will need to go into go into each assignment and retrieve the managed identity and modify its role access to contributor scoped to the associated resource group. This is due to the initiative including modify and deploy policies that act on resources, like deploying the require policy guest configuration extensions to VMs.

--- a/src/terraform/README.md
+++ b/src/terraform/README.md
@@ -29,6 +29,8 @@ Read on to understand the [prerequisites](#Prerequisistes), how to get started, 
 
 Deploying to a Cloud other than Azure Commercial? This requires updating the `azurerm` provider block `environment` and `metadata_host` values. Checkout the [Deploying to Other Clouds](#Deploying-to-Other-Clouds) documentation.
 
+Looking to assign Azure Policy? This template supports assigning NIST 800-53 policies. See the [policies documentation](../../docs/policies.md) for more information.
+
 ### Login to Azure CLI
 
 1. Log in using the Azure CLI
@@ -161,6 +163,28 @@ Here's the docs on `terraform destroy`: <https://www.terraform.io/docs/cli/comma
     ```
 
 This command will attempt to remove all the resources that were created by `terraform apply` and could take up to 45 minutes.
+
+## Assigning Azure Policy
+
+This template supports assigning NIST 800-53 policies. See the [policies documentation](../../docs/policies.md) for more information.
+
+You can enable this by providing a `true` value to the `create_policy_assignment` variable.
+
+At `apply` time:
+
+```plaintext
+terraform apply -var="create_policy_assignment=true"
+```
+
+Or, by updating `src/terraform/mlz/variables.tf`:
+
+```terraform
+variable "create_policy_assignment" {
+  description = "Assign Policy to deployed resources?"
+  type        = bool
+  default     = true
+}
+```
 
 ## Deploying new Spoke Networks
 

--- a/src/terraform/mlz/variables.tf
+++ b/src/terraform/mlz/variables.tf
@@ -296,7 +296,7 @@ variable "jumpbox_linux_vm_version" {
 variable "create_policy_assignment" {
   description = "Assign Policy to deployed resources?"
   type        = bool
-  default     = true
+  default     = false
 }
 
 #################################


### PR DESCRIPTION
# Description

Updates the Terraform implementation so that policy assignment is a user opt-in instead of assigned by default. This matches the behavior in the Bicep implementation.

## Issue reference

The issue this PR will close: #454 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
