### PR TITLE
add diagnostics settings for firewall, public IP, and network security groups

### DIFF
--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -86,6 +86,8 @@ module hub './modules/hubNetwork.bicep' = {
 
     networkSecurityGroupName: hubNetworkSecurityGroupName
     networkSecurityGroupRules: hubNetworkSecurityGroupRules
+    networkSecurityGroupDiagnosticsLogs: hubNetworkSecurityGroupDiagnosticsLogs
+    networkSecurityGroupDiagnosticsMetrics: hubNetworkSecurityGroupDiagnosticsMetrics
 
     subnetName: hubSubnetName
     subnetAddressPrefix: hubSubnetAddressPrefix
@@ -95,6 +97,8 @@ module hub './modules/hubNetwork.bicep' = {
     firewallSkuTier: firewallSkuTier
     firewallPolicyName: firewallPolicyName
     firewallThreatIntelMode: firewallThreatIntelMode
+    firewallDiagnosticsLogs: firewallDiagnosticsLogs
+    firewallDiagnosticsMetrics: firewallDiagnosticsMetrics
     firewallClientIpConfigurationName: firewallClientIpConfigurationName
     firewallClientSubnetName: firewallClientSubnetName
     firewallClientSubnetAddressPrefix: firewallClientSubnetAddressPrefix
@@ -111,6 +115,9 @@ module hub './modules/hubNetwork.bicep' = {
     firewallManagementPublicIPAddressSkuName: firewallManagementPublicIPAddressSkuName
     firewallManagementPublicIpAllocationMethod: firewallManagementPublicIpAllocationMethod
     firewallManagementPublicIPAddressAvailabilityZones: firewallManagementPublicIPAddressAvailabilityZones
+
+    publicIPAddressDiagnosticsLogs: publicIPAddressDiagnosticsLogs
+    publicIPAddressDiagnosticsMetrics: publicIPAddressDiagnosticsMetrics
   }
 }
 
@@ -135,6 +142,8 @@ module identity './modules/spokeNetwork.bicep' = {
 
     networkSecurityGroupName: identityNetworkSecurityGroupName
     networkSecurityGroupRules: identityNetworkSecurityGroupRules
+    networkSecurityGroupDiagnosticsLogs: identityNetworkSecurityGroupDiagnosticsLogs
+    networkSecurityGroupDiagnosticsMetrics: identityNetworkSecurityGroupDiagnosticsMetrics
 
     subnetName: identitySubnetName
     subnetAddressPrefix: identitySubnetAddressPrefix
@@ -163,6 +172,8 @@ module operations './modules/spokeNetwork.bicep' = {
 
     networkSecurityGroupName: operationsNetworkSecurityGroupName
     networkSecurityGroupRules: operationsNetworkSecurityGroupRules
+    networkSecurityGroupDiagnosticsLogs: operationsNetworkSecurityGroupDiagnosticsLogs
+    networkSecurityGroupDiagnosticsMetrics: operationsNetworkSecurityGroupDiagnosticsMetrics
 
     subnetName: operationsSubnetName
     subnetAddressPrefix: operationsSubnetAddressPrefix
@@ -191,6 +202,8 @@ module sharedServices './modules/spokeNetwork.bicep' = {
 
     networkSecurityGroupName: sharedServicesNetworkSecurityGroupName
     networkSecurityGroupRules: sharedServicesNetworkSecurityGroupRules
+    networkSecurityGroupDiagnosticsLogs: sharedServicesNetworkSecurityGroupDiagnosticsLogs
+    networkSecurityGroupDiagnosticsMetrics: sharedServicesNetworkSecurityGroupDiagnosticsMetrics
 
     subnetName: sharedServicesSubnetName
     subnetAddressPrefix: sharedServicesSubnetAddressPrefix
@@ -466,16 +479,7 @@ param hubVirtualNetworkName string = 'hub-vnet'
 param hubSubnetName string = 'hub-subnet'
 param hubVirtualNetworkAddressPrefix string = '10.0.100.0/24'
 param hubSubnetAddressPrefix string = '10.0.100.128/27'
-param hubVirtualNetworkDiagnosticsLogs array = [
-  {
-    category: 'NetworkSecurityGroupEvent'
-    enabled: true
-  }
-  {
-    category: 'NetworkSecurityGroupRuleCounter'
-    enabled: true
-  }
-]
+param hubVirtualNetworkDiagnosticsLogs array = []
 param hubVirtualNetworkDiagnosticsMetrics array = [
   {
     category: 'AllMetrics'
@@ -513,6 +517,22 @@ param hubNetworkSecurityGroupRules array = [
     }
   }
 ]
+param hubNetworkSecurityGroupDiagnosticsLogs array = [
+  {
+    category: 'NetworkSecurityGroupEvent'
+    enabled: true
+  }
+  {
+    category: 'NetworkSecurityGroupRuleCounter'
+    enabled: true
+  }
+]
+param hubNetworkSecurityGroupDiagnosticsMetrics array = [
+  {
+    category: 'AllMetrics'
+    enabled: true
+  }
+]
 param hubSubnetServiceEndpoints array = [
   {
     service: 'Microsoft.Storage'
@@ -526,6 +546,26 @@ param firewallManagementSubnetAddressPrefix string = '10.0.100.64/26'
 param firewallClientSubnetAddressPrefix string = '10.0.100.0/26'
 param firewallPolicyName string = 'firewall-policy'
 param firewallThreatIntelMode string = 'Alert'
+param firewallDiagnosticsLogs array = [
+  {
+    category: 'AzureFirewallApplicationRule'
+    enabled: true
+  }
+  {
+    category: 'AzureFirewallNetworkRule'
+    enabled: true
+  }
+  {
+    category: 'AzureFirewallDnsProxy'
+    enabled: true
+  }
+]
+param firewallDiagnosticsMetrics array = [
+  {
+    category: 'AllMetrics'
+    enabled: true
+  }
+]
 var firewallClientSubnetName = 'AzureFirewallSubnet' //this must be 'AzureFirewallSubnet'
 param firewallClientIpConfigurationName string = 'firewall-client-ip-config'
 param firewallClientSubnetServiceEndpoints array = []
@@ -540,6 +580,26 @@ param firewallManagementPublicIPAddressName string = 'firewall-management-public
 param firewallManagementPublicIPAddressSkuName string = 'Standard'
 param firewallManagementPublicIpAllocationMethod string = 'Static'
 param firewallManagementPublicIPAddressAvailabilityZones array = []
+param publicIPAddressDiagnosticsLogs array = [
+  {
+    category: 'DDoSProtectionNotifications'
+    enabled: true
+  }
+  {
+    category: 'DDoSMitigationFlowLogs'
+    enabled: true
+  }
+  {
+    category: 'DDoSMitigationReports'
+    enabled: true
+  }
+]
+param publicIPAddressDiagnosticsMetrics array = [
+  {
+    category: 'AllMetrics'
+    enabled: true
+  }
+]
 
 param identityResourceGroupName string = replace(hubResourceGroupName, 'hub', 'identity')
 param identityLocation string = hubLocation
@@ -551,6 +611,8 @@ param identityVirtualNetworkDiagnosticsLogs array = hubVirtualNetworkDiagnostics
 param identityVirtualNetworkDiagnosticsMetrics array = hubVirtualNetworkDiagnosticsMetrics
 param identityNetworkSecurityGroupName string = replace(hubNetworkSecurityGroupName, 'hub', 'identity')
 param identityNetworkSecurityGroupRules array = hubNetworkSecurityGroupRules
+param identityNetworkSecurityGroupDiagnosticsLogs array = hubNetworkSecurityGroupDiagnosticsLogs
+param identityNetworkSecurityGroupDiagnosticsMetrics array = hubNetworkSecurityGroupDiagnosticsMetrics
 param identitySubnetServiceEndpoints array = hubSubnetServiceEndpoints
 param identityLogStorageAccountName string = toLower(take('idlogs${uniqueId}', 24))
 param identityLogStorageSkuName string = hubLogStorageSkuName
@@ -563,6 +625,8 @@ param operationsVirtualNetworkDiagnosticsLogs array = hubVirtualNetworkDiagnosti
 param operationsVirtualNetworkDiagnosticsMetrics array = hubVirtualNetworkDiagnosticsMetrics
 param operationsNetworkSecurityGroupName string = replace(hubNetworkSecurityGroupName, 'hub', 'operations')
 param operationsNetworkSecurityGroupRules array = hubNetworkSecurityGroupRules
+param operationsNetworkSecurityGroupDiagnosticsLogs array = hubNetworkSecurityGroupDiagnosticsLogs
+param operationsNetworkSecurityGroupDiagnosticsMetrics array = hubNetworkSecurityGroupDiagnosticsMetrics
 param operationsSubnetName string = replace(hubSubnetName, 'hub', 'operations')
 param operationsSubnetAddressPrefix string = '10.0.115.0/27'
 param operationsSubnetServiceEndpoints array = hubSubnetServiceEndpoints
@@ -579,6 +643,8 @@ param sharedServicesVirtualNetworkDiagnosticsLogs array = hubVirtualNetworkDiagn
 param sharedServicesVirtualNetworkDiagnosticsMetrics array = hubVirtualNetworkDiagnosticsMetrics
 param sharedServicesNetworkSecurityGroupName string = replace(hubNetworkSecurityGroupName, 'hub', 'sharedServices')
 param sharedServicesNetworkSecurityGroupRules array = hubNetworkSecurityGroupRules
+param sharedServicesNetworkSecurityGroupDiagnosticsLogs array = hubNetworkSecurityGroupDiagnosticsLogs
+param sharedServicesNetworkSecurityGroupDiagnosticsMetrics array = hubNetworkSecurityGroupDiagnosticsMetrics
 param sharedServicesSubnetServiceEndpoints array = hubSubnetServiceEndpoints
 param sharedServicesLogStorageAccountName string = toLower(take('shrdSvclogs${uniqueId}', 24))
 param sharedServicesLogStorageSkuName string = hubLogStorageSkuName

--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -466,11 +466,58 @@ param hubVirtualNetworkName string = 'hub-vnet'
 param hubSubnetName string = 'hub-subnet'
 param hubVirtualNetworkAddressPrefix string = '10.0.100.0/24'
 param hubSubnetAddressPrefix string = '10.0.100.128/27'
-param hubVirtualNetworkDiagnosticsLogs array = []
-param hubVirtualNetworkDiagnosticsMetrics array = []
+param hubVirtualNetworkDiagnosticsLogs array = [
+  {
+    category: 'NetworkSecurityGroupEvent'
+    enabled: true
+  }
+  {
+    category: 'NetworkSecurityGroupRuleCounter'
+    enabled: true
+  }
+]
+param hubVirtualNetworkDiagnosticsMetrics array = [
+  {
+    category: 'AllMetrics'
+    enabled: true
+  }
+]
 param hubNetworkSecurityGroupName string = 'hub-nsg'
-param hubNetworkSecurityGroupRules array = []
-param hubSubnetServiceEndpoints array = []
+param hubNetworkSecurityGroupRules array = [
+  {
+    name: 'allow_ssh'
+    properties: {
+      description: 'Allow SSH access from anywhere'
+      access: 'Allow'
+      priority: 100
+      protocol: 'Tcp'
+      direction: 'Inbound'
+      sourcePortRange: '*'
+      sourceAddressPrefix: '*'
+      destinationPortRange: '22'
+      destinationAddressPrefix: '*'
+    }
+  }
+  {
+    name: 'allow_rdp'
+    properties: {
+      description: 'Allow RDP access from anywhere'
+      access: 'Allow'
+      priority: 200
+      protocol: 'Tcp'
+      direction: 'Inbound'
+      sourcePortRange: '*'
+      sourceAddressPrefix: '*'
+      destinationPortRange: '3389'
+      destinationAddressPrefix: '*'
+    }
+  }
+]
+param hubSubnetServiceEndpoints array = [
+  {
+    service: 'Microsoft.Storage'
+  }
+]
 param hubLogStorageAccountName string = toLower(take('hublogs${uniqueId}', 24))
 param hubLogStorageSkuName string = 'Standard_GRS'
 
@@ -500,11 +547,11 @@ param identityVirtualNetworkName string = replace(hubVirtualNetworkName, 'hub', 
 param identitySubnetName string = replace(hubSubnetName, 'hub', 'identity')
 param identityVirtualNetworkAddressPrefix string = '10.0.110.0/26'
 param identitySubnetAddressPrefix string = '10.0.110.0/27'
-param identityVirtualNetworkDiagnosticsLogs array = []
-param identityVirtualNetworkDiagnosticsMetrics array = []
+param identityVirtualNetworkDiagnosticsLogs array = hubVirtualNetworkDiagnosticsLogs
+param identityVirtualNetworkDiagnosticsMetrics array = hubVirtualNetworkDiagnosticsMetrics
 param identityNetworkSecurityGroupName string = replace(hubNetworkSecurityGroupName, 'hub', 'identity')
-param identityNetworkSecurityGroupRules array = []
-param identitySubnetServiceEndpoints array = []
+param identityNetworkSecurityGroupRules array = hubNetworkSecurityGroupRules
+param identitySubnetServiceEndpoints array = hubSubnetServiceEndpoints
 param identityLogStorageAccountName string = toLower(take('idlogs${uniqueId}', 24))
 param identityLogStorageSkuName string = hubLogStorageSkuName
 
@@ -512,13 +559,13 @@ param operationsResourceGroupName string = replace(hubResourceGroupName, 'hub', 
 param operationsLocation string = hubLocation
 param operationsVirtualNetworkName string = replace(hubVirtualNetworkName, 'hub', 'operations')
 param operationsVirtualNetworkAddressPrefix string = '10.0.115.0/26'
-param operationsVirtualNetworkDiagnosticsLogs array = []
-param operationsVirtualNetworkDiagnosticsMetrics array = []
+param operationsVirtualNetworkDiagnosticsLogs array = hubVirtualNetworkDiagnosticsLogs
+param operationsVirtualNetworkDiagnosticsMetrics array = hubVirtualNetworkDiagnosticsMetrics
 param operationsNetworkSecurityGroupName string = replace(hubNetworkSecurityGroupName, 'hub', 'operations')
-param operationsNetworkSecurityGroupRules array = []
+param operationsNetworkSecurityGroupRules array = hubNetworkSecurityGroupRules
 param operationsSubnetName string = replace(hubSubnetName, 'hub', 'operations')
 param operationsSubnetAddressPrefix string = '10.0.115.0/27'
-param operationsSubnetServiceEndpoints array = []
+param operationsSubnetServiceEndpoints array = hubSubnetServiceEndpoints
 param operationsLogStorageAccountName string = toLower(take('opslogs${uniqueId}', 24))
 param operationsLogStorageSkuName string = hubLogStorageSkuName
 
@@ -528,11 +575,11 @@ param sharedServicesVirtualNetworkName string = replace(hubVirtualNetworkName, '
 param sharedServicesSubnetName string = replace(hubSubnetName, 'hub', 'sharedServices')
 param sharedServicesVirtualNetworkAddressPrefix string = '10.0.120.0/26'
 param sharedServicesSubnetAddressPrefix string = '10.0.120.0/27'
-param sharedServicesVirtualNetworkDiagnosticsLogs array = []
-param sharedServicesVirtualNetworkDiagnosticsMetrics array = []
+param sharedServicesVirtualNetworkDiagnosticsLogs array = hubVirtualNetworkDiagnosticsLogs
+param sharedServicesVirtualNetworkDiagnosticsMetrics array = hubVirtualNetworkDiagnosticsMetrics
 param sharedServicesNetworkSecurityGroupName string = replace(hubNetworkSecurityGroupName, 'hub', 'sharedServices')
-param sharedServicesNetworkSecurityGroupRules array = []
-param sharedServicesSubnetServiceEndpoints array = []
+param sharedServicesNetworkSecurityGroupRules array = hubNetworkSecurityGroupRules
+param sharedServicesSubnetServiceEndpoints array = hubSubnetServiceEndpoints
 param sharedServicesLogStorageAccountName string = toLower(take('shrdSvclogs${uniqueId}', 24))
 param sharedServicesLogStorageSkuName string = hubLogStorageSkuName
 

--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -527,12 +527,7 @@ param hubNetworkSecurityGroupDiagnosticsLogs array = [
     enabled: true
   }
 ]
-param hubNetworkSecurityGroupDiagnosticsMetrics array = [
-  {
-    category: 'AllMetrics'
-    enabled: true
-  }
-]
+param hubNetworkSecurityGroupDiagnosticsMetrics array = []
 param hubSubnetServiceEndpoints array = [
   {
     service: 'Microsoft.Storage'

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "13476760732826675507"
+      "templateHash": "18242851584802728088"
     }
   },
   "parameters": {
@@ -72,7 +72,12 @@
     },
     "hubVirtualNetworkDiagnosticsMetrics": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [
+        {
+          "category": "AllMetrics",
+          "enabled": true
+        }
+      ]
     },
     "hubNetworkSecurityGroupName": {
       "type": "string",
@@ -80,11 +85,66 @@
     },
     "hubNetworkSecurityGroupRules": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [
+        {
+          "name": "allow_ssh",
+          "properties": {
+            "description": "Allow SSH access from anywhere",
+            "access": "Allow",
+            "priority": 100,
+            "protocol": "Tcp",
+            "direction": "Inbound",
+            "sourcePortRange": "*",
+            "sourceAddressPrefix": "*",
+            "destinationPortRange": "22",
+            "destinationAddressPrefix": "*"
+          }
+        },
+        {
+          "name": "allow_rdp",
+          "properties": {
+            "description": "Allow RDP access from anywhere",
+            "access": "Allow",
+            "priority": 200,
+            "protocol": "Tcp",
+            "direction": "Inbound",
+            "sourcePortRange": "*",
+            "sourceAddressPrefix": "*",
+            "destinationPortRange": "3389",
+            "destinationAddressPrefix": "*"
+          }
+        }
+      ]
+    },
+    "hubNetworkSecurityGroupDiagnosticsLogs": {
+      "type": "array",
+      "defaultValue": [
+        {
+          "category": "NetworkSecurityGroupEvent",
+          "enabled": true
+        },
+        {
+          "category": "NetworkSecurityGroupRuleCounter",
+          "enabled": true
+        }
+      ]
+    },
+    "hubNetworkSecurityGroupDiagnosticsMetrics": {
+      "type": "array",
+      "defaultValue": [
+        {
+          "category": "AllMetrics",
+          "enabled": true
+        }
+      ]
     },
     "hubSubnetServiceEndpoints": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [
+        {
+          "service": "Microsoft.Storage"
+        }
+      ]
     },
     "hubLogStorageAccountName": {
       "type": "string",
@@ -113,6 +173,32 @@
     "firewallThreatIntelMode": {
       "type": "string",
       "defaultValue": "Alert"
+    },
+    "firewallDiagnosticsLogs": {
+      "type": "array",
+      "defaultValue": [
+        {
+          "category": "AzureFirewallApplicationRule",
+          "enabled": true
+        },
+        {
+          "category": "AzureFirewallNetworkRule",
+          "enabled": true
+        },
+        {
+          "category": "AzureFirewallDnsProxy",
+          "enabled": true
+        }
+      ]
+    },
+    "firewallDiagnosticsMetrics": {
+      "type": "array",
+      "defaultValue": [
+        {
+          "category": "AllMetrics",
+          "enabled": true
+        }
+      ]
     },
     "firewallClientIpConfigurationName": {
       "type": "string",
@@ -162,6 +248,32 @@
       "type": "array",
       "defaultValue": []
     },
+    "publicIPAddressDiagnosticsLogs": {
+      "type": "array",
+      "defaultValue": [
+        {
+          "category": "DDoSProtectionNotifications",
+          "enabled": true
+        },
+        {
+          "category": "DDoSMitigationFlowLogs",
+          "enabled": true
+        },
+        {
+          "category": "DDoSMitigationReports",
+          "enabled": true
+        }
+      ]
+    },
+    "publicIPAddressDiagnosticsMetrics": {
+      "type": "array",
+      "defaultValue": [
+        {
+          "category": "AllMetrics",
+          "enabled": true
+        }
+      ]
+    },
     "identityResourceGroupName": {
       "type": "string",
       "defaultValue": "[replace(parameters('hubResourceGroupName'), 'hub', 'identity')]"
@@ -188,11 +300,11 @@
     },
     "identityVirtualNetworkDiagnosticsLogs": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": "[parameters('hubVirtualNetworkDiagnosticsLogs')]"
     },
     "identityVirtualNetworkDiagnosticsMetrics": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": "[parameters('hubVirtualNetworkDiagnosticsMetrics')]"
     },
     "identityNetworkSecurityGroupName": {
       "type": "string",
@@ -200,11 +312,19 @@
     },
     "identityNetworkSecurityGroupRules": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": "[parameters('hubNetworkSecurityGroupRules')]"
+    },
+    "identityNetworkSecurityGroupDiagnosticsLogs": {
+      "type": "array",
+      "defaultValue": "[parameters('hubNetworkSecurityGroupDiagnosticsLogs')]"
+    },
+    "identityNetworkSecurityGroupDiagnosticsMetrics": {
+      "type": "array",
+      "defaultValue": "[parameters('hubNetworkSecurityGroupDiagnosticsMetrics')]"
     },
     "identitySubnetServiceEndpoints": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": "[parameters('hubSubnetServiceEndpoints')]"
     },
     "identityLogStorageAccountName": {
       "type": "string",
@@ -232,11 +352,11 @@
     },
     "operationsVirtualNetworkDiagnosticsLogs": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": "[parameters('hubVirtualNetworkDiagnosticsLogs')]"
     },
     "operationsVirtualNetworkDiagnosticsMetrics": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": "[parameters('hubVirtualNetworkDiagnosticsMetrics')]"
     },
     "operationsNetworkSecurityGroupName": {
       "type": "string",
@@ -244,7 +364,15 @@
     },
     "operationsNetworkSecurityGroupRules": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": "[parameters('hubNetworkSecurityGroupRules')]"
