### PR TITLE
Enabling Azure Firewall premium in usgovernment

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ All network traffic is directed through the firewall residing in the Network Hub
 |-------------|--------------|-----------------|-----------------|
 |default_route| 0.0.0.0/0    |Virtual Appliance|10.0.100.4       |
 
-The default firewall conigured for MLZ is [Azure Firewall Premium](https://docs.microsoft.com/en-us/azure/firewall/premium-features) to allow for enhanced security posturing.  
-Presently, there are two firewall rules configured to ensure access to the Azure Portal and to facilitate interactive logon via PowerShell and Azure CLI, all other traffic is restricted by default. Below are the collection of rules configured for Azure public cloud:
+The default firewall configured for MLZ is [Azure Firewall Premium](https://docs.microsoft.com/en-us/azure/firewall/premium-features) for both Azure Commercial and Azure Government to allow for enhanced security posturing.  
+Presently, there are two firewall rules configured to ensure access to the Azure Portal and to facilitate interactive logon via PowerShell and Azure CLI, all other traffic is restricted by default. Below are the collection of rules configured for Azure Commercial and Azure Government clouds:
 
 |Rule Collection Priority | Rule Collection Name | Rule name | Source | Port     | Protocol                               |
 |-------------------------|----------------------|-----------|--------|----------|----------------------------------------|

--- a/src/terraform/mlz/main.tf
+++ b/src/terraform/mlz/main.tf
@@ -113,7 +113,7 @@ data "azurerm_client_config" "current_client" {
 ################################
 
 locals {
-  firewall_premium_environments = ["public"] # terraform azurerm environments where Azure Firewall Premium is supported
+  firewall_premium_environments = ["public", "usgovernment"] # terraform azurerm environments where Azure Firewall Premium is supported
 }
 
 ################################


### PR DESCRIPTION
# Description
Small change to enable azure firewall premium on usgovernment and public by default.
Update documentation to reflect this new change.

This configuration was tested in Azure Commercial and Government (usgovvirginia)

## Issue reference

NA

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [X] All acceptance criteria in the backlog item are met
* [X] The documentation is updated to cover any new or changed features
* [X] Manual tests have passed
* [X] Relevant issues are linked to this PR
