### PR TITLE
disable CI trigger on credscan and policheck

### DIFF
--- a/.azure-devops/cred-poli-scan.yml
+++ b/.azure-devops/cred-poli-scan.yml
@@ -1,6 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# disable CI per:
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#disabling-the-ci-trigger
+trigger: none
+
+# pull request validation
 pr:
 - main
 


### PR DESCRIPTION
# Description

The pipeline was being executed for all branches and all changes. This change disables that CI trigger while maintaining the PR validation trigger.

docs here: https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#pr-triggers

## Issue reference

The issue this PR will close: #491 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