+    },
+    "operationsNetworkSecurityGroupDiagnosticsLogs": {
+      "type": "array",
+      "defaultValue": "[parameters('hubNetworkSecurityGroupDiagnosticsLogs')]"
+    },
+    "operationsNetworkSecurityGroupDiagnosticsMetrics": {
+      "type": "array",
+      "defaultValue": "[parameters('hubNetworkSecurityGroupDiagnosticsMetrics')]"
     },
     "operationsSubnetName": {
       "type": "string",
@@ -256,7 +384,7 @@
     },
     "operationsSubnetServiceEndpoints": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": "[parameters('hubSubnetServiceEndpoints')]"
     },
     "operationsLogStorageAccountName": {
       "type": "string",
@@ -292,11 +420,11 @@
     },
     "sharedServicesVirtualNetworkDiagnosticsLogs": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": "[parameters('hubVirtualNetworkDiagnosticsLogs')]"
     },
     "sharedServicesVirtualNetworkDiagnosticsMetrics": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": "[parameters('hubVirtualNetworkDiagnosticsMetrics')]"
     },
     "sharedServicesNetworkSecurityGroupName": {
       "type": "string",
@@ -304,11 +432,19 @@
     },
     "sharedServicesNetworkSecurityGroupRules": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": "[parameters('hubNetworkSecurityGroupRules')]"
