### PR TITLE
remove virtual network diagnostics from Terraform

### DIFF
--- a/src/terraform/modules/virtual-network/main.tf
+++ b/src/terraform/modules/virtual-network/main.tf
@@ -26,10 +26,3 @@ resource "azurerm_storage_account" "loganalytics" {
   enable_https_traffic_only = true
   tags                      = var.tags
 }
-
-resource "azurerm_monitor_diagnostic_setting" "vnet" {
-  name                       = "${var.vnet_name}-vn-diagnostics"
-  target_resource_id         = azurerm_virtual_network.vnet.id
-  storage_account_id         = azurerm_storage_account.loganalytics.id
-  log_analytics_workspace_id = var.log_analytics_workspace_resource_id
-}

--- a/src/terraform/modules/virtual-network/main.tf
+++ b/src/terraform/modules/virtual-network/main.tf
@@ -32,12 +32,4 @@ resource "azurerm_monitor_diagnostic_setting" "vnet" {
   target_resource_id         = azurerm_virtual_network.vnet.id
   storage_account_id         = azurerm_storage_account.loganalytics.id
   log_analytics_workspace_id = var.log_analytics_workspace_resource_id
-
-  metric {
-    category = "AllMetrics"
-
-    retention_policy {
-      enabled = false
-    }
-  }
 }


### PR DESCRIPTION
# Description

Remove the virtual network 'AllMetrics' diagnostic setting from the Terraform deployment since it does not add value out-of-the-box but can be enabled any time by a user post-deployment.

## Issue reference

The issue this PR will close: #474

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
