### PR TITLE
added missing privateDnsZoneId for storage in AMPLS fixing agent reporting

### DIFF
--- a/src/bicep/modules/privateLink.bicep
+++ b/src/bicep/modules/privateLink.bicep
@@ -96,6 +96,12 @@ resource dnsZonePrivateLinkEndpoint 'Microsoft.Network/privateEndpoints/privateD
           privateDnsZoneId: privatelink_agentsvc_azure_automation_net .id
         }
       }
+      {
+        name: 'storage'
+        properties: {
+          privateDnsZoneId: privatelink_blob_core_cloudapi_net.id
+        }
+      }
     ]
   }
   dependsOn: [


### PR DESCRIPTION
# Description

During testing a deployment Windows machine was found not reporting to Log Analytics. It was discovered it wasn't reaching the storage account used by Azure Monitor to store agent configurations and causing it to not report. The bug was a missing DNS zone entry in private link module for storage.

## Issue reference

The issue this PR will close: #455 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