+    },
+    "sharedServicesNetworkSecurityGroupDiagnosticsLogs": {
+      "type": "array",
+      "defaultValue": "[parameters('hubNetworkSecurityGroupDiagnosticsLogs')]"
+    },
+    "sharedServicesNetworkSecurityGroupDiagnosticsMetrics": {
+      "type": "array",
+      "defaultValue": "[parameters('hubNetworkSecurityGroupDiagnosticsMetrics')]"
     },
     "sharedServicesSubnetServiceEndpoints": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": "[parameters('hubSubnetServiceEndpoints')]"
     },
     "sharedServicesLogStorageAccountName": {
       "type": "string",
@@ -1055,6 +1191,12 @@
           "networkSecurityGroupRules": {
             "value": "[parameters('hubNetworkSecurityGroupRules')]"
           },
+          "networkSecurityGroupDiagnosticsLogs": {
+            "value": "[parameters('hubNetworkSecurityGroupDiagnosticsLogs')]"
+          },
+          "networkSecurityGroupDiagnosticsMetrics": {
+            "value": "[parameters('hubNetworkSecurityGroupDiagnosticsMetrics')]"
+          },
           "subnetName": {
             "value": "[parameters('hubSubnetName')]"
           },
@@ -1075,6 +1217,12 @@
           },
           "firewallThreatIntelMode": {
             "value": "[parameters('firewallThreatIntelMode')]"
+          },
+          "firewallDiagnosticsLogs": {
+            "value": "[parameters('firewallDiagnosticsLogs')]"
+          },
+          "firewallDiagnosticsMetrics": {
+            "value": "[parameters('firewallDiagnosticsMetrics')]"
           },
           "firewallClientIpConfigurationName": {
             "value": "[parameters('firewallClientIpConfigurationName')]"
@@ -1123,6 +1271,12 @@
           },
           "firewallManagementPublicIPAddressAvailabilityZones": {
             "value": "[parameters('firewallManagementPublicIPAddressAvailabilityZones')]"
+          },
+          "publicIPAddressDiagnosticsLogs": {
+            "value": "[parameters('publicIPAddressDiagnosticsLogs')]"
+          },
+          "publicIPAddressDiagnosticsMetrics": {
+            "value": "[parameters('publicIPAddressDiagnosticsMetrics')]"
           }
         },
         "template": {
@@ -1132,7 +1286,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "12334361858927907885"
+              "templateHash": "18137640474022318846"
             }
           },
           "parameters": {
@@ -1174,6 +1328,12 @@
             "networkSecurityGroupRules": {
               "type": "array"
             },
+            "networkSecurityGroupDiagnosticsLogs": {
+              "type": "array"
+            },
+            "networkSecurityGroupDiagnosticsMetrics": {
+              "type": "array"
+            },
             "subnetName": {
               "type": "string"
             },
@@ -1210,6 +1370,12 @@
             },
             "firewallThreatIntelMode": {
               "type": "string"
+            },
+            "firewallDiagnosticsLogs": {
+              "type": "array"
+            },
+            "firewallDiagnosticsMetrics": {
+              "type": "array"
             },
             "firewallClientIpConfigurationName": {
               "type": "string"
@@ -1258,53 +1424,15 @@
             },
             "firewallManagementPublicIPAddressAvailabilityZones": {
               "type": "array"
+            },
+            "publicIPAddressDiagnosticsLogs": {
+              "type": "array"
+            },
+            "publicIPAddressDiagnosticsMetrics": {
+              "type": "array"
             }
           },
           "functions": [],
-          "variables": {
-            "defaultVirtualNewtorkDiagnosticsLogs": [],
-            "defaultVirtualNetworkDiagnosticsMetrics": [
-              {
-                "category": "AllMetrics",
-                "enabled": true
-              }
-            ],
-            "defaultSubnetServiceEndpoints": [
-              {
-                "service": "Microsoft.Storage"
-              }
-            ],
-            "defaultNetworkSecurityGroupRules": [
-              {
-                "name": "allow_ssh",
-                "properties": {
-                  "description": "Allow SSH access from anywhere",
-                  "access": "Allow",
-                  "priority": 100,
-                  "protocol": "Tcp",
-                  "direction": "Inbound",
-                  "sourcePortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationPortRange": "22",
-                  "destinationAddressPrefix": "*"
-                }
-              },
-              {
-                "name": "allow_rdp",
-                "properties": {
-                  "description": "Allow RDP access from anywhere",
-                  "access": "Allow",
-                  "priority": 200,
-                  "protocol": "Tcp",
-                  "direction": "Inbound",
-                  "sourcePortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationPortRange": "3389",
-                  "destinationAddressPrefix": "*"
-                }
-              }
-            ]
-          },
           "resources": [
             {
               "type": "Microsoft.Network/virtualNetworks/subnets",
@@ -1318,7 +1446,7 @@
                 "routeTable": {
                   "id": "[reference(resourceId('Microsoft.Resources/deployments', 'routeTable'), '2020-06-01').outputs.id.value]"
                 },
-                "serviceEndpoints": "[if(empty(parameters('subnetServiceEndpoints')), variables('defaultSubnetServiceEndpoints'), parameters('subnetServiceEndpoints'))]",
+                "serviceEndpoints": "[parameters('subnetServiceEndpoints')]",
                 "privateEndpointNetworkPolicies": "Disabled",
                 "privateLinkServiceNetworkPolicies": "Enabled"
               },
@@ -1420,7 +1548,19 @@
                     "value": "[parameters('tags')]"
                   },
                   "securityRules": {
-                    "value": "[if(empty(parameters('networkSecurityGroupRules')), variables('defaultNetworkSecurityGroupRules'), parameters('networkSecurityGroupRules'))]"
+                    "value": "[parameters('networkSecurityGroupRules')]"
+                  },
+                  "logAnalyticsWorkspaceResourceId": {
+                    "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
+                  },
+                  "logStorageAccountResourceId": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
+                  },
+                  "logs": {
+                    "value": "[parameters('networkSecurityGroupDiagnosticsLogs')]"
+                  },
+                  "metrics": {
+                    "value": "[parameters('networkSecurityGroupDiagnosticsMetrics')]"
                   }
                 },
                 "template": {
@@ -1430,7 +1570,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "9304664949671097450"
+                      "templateHash": "4497555273030729522"
                     }
                   },
                   "parameters": {
@@ -1446,6 +1586,18 @@
                     },
                     "securityRules": {
                       "type": "array"
+                    },
+                    "logStorageAccountResourceId": {
+                      "type": "string"
+                    },
+                    "logAnalyticsWorkspaceResourceId": {
+                      "type": "string"
+                    },
+                    "logs": {
+                      "type": "array"
+                    },
+                    "metrics": {
+                      "type": "array"
                     }
                   },
                   "functions": [],
@@ -1459,6 +1611,21 @@
                       "properties": {
                         "securityRules": "[parameters('securityRules')]"
                       }
+                    },
+                    {
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2017-05-01-preview",
+                      "scope": "[format('Microsoft.Network/networkSecurityGroups/{0}', parameters('name'))]",
+                      "name": "[format('{0}-diagnostics', parameters('name'))]",
+                      "properties": {
+                        "storageAccountId": "[parameters('logStorageAccountResourceId')]",
+                        "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
+                        "logs": "[parameters('logs')]",
+                        "metrics": "[parameters('metrics')]"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                      ]
                     }
                   ],
                   "outputs": {
@@ -1472,7 +1639,10 @@
                     }
                   }
                 }
-              }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'logStorage')]"
+              ]
             },
             {
               "type": "Microsoft.Resources/deployments",
@@ -1495,12 +1665,6 @@
                   },
                   "addressPrefix": {
                     "value": "[parameters('virtualNetworkAddressPrefix')]"
-                  },
-                  "diagnosticsLogs": {
-                    "value": "[if(empty(parameters('virtualNetworkDiagnosticsLogs')), variables('defaultVirtualNewtorkDiagnosticsLogs'), parameters('virtualNetworkDiagnosticsLogs'))]"
-                  },
-                  "diagnosticsMetrics": {
-                    "value": "[if(empty(parameters('virtualNetworkDiagnosticsMetrics')), variables('defaultVirtualNetworkDiagnosticsMetrics'), parameters('virtualNetworkDiagnosticsMetrics'))]"
                   },
                   "subnets": {
                     "value": [
@@ -1525,6 +1689,12 @@
                   },
                   "logStorageAccountResourceId": {
                     "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
+                  },
+                  "logs": {
+                    "value": "[parameters('virtualNetworkDiagnosticsLogs')]"
+                  },
+                  "metrics": {
+                    "value": "[parameters('virtualNetworkDiagnosticsMetrics')]"
                   }
                 },
                 "template": {
@@ -1534,7 +1704,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "14686239955820792027"
+                      "templateHash": "12119421388421560495"
                     }
                   },
                   "parameters": {
@@ -1560,10 +1730,10 @@
                     "subnets": {
                       "type": "array"
                     },
-                    "diagnosticsMetrics": {
+                    "logs": {
                       "type": "array"
                     },
-                    "diagnosticsLogs": {
+                    "metrics": {
                       "type": "array"
                     }
                   },
@@ -1592,8 +1762,8 @@
                       "properties": {
                         "storageAccountId": "[parameters('logStorageAccountResourceId')]",
                         "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
-                        "metrics": "[parameters('diagnosticsMetrics')]",
-                        "logs": "[parameters('diagnosticsLogs')]"
+                        "logs": "[parameters('logs')]",
+                        "metrics": "[parameters('metrics')]"
                       },
                       "dependsOn": [
                         "[resourceId('Microsoft.Network/virtualNetworks', parameters('name'))]"
@@ -1751,6 +1921,18 @@
                   },
                   "availabilityZones": {
                     "value": "[parameters('firewallClientPublicIPAddressAvailabilityZones')]"
+                  },
+                  "logAnalyticsWorkspaceResourceId": {
+                    "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
+                  },
+                  "logStorageAccountResourceId": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
+                  },
+                  "logs": {
+                    "value": "[parameters('publicIPAddressDiagnosticsLogs')]"
+                  },
+                  "metrics": {
+                    "value": "[parameters('publicIPAddressDiagnosticsMetrics')]"
                   }
                 },
                 "template": {
@@ -1760,7 +1942,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "9471207349099328587"
+                      "templateHash": "9624598078084769254"
                     }
                   },
                   "parameters": {
@@ -1782,6 +1964,18 @@
                     },
                     "availabilityZones": {
                       "type": "array"
+                    },
+                    "logStorageAccountResourceId": {
+                      "type": "string"
+                    },
+                    "logAnalyticsWorkspaceResourceId": {
+                      "type": "string"
+                    },
+                    "logs": {
+                      "type": "array"
+                    },
+                    "metrics": {
+                      "type": "array"
                     }
                   },
                   "functions": [],
@@ -1799,6 +1993,21 @@
                         "publicIPAllocationMethod": "[parameters('publicIpAllocationMethod')]"
                       },
                       "zones": "[parameters('availabilityZones')]"
+                    },
+                    {
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2017-05-01-preview",
+                      "scope": "[format('Microsoft.Network/publicIPAddresses/{0}', parameters('name'))]",
+                      "name": "[format('{0}-diagnostics', parameters('name'))]",
+                      "properties": {
+                        "storageAccountId": "[parameters('logStorageAccountResourceId')]",
+                        "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
+                        "logs": "[parameters('logs')]",
+                        "metrics": "[parameters('metrics')]"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/publicIPAddresses', parameters('name'))]"
+                      ]
                     }
                   ],
                   "outputs": {
@@ -1808,7 +2017,10 @@
                     }
                   }
                 }
-              }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'logStorage')]"
+              ]
             },
             {
               "type": "Microsoft.Resources/deployments",
@@ -1837,6 +2049,18 @@
                   },
                   "availabilityZones": {
                     "value": "[parameters('firewallManagementPublicIPAddressAvailabilityZones')]"
+                  },
+                  "logAnalyticsWorkspaceResourceId": {
+                    "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
+                  },
+                  "logStorageAccountResourceId": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
+                  },
+                  "logs": {
+                    "value": "[parameters('publicIPAddressDiagnosticsLogs')]"
+                  },
+                  "metrics": {
+                    "value": "[parameters('publicIPAddressDiagnosticsMetrics')]"
                   }
                 },
                 "template": {
@@ -1846,7 +2070,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "9471207349099328587"
+                      "templateHash": "9624598078084769254"
                     }
                   },
                   "parameters": {
@@ -1868,6 +2092,18 @@
                     },
                     "availabilityZones": {
                       "type": "array"
+                    },
+                    "logStorageAccountResourceId": {
+                      "type": "string"
+                    },
+                    "logAnalyticsWorkspaceResourceId": {
+                      "type": "string"
+                    },
+                    "logs": {
+                      "type": "array"
+                    },
+                    "metrics": {
+                      "type": "array"
                     }
                   },
                   "functions": [],
@@ -1885,6 +2121,21 @@
                         "publicIPAllocationMethod": "[parameters('publicIpAllocationMethod')]"
                       },
                       "zones": "[parameters('availabilityZones')]"
+                    },
+                    {
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2017-05-01-preview",
+                      "scope": "[format('Microsoft.Network/publicIPAddresses/{0}', parameters('name'))]",
+                      "name": "[format('{0}-diagnostics', parameters('name'))]",
+                      "properties": {
+                        "storageAccountId": "[parameters('logStorageAccountResourceId')]",
+                        "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
+                        "logs": "[parameters('logs')]",
+                        "metrics": "[parameters('metrics')]"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/publicIPAddresses', parameters('name'))]"
+                      ]
                     }
                   ],
                   "outputs": {
@@ -1894,7 +2145,10 @@
                     }
                   }
                 }
-              }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'logStorage')]"
+              ]
             },
             {
               "type": "Microsoft.Resources/deployments",
@@ -1941,6 +2195,18 @@
                   },
                   "managementIpConfigurationPublicIPAddressResourceId": {
                     "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewallManagementPublicIPAddress'), '2020-06-01').outputs.id.value]"
+                  },
+                  "logAnalyticsWorkspaceResourceId": {
+                    "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
+                  },
+                  "logStorageAccountResourceId": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
+                  },
+                  "logs": {
+                    "value": "[parameters('firewallDiagnosticsLogs')]"
+                  },
+                  "metrics": {
+                    "value": "[parameters('firewallDiagnosticsMetrics')]"
                   }
                 },
                 "template": {
@@ -1950,7 +2216,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "8821707208863806383"
+                      "templateHash": "16515753424142002553"
                     }
                   },
                   "parameters": {
@@ -1991,6 +2257,18 @@
                     },
                     "firewallPolicyName": {
                       "type": "string"
+                    },
+                    "logStorageAccountResourceId": {
+                      "type": "string"
+                    },
+                    "logAnalyticsWorkspaceResourceId": {
+                      "type": "string"
+                    },
+                    "logs": {
+                      "type": "array"
+                    },
+                    "metrics": {
+                      "type": "array"
                     }
                   },
                   "functions": [],
@@ -2140,6 +2418,21 @@
                         "[resourceId('Microsoft.Network/firewallPolicies/ruleCollectionGroups', split(format('{0}/DefaultNetworkRuleCollectionGroup', parameters('firewallPolicyName')), '/')[0], split(format('{0}/DefaultNetworkRuleCollectionGroup', parameters('firewallPolicyName')), '/')[1])]",
                         "[resourceId('Microsoft.Network/firewallPolicies', parameters('firewallPolicyName'))]"
                       ]
+                    },
+                    {
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2017-05-01-preview",
+                      "scope": "[format('Microsoft.Network/azureFirewalls/{0}', parameters('name'))]",
+                      "name": "[format('{0}-diagnostics', parameters('name'))]",
+                      "properties": {
+                        "storageAccountId": "[parameters('logStorageAccountResourceId')]",
+                        "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
+                        "logs": "[parameters('logs')]",
+                        "metrics": "[parameters('metrics')]"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/azureFirewalls', parameters('name'))]"
+                      ]
                     }
                   ],
                   "outputs": {
@@ -2153,6 +2446,7 @@
               "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', 'firewallClientPublicIPAddress')]",
                 "[resourceId('Microsoft.Resources/deployments', 'firewallManagementPublicIPAddress')]",
+                "[resourceId('Microsoft.Resources/deployments', 'logStorage')]",
                 "[resourceId('Microsoft.Resources/deployments', 'virtualNetwork')]"
               ]
             },
@@ -2549,6 +2843,12 @@
           "networkSecurityGroupRules": {
             "value": "[parameters('identityNetworkSecurityGroupRules')]"
           },
+          "networkSecurityGroupDiagnosticsLogs": {
+            "value": "[parameters('identityNetworkSecurityGroupDiagnosticsLogs')]"
+          },
+          "networkSecurityGroupDiagnosticsMetrics": {
+            "value": "[parameters('identityNetworkSecurityGroupDiagnosticsMetrics')]"
+          },
           "subnetName": {
             "value": "[parameters('identitySubnetName')]"
           },
@@ -2566,7 +2866,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "13423908076245323056"
+              "templateHash": "17180259987553481892"
             }
           },
           "parameters": {
@@ -2608,6 +2908,12 @@
             "networkSecurityGroupRules": {
               "type": "array"
             },
+            "networkSecurityGroupDiagnosticsLogs": {
+              "type": "array"
+            },
+            "networkSecurityGroupDiagnosticsMetrics": {
+              "type": "array"
+            },
             "subnetName": {
               "type": "string"
             },
@@ -2639,50 +2945,6 @@
             }
           },
           "functions": [],
-          "variables": {
-            "defaultVirtualNetworkDiagnosticsLogs": [],
-            "defaultVirtualNetworkDiagnosticsMetrics": [
-              {
-                "category": "AllMetrics",
-                "enabled": true
-              }
-            ],
-            "defaultSubnetServiceEndpoints": [
-              {
-                "service": "Microsoft.Storage"
-              }
-            ],
-            "defaultNetworkSecurityGroupRules": [
-              {
-                "name": "allow_ssh",
-                "properties": {
-                  "description": "Allow SSH access from anywhere",
-                  "access": "Allow",
-                  "priority": 100,
-                  "protocol": "Tcp",
-                  "direction": "Inbound",
-                  "sourcePortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationPortRange": "22",
-                  "destinationAddressPrefix": "*"
-                }
-              },
-              {
-                "name": "allow_rdp",
-                "properties": {
-                  "description": "Allow RDP access from anywhere",
-                  "access": "Allow",
-                  "priority": 200,
-                  "protocol": "Tcp",
-                  "direction": "Inbound",
-                  "sourcePortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationPortRange": "3389",
-                  "destinationAddressPrefix": "*"
-                }
-              }
-            ]
-          },
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
@@ -2775,7 +3037,19 @@
                     "value": "[parameters('tags')]"
                   },
                   "securityRules": {
-                    "value": "[if(empty(parameters('networkSecurityGroupRules')), variables('defaultNetworkSecurityGroupRules'), parameters('networkSecurityGroupRules'))]"
+                    "value": "[parameters('networkSecurityGroupRules')]"
+                  },
+                  "logAnalyticsWorkspaceResourceId": {
+                    "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
+                  },
+                  "logStorageAccountResourceId": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
+                  },
+                  "logs": {
+                    "value": "[parameters('networkSecurityGroupDiagnosticsLogs')]"
+                  },
+                  "metrics": {
+                    "value": "[parameters('networkSecurityGroupDiagnosticsMetrics')]"
                   }
                 },
                 "template": {
@@ -2785,7 +3059,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "9304664949671097450"
+                      "templateHash": "4497555273030729522"
                     }
                   },
                   "parameters": {
@@ -2801,6 +3075,18 @@
                     },
                     "securityRules": {
                       "type": "array"
+                    },
+                    "logStorageAccountResourceId": {
+                      "type": "string"
+                    },
+                    "logAnalyticsWorkspaceResourceId": {
+                      "type": "string"
+                    },
+                    "logs": {
+                      "type": "array"
+                    },
+                    "metrics": {
+                      "type": "array"
                     }
                   },
                   "functions": [],
@@ -2814,6 +3100,21 @@
                       "properties": {
                         "securityRules": "[parameters('securityRules')]"
                       }
+                    },
+                    {
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2017-05-01-preview",
+                      "scope": "[format('Microsoft.Network/networkSecurityGroups/{0}', parameters('name'))]",
+                      "name": "[format('{0}-diagnostics', parameters('name'))]",
+                      "properties": {
+                        "storageAccountId": "[parameters('logStorageAccountResourceId')]",
+                        "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
+                        "logs": "[parameters('logs')]",
+                        "metrics": "[parameters('metrics')]"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                      ]
                     }
                   ],
                   "outputs": {
@@ -2827,7 +3128,10 @@
                     }
                   }
                 }
-              }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'logStorage')]"
+              ]
             },
             {
               "type": "Microsoft.Resources/deployments",
@@ -2952,12 +3256,6 @@
                   "addressPrefix": {
                     "value": "[parameters('virtualNetworkAddressPrefix')]"
                   },
-                  "diagnosticsLogs": {
-                    "value": "[if(empty(parameters('virtualNetworkDiagnosticsLogs')), variables('defaultVirtualNetworkDiagnosticsLogs'), parameters('virtualNetworkDiagnosticsLogs'))]"
-                  },
-                  "diagnosticsMetrics": {
-                    "value": "[if(empty(parameters('virtualNetworkDiagnosticsMetrics')), variables('defaultVirtualNetworkDiagnosticsMetrics'), parameters('virtualNetworkDiagnosticsMetrics'))]"
-                  },
                   "subnets": {
                     "value": [
                       {
@@ -2970,7 +3268,7 @@
                           "routeTable": {
                             "id": "[reference(resourceId('Microsoft.Resources/deployments', 'routeTable'), '2020-06-01').outputs.id.value]"
                           },
-                          "serviceEndpoints": "[if(empty(parameters('subnetServiceEndpoints')), variables('defaultSubnetServiceEndpoints'), parameters('subnetServiceEndpoints'))]"
+                          "serviceEndpoints": "[parameters('subnetServiceEndpoints')]"
                         }
                       }
                     ]
@@ -2980,6 +3278,12 @@
                   },
                   "logStorageAccountResourceId": {
                     "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
+                  },
+                  "logs": {
+                    "value": "[parameters('virtualNetworkDiagnosticsLogs')]"
+                  },
+                  "metrics": {
+                    "value": "[parameters('virtualNetworkDiagnosticsMetrics')]"
                   }
                 },
                 "template": {
@@ -2989,7 +3293,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "14686239955820792027"
+                      "templateHash": "12119421388421560495"
                     }
                   },
                   "parameters": {
@@ -3015,10 +3319,10 @@
                     "subnets": {
                       "type": "array"
                     },
-                    "diagnosticsMetrics": {
+                    "logs": {
                       "type": "array"
                     },
-                    "diagnosticsLogs": {
+                    "metrics": {
                       "type": "array"
                     }
                   },
@@ -3047,8 +3351,8 @@
                       "properties": {
                         "storageAccountId": "[parameters('logStorageAccountResourceId')]",
                         "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
-                        "metrics": "[parameters('diagnosticsMetrics')]",
-                        "logs": "[parameters('diagnosticsLogs')]"
+                        "logs": "[parameters('logs')]",
+                        "metrics": "[parameters('metrics')]"
                       },
                       "dependsOn": [
                         "[resourceId('Microsoft.Network/virtualNetworks', parameters('name'))]"
@@ -3163,6 +3467,12 @@
           "networkSecurityGroupRules": {
             "value": "[parameters('operationsNetworkSecurityGroupRules')]"
           },
+          "networkSecurityGroupDiagnosticsLogs": {
+            "value": "[parameters('operationsNetworkSecurityGroupDiagnosticsLogs')]"
+          },
+          "networkSecurityGroupDiagnosticsMetrics": {
+            "value": "[parameters('operationsNetworkSecurityGroupDiagnosticsMetrics')]"
+          },
           "subnetName": {
             "value": "[parameters('operationsSubnetName')]"
           },
@@ -3180,7 +3490,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "13423908076245323056"
+              "templateHash": "17180259987553481892"
             }
           },
           "parameters": {
@@ -3222,6 +3532,12 @@
             "networkSecurityGroupRules": {
               "type": "array"
             },
+            "networkSecurityGroupDiagnosticsLogs": {
+              "type": "array"
+            },
+            "networkSecurityGroupDiagnosticsMetrics": {
+              "type": "array"
+            },
             "subnetName": {
               "type": "string"
             },
@@ -3253,50 +3569,6 @@
             }
           },
           "functions": [],
-          "variables": {
-            "defaultVirtualNetworkDiagnosticsLogs": [],
-            "defaultVirtualNetworkDiagnosticsMetrics": [
-              {
-                "category": "AllMetrics",
-                "enabled": true
-              }
-            ],
-            "defaultSubnetServiceEndpoints": [
-              {
-                "service": "Microsoft.Storage"
-              }
-            ],
-            "defaultNetworkSecurityGroupRules": [
-              {
-                "name": "allow_ssh",
-                "properties": {
-                  "description": "Allow SSH access from anywhere",
-                  "access": "Allow",
-                  "priority": 100,
-                  "protocol": "Tcp",
-                  "direction": "Inbound",
-                  "sourcePortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationPortRange": "22",
-                  "destinationAddressPrefix": "*"
-                }
-              },
-              {
-                "name": "allow_rdp",
-                "properties": {
-                  "description": "Allow RDP access from anywhere",
-                  "access": "Allow",
-                  "priority": 200,
-                  "protocol": "Tcp",
-                  "direction": "Inbound",
-                  "sourcePortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationPortRange": "3389",
-                  "destinationAddressPrefix": "*"
-                }
-              }
-            ]
-          },
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
@@ -3389,7 +3661,19 @@
                     "value": "[parameters('tags')]"
                   },
                   "securityRules": {
-                    "value": "[if(empty(parameters('networkSecurityGroupRules')), variables('defaultNetworkSecurityGroupRules'), parameters('networkSecurityGroupRules'))]"
+                    "value": "[parameters('networkSecurityGroupRules')]"
+                  },
+                  "logAnalyticsWorkspaceResourceId": {
+                    "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
+                  },
+                  "logStorageAccountResourceId": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
+                  },
+                  "logs": {
+                    "value": "[parameters('networkSecurityGroupDiagnosticsLogs')]"
+                  },
+                  "metrics": {
+                    "value": "[parameters('networkSecurityGroupDiagnosticsMetrics')]"
                   }
                 },
                 "template": {
@@ -3399,7 +3683,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "9304664949671097450"
+                      "templateHash": "4497555273030729522"
                     }
                   },
                   "parameters": {
@@ -3415,6 +3699,18 @@
                     },
                     "securityRules": {
                       "type": "array"
+                    },
+                    "logStorageAccountResourceId": {
+                      "type": "string"
+                    },
+                    "logAnalyticsWorkspaceResourceId": {
+                      "type": "string"
+                    },
+                    "logs": {
+                      "type": "array"
+                    },
+                    "metrics": {
+                      "type": "array"
                     }
                   },
                   "functions": [],
@@ -3428,6 +3724,21 @@
                       "properties": {
                         "securityRules": "[parameters('securityRules')]"
                       }
+                    },
+                    {
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2017-05-01-preview",
+                      "scope": "[format('Microsoft.Network/networkSecurityGroups/{0}', parameters('name'))]",
+                      "name": "[format('{0}-diagnostics', parameters('name'))]",
+                      "properties": {
+                        "storageAccountId": "[parameters('logStorageAccountResourceId')]",
+                        "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
+                        "logs": "[parameters('logs')]",
+                        "metrics": "[parameters('metrics')]"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                      ]
                     }
                   ],
                   "outputs": {
@@ -3441,7 +3752,10 @@
                     }
                   }
                 }
-              }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'logStorage')]"
+              ]
             },
             {
               "type": "Microsoft.Resources/deployments",
@@ -3566,12 +3880,6 @@
                   "addressPrefix": {
                     "value": "[parameters('virtualNetworkAddressPrefix')]"
                   },
-                  "diagnosticsLogs": {
-                    "value": "[if(empty(parameters('virtualNetworkDiagnosticsLogs')), variables('defaultVirtualNetworkDiagnosticsLogs'), parameters('virtualNetworkDiagnosticsLogs'))]"
-                  },
-                  "diagnosticsMetrics": {
-                    "value": "[if(empty(parameters('virtualNetworkDiagnosticsMetrics')), variables('defaultVirtualNetworkDiagnosticsMetrics'), parameters('virtualNetworkDiagnosticsMetrics'))]"
-                  },
                   "subnets": {
                     "value": [
                       {
@@ -3584,7 +3892,7 @@
                           "routeTable": {
                             "id": "[reference(resourceId('Microsoft.Resources/deployments', 'routeTable'), '2020-06-01').outputs.id.value]"
                           },
-                          "serviceEndpoints": "[if(empty(parameters('subnetServiceEndpoints')), variables('defaultSubnetServiceEndpoints'), parameters('subnetServiceEndpoints'))]"
+                          "serviceEndpoints": "[parameters('subnetServiceEndpoints')]"
                         }
                       }
                     ]
@@ -3594,6 +3902,12 @@
                   },
                   "logStorageAccountResourceId": {
                     "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
+                  },
+                  "logs": {
+                    "value": "[parameters('virtualNetworkDiagnosticsLogs')]"
+                  },
+                  "metrics": {
+                    "value": "[parameters('virtualNetworkDiagnosticsMetrics')]"
                   }
                 },
                 "template": {
@@ -3603,7 +3917,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "14686239955820792027"
+                      "templateHash": "12119421388421560495"
                     }
                   },
                   "parameters": {
@@ -3629,10 +3943,10 @@
                     "subnets": {
                       "type": "array"
                     },
-                    "diagnosticsMetrics": {
+                    "logs": {
                       "type": "array"
                     },
-                    "diagnosticsLogs": {
+                    "metrics": {
                       "type": "array"
                     }
                   },
@@ -3661,8 +3975,8 @@
                       "properties": {
                         "storageAccountId": "[parameters('logStorageAccountResourceId')]",
                         "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
-                        "metrics": "[parameters('diagnosticsMetrics')]",
-                        "logs": "[parameters('diagnosticsLogs')]"
+                        "logs": "[parameters('logs')]",
+                        "metrics": "[parameters('metrics')]"
                       },
                       "dependsOn": [
                         "[resourceId('Microsoft.Network/virtualNetworks', parameters('name'))]"
@@ -3777,6 +4091,12 @@
           "networkSecurityGroupRules": {
             "value": "[parameters('sharedServicesNetworkSecurityGroupRules')]"
           },
+          "networkSecurityGroupDiagnosticsLogs": {
+            "value": "[parameters('sharedServicesNetworkSecurityGroupDiagnosticsLogs')]"
+          },
+          "networkSecurityGroupDiagnosticsMetrics": {
+            "value": "[parameters('sharedServicesNetworkSecurityGroupDiagnosticsMetrics')]"
+          },
           "subnetName": {
             "value": "[parameters('sharedServicesSubnetName')]"
           },
@@ -3794,7 +4114,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "13423908076245323056"
+              "templateHash": "17180259987553481892"
             }
           },
           "parameters": {
@@ -3836,6 +4156,12 @@
             "networkSecurityGroupRules": {
               "type": "array"
             },
+            "networkSecurityGroupDiagnosticsLogs": {
+              "type": "array"
+            },
+            "networkSecurityGroupDiagnosticsMetrics": {
+              "type": "array"
+            },
             "subnetName": {
               "type": "string"
             },
@@ -3867,50 +4193,6 @@
             }
           },
           "functions": [],
-          "variables": {
-            "defaultVirtualNetworkDiagnosticsLogs": [],
-            "defaultVirtualNetworkDiagnosticsMetrics": [
-              {
-                "category": "AllMetrics",
-                "enabled": true
-              }
-            ],
-            "defaultSubnetServiceEndpoints": [
-              {
-                "service": "Microsoft.Storage"
-              }
-            ],
-            "defaultNetworkSecurityGroupRules": [
-              {
-                "name": "allow_ssh",
-                "properties": {
-                  "description": "Allow SSH access from anywhere",
-                  "access": "Allow",
-                  "priority": 100,
-                  "protocol": "Tcp",
-                  "direction": "Inbound",
-                  "sourcePortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationPortRange": "22",
-                  "destinationAddressPrefix": "*"
-                }
-              },
-              {
-                "name": "allow_rdp",
-                "properties": {
-                  "description": "Allow RDP access from anywhere",
-                  "access": "Allow",
-                  "priority": 200,
-                  "protocol": "Tcp",
-                  "direction": "Inbound",
-                  "sourcePortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationPortRange": "3389",
-                  "destinationAddressPrefix": "*"
-                }
-              }
-            ]
-          },
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
@@ -4003,7 +4285,19 @@
                     "value": "[parameters('tags')]"
                   },
                   "securityRules": {
-                    "value": "[if(empty(parameters('networkSecurityGroupRules')), variables('defaultNetworkSecurityGroupRules'), parameters('networkSecurityGroupRules'))]"
+                    "value": "[parameters('networkSecurityGroupRules')]"
+                  },
+                  "logAnalyticsWorkspaceResourceId": {
+                    "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
+                  },
+                  "logStorageAccountResourceId": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
+                  },
+                  "logs": {
+                    "value": "[parameters('networkSecurityGroupDiagnosticsLogs')]"
+                  },
+                  "metrics": {
+                    "value": "[parameters('networkSecurityGroupDiagnosticsMetrics')]"
                   }
                 },
                 "template": {
@@ -4013,7 +4307,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "9304664949671097450"
+                      "templateHash": "4497555273030729522"
                     }
                   },
                   "parameters": {
@@ -4029,6 +4323,18 @@
                     },
                     "securityRules": {
                       "type": "array"
+                    },
+                    "logStorageAccountResourceId": {
+                      "type": "string"
+                    },
+                    "logAnalyticsWorkspaceResourceId": {
+                      "type": "string"
+                    },
+                    "logs": {
+                      "type": "array"
+                    },
+                    "metrics": {
+                      "type": "array"
                     }
                   },
                   "functions": [],
@@ -4042,6 +4348,21 @@
                       "properties": {
                         "securityRules": "[parameters('securityRules')]"
                       }
+                    },
+                    {
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2017-05-01-preview",
+                      "scope": "[format('Microsoft.Network/networkSecurityGroups/{0}', parameters('name'))]",
+                      "name": "[format('{0}-diagnostics', parameters('name'))]",
+                      "properties": {
+                        "storageAccountId": "[parameters('logStorageAccountResourceId')]",
+                        "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
+                        "logs": "[parameters('logs')]",
+                        "metrics": "[parameters('metrics')]"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                      ]
                     }
                   ],
                   "outputs": {
@@ -4055,7 +4376,10 @@
                     }
                   }
                 }
-              }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'logStorage')]"
+              ]
             },
             {
               "type": "Microsoft.Resources/deployments",
@@ -4180,12 +4504,6 @@
                   "addressPrefix": {
                     "value": "[parameters('virtualNetworkAddressPrefix')]"
                   },
-                  "diagnosticsLogs": {
-                    "value": "[if(empty(parameters('virtualNetworkDiagnosticsLogs')), variables('defaultVirtualNetworkDiagnosticsLogs'), parameters('virtualNetworkDiagnosticsLogs'))]"
-                  },
-                  "diagnosticsMetrics": {
-                    "value": "[if(empty(parameters('virtualNetworkDiagnosticsMetrics')), variables('defaultVirtualNetworkDiagnosticsMetrics'), parameters('virtualNetworkDiagnosticsMetrics'))]"
-                  },
                   "subnets": {
                     "value": [
                       {
@@ -4198,7 +4516,7 @@
                           "routeTable": {
                             "id": "[reference(resourceId('Microsoft.Resources/deployments', 'routeTable'), '2020-06-01').outputs.id.value]"
                           },
-                          "serviceEndpoints": "[if(empty(parameters('subnetServiceEndpoints')), variables('defaultSubnetServiceEndpoints'), parameters('subnetServiceEndpoints'))]"
+                          "serviceEndpoints": "[parameters('subnetServiceEndpoints')]"
                         }
                       }
                     ]
@@ -4208,6 +4526,12 @@
                   },
                   "logStorageAccountResourceId": {
                     "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
+                  },
+                  "logs": {
+                    "value": "[parameters('virtualNetworkDiagnosticsLogs')]"
+                  },
+                  "metrics": {
+                    "value": "[parameters('virtualNetworkDiagnosticsMetrics')]"
                   }
                 },
                 "template": {
@@ -4217,7 +4541,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "14686239955820792027"
+                      "templateHash": "12119421388421560495"
                     }
                   },
                   "parameters": {
@@ -4243,10 +4567,10 @@
                     "subnets": {
                       "type": "array"
                     },
-                    "diagnosticsMetrics": {
+                    "logs": {
                       "type": "array"
                     },
-                    "diagnosticsLogs": {
+                    "metrics": {
                       "type": "array"
                     }
                   },
@@ -4275,8 +4599,8 @@
                       "properties": {
                         "storageAccountId": "[parameters('logStorageAccountResourceId')]",
                         "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
-                        "metrics": "[parameters('diagnosticsMetrics')]",
-                        "logs": "[parameters('diagnosticsLogs')]"
+                        "logs": "[parameters('logs')]",
+                        "metrics": "[parameters('metrics')]"
                       },
                       "dependsOn": [
                         "[resourceId('Microsoft.Network/virtualNetworks', parameters('name'))]"

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "18242851584802728088"
+      "templateHash": "6098859535836188364"
     }
   },
   "parameters": {
@@ -131,12 +131,7 @@
     },
     "hubNetworkSecurityGroupDiagnosticsMetrics": {
       "type": "array",
-      "defaultValue": [
-        {
-          "category": "AllMetrics",
-          "enabled": true
-        }
-      ]
+      "defaultValue": []
     },
     "hubSubnetServiceEndpoints": {
       "type": "array",

--- a/src/bicep/modules/firewall.bicep
+++ b/src/bicep/modules/firewall.bicep
@@ -15,6 +15,12 @@ param managementIpConfigurationPublicIPAddressResourceId string
 
 param firewallPolicyName string
 
+param logStorageAccountResourceId string
+param logAnalyticsWorkspaceResourceId string
+
+param logs array
+param metrics array
+
 resource firewallPolicy 'Microsoft.Network/firewallPolicies@2021-02-01' = {
   name: firewallPolicyName
   location: location
@@ -153,6 +159,17 @@ resource firewall 'Microsoft.Network/azureFirewalls@2021-02-01' = {
     sku: {
       tier: skuTier
     }
+  }
+}
+
+resource diagnostics 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = {
+  scope: firewall
+  name: '${firewall.name}-diagnostics'
+  properties: {
+    storageAccountId: logStorageAccountResourceId
+    workspaceId: logAnalyticsWorkspaceResourceId
+    logs: logs
+    metrics: metrics
   }
 }
 

--- a/src/bicep/modules/networkSecurityGroup.bicep
+++ b/src/bicep/modules/networkSecurityGroup.bicep
@@ -4,6 +4,12 @@ param tags object = {}
 
 param securityRules array
 
+param logStorageAccountResourceId string
+param logAnalyticsWorkspaceResourceId string
+
+param logs array
+param metrics array
+
 resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
   name: name
   location: location
@@ -11,6 +17,17 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2021-02-0
 
   properties: {
     securityRules: securityRules
+  }
+}
+
+resource diagnostics 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = {
+  scope: networkSecurityGroup
+  name: '${networkSecurityGroup.name}-diagnostics'
+  properties: {
+    storageAccountId: logStorageAccountResourceId
+    workspaceId: logAnalyticsWorkspaceResourceId
+    logs: logs
+    metrics: metrics
   }
 }
 

--- a/src/bicep/modules/publicIPAddress.bicep
+++ b/src/bicep/modules/publicIPAddress.bicep
@@ -6,6 +6,12 @@ param skuName string
 param publicIpAllocationMethod string
 param availabilityZones array
 
+param logStorageAccountResourceId string
+param logAnalyticsWorkspaceResourceId string
+
+param logs array
+param metrics array
+
 resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
   name: name
   location: location
@@ -20,6 +26,17 @@ resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
   }
 
   zones: availabilityZones
+}
+
+resource diagnostics 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = {
+  scope: publicIPAddress
+  name: '${publicIPAddress.name}-diagnostics'
+  properties: {
+    storageAccountId: logStorageAccountResourceId
+    workspaceId: logAnalyticsWorkspaceResourceId
+    logs: logs
+    metrics: metrics
+  }
 }
 
 output id string = publicIPAddress.id

--- a/src/bicep/modules/spokeNetwork.bicep
+++ b/src/bicep/modules/spokeNetwork.bicep
@@ -16,6 +16,9 @@ param virtualNetworkDiagnosticsMetrics array
 param networkSecurityGroupName string
 param networkSecurityGroupRules array
 
+param networkSecurityGroupDiagnosticsLogs array
+param networkSecurityGroupDiagnosticsMetrics array
+
 param subnetName string
 param subnetAddressPrefix string
 param subnetServiceEndpoints array
@@ -25,58 +28,6 @@ param routeTableRouteName string = 'default_route'
 param routeTableRouteAddressPrefix string = '0.0.0.0/0'
 param routeTableRouteNextHopIpAddress string = firewallPrivateIPAddress
 param routeTableRouteNextHopType string = 'VirtualAppliance'
-
-var defaultVirtualNetworkDiagnosticsLogs = [
-  // TODO: 'VMProtectionAlerts' is not supported in AzureUsGovernment
-  // {
-  //   category: 'VMProtectionAlerts'
-  //   enabled: true
-  // }
-]
-
-var defaultVirtualNetworkDiagnosticsMetrics = [
-  {
-    category: 'AllMetrics'
-    enabled: true
-  }
-]
-
-var defaultSubnetServiceEndpoints = [
-  {
-    service: 'Microsoft.Storage'
-  }
-]
-
-var defaultNetworkSecurityGroupRules = [
-  {
-    name: 'allow_ssh'
-    properties: {
-      description: 'Allow SSH access from anywhere'
-      access: 'Allow'
-      priority: 100
-      protocol: 'Tcp'
-      direction: 'Inbound'
-      sourcePortRange: '*'
-      sourceAddressPrefix: '*'
-      destinationPortRange: '22'
-      destinationAddressPrefix: '*'
-    }
-  }
-  {
-    name: 'allow_rdp'
-    properties: {
-      description: 'Allow RDP access from anywhere'
-      access: 'Allow'
-      priority: 200
-      protocol: 'Tcp'
-      direction: 'Inbound'
-      sourcePortRange: '*'
-      sourceAddressPrefix: '*'
-      destinationPortRange: '3389'
-      destinationAddressPrefix: '*'
-    }
-  }
-]
 
 module logStorage './storageAccount.bicep' = {
   name: 'logStorage'
@@ -95,7 +46,13 @@ module networkSecurityGroup './networkSecurityGroup.bicep' = {
     location: location
     tags: tags
 
-    securityRules: empty(networkSecurityGroupRules) ? defaultNetworkSecurityGroupRules : networkSecurityGroupRules
+    securityRules: networkSecurityGroupRules
+    
+    logs: networkSecurityGroupDiagnosticsLogs
+    metrics: networkSecurityGroupDiagnosticsMetrics
+    
+    logAnalyticsWorkspaceResourceId: logAnalyticsWorkspaceResourceId
+    logStorageAccountResourceId: logStorage.outputs.id
   }
 }
 
@@ -122,9 +79,6 @@ module virtualNetwork './virtualNetwork.bicep' = {
 
     addressPrefix: virtualNetworkAddressPrefix
 
-    diagnosticsLogs: empty(virtualNetworkDiagnosticsLogs) ? defaultVirtualNetworkDiagnosticsLogs : virtualNetworkDiagnosticsLogs
-    diagnosticsMetrics: empty(virtualNetworkDiagnosticsMetrics) ? defaultVirtualNetworkDiagnosticsMetrics : virtualNetworkDiagnosticsMetrics
-
     subnets: [
       {
         name: subnetName
@@ -136,10 +90,13 @@ module virtualNetwork './virtualNetwork.bicep' = {
           routeTable: {
             id: routeTable.outputs.id
           }
-          serviceEndpoints: empty(subnetServiceEndpoints) ? defaultSubnetServiceEndpoints : subnetServiceEndpoints
+          serviceEndpoints: subnetServiceEndpoints
         }
       }
     ]
+
+    logs: virtualNetworkDiagnosticsLogs
+    metrics: virtualNetworkDiagnosticsMetrics
 
     logAnalyticsWorkspaceResourceId: logAnalyticsWorkspaceResourceId
     logStorageAccountResourceId: logStorage.outputs.id

--- a/src/bicep/modules/spokeNetwork.bicep
+++ b/src/bicep/modules/spokeNetwork.bicep
@@ -48,11 +48,11 @@ module networkSecurityGroup './networkSecurityGroup.bicep' = {
 
     securityRules: networkSecurityGroupRules
     
-    logs: networkSecurityGroupDiagnosticsLogs
-    metrics: networkSecurityGroupDiagnosticsMetrics
-    
     logAnalyticsWorkspaceResourceId: logAnalyticsWorkspaceResourceId
     logStorageAccountResourceId: logStorage.outputs.id
+
+    logs: networkSecurityGroupDiagnosticsLogs
+    metrics: networkSecurityGroupDiagnosticsMetrics
   }
 }
 
@@ -95,11 +95,11 @@ module virtualNetwork './virtualNetwork.bicep' = {
       }
     ]
 
-    logs: virtualNetworkDiagnosticsLogs
-    metrics: virtualNetworkDiagnosticsMetrics
-
     logAnalyticsWorkspaceResourceId: logAnalyticsWorkspaceResourceId
     logStorageAccountResourceId: logStorage.outputs.id
+
+    logs: virtualNetworkDiagnosticsLogs
+    metrics: virtualNetworkDiagnosticsMetrics
   }
 }
 

--- a/src/bicep/modules/virtualNetwork.bicep
+++ b/src/bicep/modules/virtualNetwork.bicep
@@ -7,9 +7,8 @@ param logAnalyticsWorkspaceResourceId string
 param logStorageAccountResourceId string
 param subnets array
 
-param diagnosticsMetrics array
-
-param diagnosticsLogs array
+param logs array
+param metrics array
 
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
   name: name
@@ -32,8 +31,8 @@ resource diagnostics 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' 
   properties: {
     storageAccountId: logStorageAccountResourceId
     workspaceId: logAnalyticsWorkspaceResourceId
-    metrics: diagnosticsMetrics
-    logs: diagnosticsLogs
+    logs: logs
+    metrics: metrics
   }
 }
 


### PR DESCRIPTION
# Description

Defaults the diagnostic logs and metrics settings for these resources:

Azure Firewall
- AzureFirewallApplicationRule
- AzureFirewallNetworkRule
- AzureFirewallDnsProxy
- AllMetrics

Public IP Address
- DDoSProtectionNotifications
- DDoSMitigationFlowLogs
- DDoSMitigationReports
- AllMetrics

Network Security Group
- NetworkSecurityGroupEvent
- NetworkSecurityGroupRuleCounter

Virtual Network
- AllMetrics

## Demo

To demo this, deploy MLZ as you usually would with `az deployment sub create`. 

You can visually see these diagnostic settings by selecting "Diagnostic Settings" from any of the resource groups. For example, here's a Hub Resource Group Diagnostic Settings blade:

![image](https://user-images.githubusercontent.com/4622125/138153323-646c2f99-41ed-4b07-9f3d-6a798ca00bf4.png)

## Issue reference

The issue this PR will close: #465 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
