### PR TITLE
use Bicep loop syntax to create spoke resources the same way

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -46,6 +46,7 @@ To include one of the built in Azure policy initiatives for NIST 800-53, CMMC Le
 az deployment sub create \
   --location eastus \
   --template-file mlz.bicep \
+  --parameters deployPolicy=true \
   --parameters policy=<one of 'CMMC', 'IL5', or 'NIST'>
 ```
 
@@ -87,19 +88,19 @@ Example parameters file snippet:
 
 ```arm
 {
-    "listOfMembersToExcludeFromWindowsVMAdministratorsGroup": 
+    "listOfMembersToExcludeFromWindowsVMAdministratorsGroup":
     {
       "value": "admin"
     },
-    "listOfMembersToIncludeInWindowsVMAdministratorsGroup": 
+    "listOfMembersToIncludeInWindowsVMAdministratorsGroup":
     {
       "value": "azureuser"
     },
-    "logAnalyticsWorkspaceIdforVMReporting": 
+    "logAnalyticsWorkspaceIdforVMReporting":
     {
       "value": ${jsonencode(laws_instance_id)}
     },
-    "IncludeArcMachines": 
+    "IncludeArcMachines":
     {
         "value": "true"
     }

--- a/src/bicep/README.md
+++ b/src/bicep/README.md
@@ -260,7 +260,7 @@ Before giving this a try, it's probably a good idea to [review the Azure CLI's d
 
 First off, let's say you deployed Mission Landing Zone with a deployment name of `myMissionLandingZone`:
 
-```azcli
+```plaintext
 az deployment sub create \
   --name "myMissionLandingZone" \
   --location "East US" \
@@ -269,7 +269,7 @@ az deployment sub create \
 
 Once it's complete, you could see all the resources provisioned by that deployment querying the `properties.outputResources` property:
 
-```azcli
+```plaintext
 az deployment sub show \
   --name "myMissionLandingZone" \
   --query "properties.outputResources"
@@ -277,7 +277,7 @@ az deployment sub show \
 
 That's a lot of resources. Thankfully, the template produces outputs for just the things you probably need at `properties.outputs`:
 
-```azcli
+```plaintext
 az deployment sub show \
   --name "myMissionLandingZone" \
   --query "properties.outputs"
@@ -285,7 +285,7 @@ az deployment sub show \
 
 For example, if you need just the Firewall Private IP address you could retrieve it like this:
 
-```azcli
+```plaintext
 az deployment sub show \
   --name "myMissionLandingZone" \
   --query "properties.outputs.firewallPrivateIPAddress.value"
@@ -293,7 +293,7 @@ az deployment sub show \
 
 Or, if you need just the Log Analytics Workspace that performs central logging you could retrieve it like this:
 
-```azcli
+```plaintext
 az deployment sub show \
   --name "myMissionLandingZone" \
   --query "properties.outputs.logAnalyticsWorkspaceResourceId.value"
@@ -301,7 +301,7 @@ az deployment sub show \
 
 Or, say you wanted to deploy resources into the Identity spoke. You could retrieve information about the Identity spoke by querying it from the `properties.outputs.spokes` array like this:
 
-```azcli
+```plaintext
 az deployment sub show \
   --name "myMissionLandingZone" \
   --query "properties.outputs.spokes.value[?name=='identity']"

--- a/src/bicep/README.md
+++ b/src/bicep/README.md
@@ -27,6 +27,10 @@ By default, this template deploys **[Azure Firewall Premium](https://docs.micros
 - See [Setting the Firewall SKU](#Setting-the-Firewall-SKU) for steps on how to use the Standard SKU instead.
 - See [Setting the Firewall Location](#Setting-the-Firewall-Location) for steps on how to deploy into a different region.
 
+After a deployment is complete, you can refer to the provisioned resources programmaticaly with the Azure CLI.
+
+- See [Reference Deployment Output](#Reference-Deployment-Output) for steps on how to use `az deployment` subcommands and JMESPath to query for specific properties.
+
 ### Azure CLI
 
 Use `az deployment sub` to deploy MLZ across 1:M subscriptions (and `az deployment sub create --help` for more information).
@@ -245,6 +249,88 @@ az deployment sub create \
   --location "South Central US" \
   --template-file "src/bicep/mlz.bicep"
 ```
+
+### Reference Deployment Output
+
+After you've deployed Mission Landing Zone you'll probably want to integrate additional services or infrastructure.
+
+Once Mission Landing Zone is deployed and you're ready to start plugging things in, you can use the `az deployment sub show` command with a `--query` argument to retrieve information about the resources you deployed.
+
+Before giving this a try, it's probably a good idea to [review the Azure CLI's documentation on querying with JMESPath](https://docs.microsoft.com/en-us/cli/azure/query-azure-cli).
+
+First off, let's say you deployed Mission Landing Zone with a deployment name of `myMissionLandingZone`:
+
+```azcli
+az deployment sub create \
+  --name "myMissionLandingZone" \
+  --location "East US" \
+  --template-file "src/bicep/mlz.bicep"
+```
+
+Once it's complete, you could see all the resources provisioned by that deployment querying the `properties.outputResources` property:
+
+```azcli
+az deployment sub show \
+  --name "myMissionLandingZone" \
+  --query "properties.outputResources"
+```
+
+That's a lot of resources. Thankfully, the template produces outputs for just the things you probably need at `properties.outputs`:
+
+```azcli
+az deployment sub show \
+  --name "myMissionLandingZone" \
+  --query "properties.outputs"
+```
+
+For example, if you need just the Firewall Private IP address you could retrieve it like this:
+
+```azcli
+az deployment sub show \
+  --name "myMissionLandingZone" \
+  --query "properties.outputs.firewallPrivateIPAddress.value"
+```
+
+Or, if you need just the Log Analytics Workspace that performs central logging you could retrieve it like this:
+
+```azcli
+az deployment sub show \
+  --name "myMissionLandingZone" \
+  --query "properties.outputs.logAnalyticsWorkspaceResourceId.value"
+```
+
+Or, say you wanted to deploy resources into the Identity spoke. You could retrieve information about the Identity spoke by querying it from the `properties.outputs.spokes` array like this:
+
+```azcli
+az deployment sub show \
+  --name "myMissionLandingZone" \
+  --query "properties.outputs.spokes.value[?name=='identity']"
+```
+
+Which would return an output similar to:
+
+```json
+[
+  {
+    "name": "identity",
+    "networkSecurityGroupName": "identity-nsg",
+    "networkSecurityGroupResourceId": ".../providers/Microsoft.Network/networkSecurityGroups/identity-nsg",
+    "resourceGroupId": ".../resourceGroups/mlz-identity",
+    "resourceGroupName": "mlz-identity",
+    "subnetAddressPrefix": "10.0.110.0/27",
+    "subnetName": "identity-subnet",
+    "subscriptionId": "<A GUID>",
+    "virtualNetworkName": "identity-vnet",
+    "virtualNetworkResourceId": ".../providers/Microsoft.Network/virtualNetworks/identity-vnet"
+  }
+]
+```
+
+Bicep templates paired with the Azure CLI and JMESpath queries allow you to build flexible infrastructure that can build on-top of each other in an automated fashion, passing output from one template as input to another.
+
+Read more about `az deployment` at: [https://docs.microsoft.com](https://docs.microsoft.com/en-us/cli/azure/deployment?view=azure-cli-latest)
+
+Read more about JMESPath queries at: <https://jmespath.org/>
 
 ## Development Pre-requisites
 

--- a/src/bicep/README.md
+++ b/src/bicep/README.md
@@ -254,9 +254,9 @@ az deployment sub create \
 
 After you've deployed Mission Landing Zone you'll probably want to integrate additional services or infrastructure.
 
-Once Mission Landing Zone is deployed and you're ready to start plugging things in, you can use the `az deployment sub show` command with a `--query` argument to retrieve information about the resources you deployed.
+You can use the `az deployment sub show` command with a `--query` argument to retrieve information about the resources you deployed.
 
-Before giving this a try, it's probably a good idea to [review the Azure CLI's documentation on querying with JMESPath](https://docs.microsoft.com/en-us/cli/azure/query-azure-cli).
+Before giving the next steps a try, it's probably a good idea to [review the Azure CLI's documentation on querying with JMESPath](https://docs.microsoft.com/en-us/cli/azure/query-azure-cli).
 
 First off, let's say you deployed Mission Landing Zone with a deployment name of `myMissionLandingZone`:
 
@@ -267,7 +267,7 @@ az deployment sub create \
   --template-file "src/bicep/mlz.bicep"
 ```
 
-Once it's complete, you could see all the resources provisioned by that deployment querying the `properties.outputResources` property:
+Once it's complete, you could see all the resources provisioned in that deployment by querying the `properties.outputResources` property:
 
 ```plaintext
 az deployment sub show \
@@ -275,7 +275,7 @@ az deployment sub show \
   --query "properties.outputResources"
 ```
 
-That's a lot of resources. Thankfully, the template produces outputs for just the things you probably need at `properties.outputs`:
+That's a lot of resources. Thankfully, the template produces outputs for just the things you _probably_ need at `properties.outputs`:
 
 ```plaintext
 az deployment sub show \
@@ -326,7 +326,7 @@ Which would return an output similar to:
 ]
 ```
 
-Bicep templates paired with the Azure CLI and JMESpath queries allow you to build flexible infrastructure that can build on-top of each other in an automated fashion, passing output from one template as input to another.
+Bicep templates, the Azure CLI, and JMESpath queries allows you to manually, or in an automated fashion, compose infrastructure incrementally and pass output from one template as input to another.
 
 Read more about `az deployment` at: [https://docs.microsoft.com](https://docs.microsoft.com/en-us/cli/azure/deployment?view=azure-cli-latest)
 

--- a/src/bicep/examples/newWorkload/README.md
+++ b/src/bicep/examples/newWorkload/README.md
@@ -48,45 +48,28 @@ az deployment sub show \
 
 ```plaintext
 {
-  "hubSubscriptionId": {
+  "firewallPrivateIPAddress": {
     "type": "String",
-    "value": "0987654-3210..."
+    "value": "10.0.100.4"
   },
-  ...
-  "hubResourceGroupName": {
-    "type": "String",
-    "value": "mlz-dev-hub"
+  "hub": {
+    "type": "Object",
+    "value": {
+      ...
+      "resourceGroupName": "mlz-dev-hub",
+      ...
+      "subscriptionId": "...",
+      "virtualNetworkName": "hub-vnet",
+      "virtualNetworkResourceId": "/subscriptions/.../providers/Microsoft.Network/virtualNetworks/hub-vnet"
+    }
   },
-  ...
-  "hubVirtualNetworkName": {
-    "type": "String",
-    "value": "hub-vnet"
-  },
-  ...
-  "hubVirtualNetworkId": {
-    "type": "String",
-    "value": "/subscriptions/.../providers/Microsoft.Network/virtualNetworks/hub-vnet"
-  },
-  ...
   "logAnalyticsWorkspaceResourceId": {
     "type": "String",
     "value": "/subscriptions/.../providers/Microsoft.OperationalInsights/workspaces/mlz-dev-laws"
   },
   ...
-  "firewallPrivateIPAddress": {
-    "type": "String",
-    "value": "10.0.100.4"
-  },
 }
 ```
-
-...and if you're on a BASH terminal, this command (take note to replace "myMlzDeployment" with your deployment name) will export the values as environment variables:
-
-<!-- markdownlint-disable MD013 -->
-```bash
-export $(az deployment sub show --name "myMlzDeployment" --query "properties.outputs.{ args: [ join('', ['hubSubscriptionId=', hubSubscriptionId.value]), join('', ['hubResourceGroupName=', hubResourceGroupName.value]), join('', ['hubVirtualNetworkName=', hubVirtualNetworkName.value]), join('', ['hubVirtualNetworkResourceId=', hubVirtualNetworkResourceId.value]), join('', ['logAnalyticsWorkspaceResourceId=', logAnalyticsWorkspaceResourceId.value]), join('', ['firewallPrivateIPAddress=', firewallPrivateIPAddress.value]) ] }.args" --output tsv | xargs)
-```
-<!-- markdownlint-enable MD013 -->
 
 ## Deploy the example
 

--- a/src/bicep/examples/remoteAccess/README.md
+++ b/src/bicep/examples/remoteAccess/README.md
@@ -55,40 +55,26 @@ az deployment sub show \
 ```plaintext
 {
   ...
-  "hubResourceGroupName": {
-    "type": "String",
-    "value": "mlz-dev-hub"
+  "hub": {
+    "type": "Object",
+    "value": {
+      ...
+      "resourceGroupName": "mlz-dev-hub",
+      ...
+      "networkSecurityGroupResourceId": "/subscriptions/.../providers/Microsoft.Network/networkSecurityGroups/hub-nsg
+      ...
+      "subnetResourceId": "/subscriptions/.../providers/Microsoft.Network/virtualNetworks/hub-vnet/subnets/hub-subnet",
+      ...
+      "virtualNetworkName": "hub-vnet"
+    }
   },
-  ...
-  "hubVirtualNetworkName": {
-    "type": "String",
-    "value": "hub-vnet"
-  },
-  ...
-  "hubSubnetResourceId": {
-    "type": "String",
-    "value": "/subscriptions/.../providers/Microsoft.Network/virtualNetworks/hub-vnet/subnets/hub-subnet"
-  },
-  ...
-  "hubNetworkSecurityGroupResourceId": {
-    "type": "String",
-    "value": "/subscriptions/.../providers/Microsoft.Network/networkSecurityGroups/hub-nsg"
-  },
-  ...
   "logAnalyticsWorkspaceResourceId": {
     "type": "String",
     "value": "/subscriptions/.../providers/Microsoft.OperationalInsights/workspaces/mlz-dev-laws"
   },
+  ...
 }
 ```
-
-...and if you're on a BASH terminal, this command (take note to replace "myMlzDeployment" with your deployment name) will export the values as environment variables:
-
-<!-- markdownlint-disable MD013 -->
-```bash
-export $(az deployment sub show --name "myMlzDeployment" --query "properties.outputs.{ args: [ join('', ['hubResourceGroupName=', hubResourceGroupName.value]), join('', ['hubVirtualNetworkName=', hubVirtualNetworkName.value]), join('', ['hubSubnetResourceId=', hubSubnetResourceId.value]), join('', ['hubNetworkSecurityGroupResourceId=', hubNetworkSecurityGroupResourceId.value]), join('', ['logAnalyticsWorkspaceResourceId=', logAnalyticsWorkspaceResourceId.value]) ] }.args" --output tsv | xargs)
-```
-<!-- markdownlint-enable MD013 -->
 
 ## Deploy the example
 

--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -102,7 +102,7 @@ module hubNetwork './modules/hubNetwork.bicep' = {
 
 module spokeNetworks './modules/spokeNetwork.bicep' = [ for spoke in spokes: {
   name: 'deploy-vnet-${spoke.type}-${nowUtc}'
-  scope: resourceGroup(spoke.subscription, spoke.resourceGroupName)
+  scope: resourceGroup(spoke.subscriptionId, spoke.resourceGroupName)
   params: {
     location: spoke.location
     tags: tags
@@ -134,13 +134,12 @@ module spokeNetworks './modules/spokeNetwork.bicep' = [ for spoke in spokes: {
 
 module hubVirtualNetworkPeerings './modules/hubNetworkPeerings.bicep' = {
   name: 'deploy-vnet-peerings-hub-${nowUtc}'
-  scope: subscription(hubSubscriptionId)
+  scope: resourceGroup(hubSubscriptionId, hubResourceGroupName)
   params: {
-    hubResourceGroupName: hubResourceGroupName
     hubVirtualNetworkName: hubNetwork.outputs.virtualNetworkName
-    spokeNetworks: [ for (spoke, i) in spokes: {
+    spokes: [ for (spoke, i) in spokes: {
       type: spoke.type
-      name: spokeNetworks[i].outputs.virtualNetworkName
+      virtualNetworkName: spokeNetworks[i].outputs.virtualNetworkName
       virtualNetworkResourceId: spokeNetworks[i].outputs.virtualNetworkResourceId
     }]
   }
@@ -150,6 +149,7 @@ module spokeVirtualNetworkPeerings './modules/spokeNetworkPeering.bicep' = [ for
   name: 'deploy-vnet-peerings-${spoke.type}-${nowUtc}'
   scope: subscription(spoke.subscriptionId)
   params: {
+    spokeType: spoke.type
     spokeResourceGroupName: spoke.resourceGroupName
     spokeVirtualNetworkName: spokeNetworks[i].outputs.virtualNetworkName
     hubVirtualNetworkName: hubNetwork.outputs.virtualNetworkName

--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -190,6 +190,9 @@ module hubSubscriptionActivityLogging './modules/centralLogging.bicep' = {
     diagnosticSettingName: 'log-hub-sub-activity-to-${logAnalyticsWorkspace.outputs.name}'
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.outputs.id
   }
+  dependsOn: [
+    hubNetwork
+  ]
 }
 
 module spokeSubscriptionActivityLogging './modules/centralLogging.bicep' = [ for spoke in spokes: if(spoke.subscriptionId != hubSubscriptionId) {
@@ -199,6 +202,9 @@ module spokeSubscriptionActivityLogging './modules/centralLogging.bicep' = [ for
     diagnosticSettingName: 'log-${spoke.type}-sub-activity-to-${logAnalyticsWorkspace.outputs.name}'
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.outputs.id
   }
+  dependsOn: [
+    spokeNetworks
+  ]
 }]
 
 //// log analytics workspace diagnostic logging
@@ -211,6 +217,10 @@ module logAnalyticsDiagnosticLogging './modules/logAnalyticsDiagnosticLogging.bi
     logAnalyticsWorkspaceName: logAnalyticsWorkspace.outputs.name
     enableDiagnostics: true
   }
+  dependsOn: [
+    hubNetwork
+    spokeNetworks
+  ]
 }
 
 // security center per subscription if different per hub/spoke
@@ -606,51 +616,51 @@ var spokes = [
 
 // outputs
 
-// output hubSubscriptionId string = hubSubscriptionId
-// output hubResourceGroupName string = hubResourceGroup.outputs.name
-// output hubResourceGroupResourceId string = hubResourceGroup.outputs.id
-// output hubVirtualNetworkName string = hub.outputs.virtualNetworkName
-// output hubVirtualNetworkResourceId string = hub.outputs.virtualNetworkResourceId
-// output hubSubnetName string = hub.outputs.subnetName
-// output hubSubnetResourceId string = hub.outputs.subnetResourceId
-// output hubSubnetAddressPrefix string = hub.outputs.subnetAddressPrefix
-// output hubNetworkSecurityGroupName string = hub.outputs.networkSecurityGroupName
-// output hubNetworkSecurityGroupResourceId string = hub.outputs.networkSecurityGroupResourceId
-// output hubFirewallPrivateIPAddress string = hub.outputs.firewallPrivateIPAddress
+output hubSubscriptionId string = hubSubscriptionId
+output hubResourceGroupName string = hubResourceGroup.outputs.name
+output hubResourceGroupResourceId string = hubResourceGroup.outputs.id
+output hubVirtualNetworkName string = hubVirtualNetworkName
+output hubVirtualNetworkResourceId string = hubNetwork.outputs.virtualNetworkResourceId
+output hubSubnetName string = hubNetwork.outputs.subnetName
+output hubSubnetResourceId string = hubNetwork.outputs.subnetResourceId
+output hubSubnetAddressPrefix string = hubNetwork.outputs.subnetAddressPrefix
+output hubNetworkSecurityGroupName string = hubNetwork.outputs.networkSecurityGroupName
+output hubNetworkSecurityGroupResourceId string = hubNetwork.outputs.networkSecurityGroupResourceId
+output hubFirewallPrivateIPAddress string = hubNetwork.outputs.firewallPrivateIPAddress
 
-// output logAnalyticsWorkspaceName string = logAnalyticsWorkspace.outputs.name
-// output logAnalyticsWorkspaceResourceId string = logAnalyticsWorkspace.outputs.id
-// output firewallPrivateIPAddress string = hub.outputs.firewallPrivateIPAddress
+output logAnalyticsWorkspaceName string = logAnalyticsWorkspace.outputs.name
+output logAnalyticsWorkspaceResourceId string = logAnalyticsWorkspace.outputs.id
+output firewallPrivateIPAddress string = hubNetwork.outputs.firewallPrivateIPAddress
 
-// output identitySubscriptionId string = identitySubscriptionId
-// output identityResourceGroupName string = identityResourceGroup.outputs.name
-// output identityResourceGroupResourceId string = identityResourceGroup.outputs.id
-// output identityVirtualNetworkName string = identity.outputs.virtualNetworkName
-// output identityVirtualNetworkResourceId string = identity.outputs.virtualNetworkResourceId
-// output identitySubnetName string = identity.outputs.subnetName
-// output identitySubnetResourceId string = identity.outputs.subnetResourceId
-// output identitySubnetAddressPrefix string = identity.outputs.subnetAddressPrefix
-// output identityNetworkSecurityGroupName string = identity.outputs.networkSecurityGroupName
-// output identityNetworkSecurityGroupResourceId string = identity.outputs.networkSecurityGroupResourceId
+output identitySubscriptionId string = identitySubscriptionId
+output identityResourceGroupName string = identityResourceGroupName
+output identityResourceGroupResourceId string = resourceId(identitySubscriptionId, identityResourceGroupName, 'Microsoft.Resource/resourceGroups', identityResourceGroupName)
+output identityVirtualNetworkName string = identityVirtualNetworkName
+output identityVirtualNetworkResourceId string = resourceId(identitySubscriptionId, identityResourceGroupName, 'Microsoft.Network/virtualNetworks', identityVirtualNetworkName)
+output identitySubnetName string = identitySubnetName
+output identitySubnetResourceId string = resourceId(identitySubscriptionId, identityResourceGroupName, 'Microsoft.Network/Virtualnetworks/subnets', '${identityVirtualNetworkName}/${identitySubnetName}')
+output identitySubnetAddressPrefix string = identitySubnetAddressPrefix
+output identityNetworkSecurityGroupName string = identityNetworkSecurityGroupName
+output identityNetworkSecurityGroupResourceId string = resourceId(identitySubscriptionId, identityResourceGroupName, 'Microsoft.Network/networkSecurityGroups', identityNetworkSecurityGroupName)
 
-// output operationsSubscriptionId string = operationsSubscriptionId
-// output operationsResourceGroupName string = operationsResourceGroupName
-// output operationsResourceGroupResourceId string = operationsResourceGroup.outputs.id
-// output operationsVirtualNetworkName string = operations.outputs.virtualNetworkName
-// output operationsVirtualNetworkResourceId string = operations.outputs.virtualNetworkResourceId
-// output operationsSubnetName string = operations.outputs.subnetName
-// output operationsSubnetResourceId string = operations.outputs.subnetResourceId
-// output operationsSubnetAddressPrefix string = operations.outputs.subnetAddressPrefix
-// output operationsNetworkSecurityGroupName string = operations.outputs.networkSecurityGroupName
-// output operationsNetworkSecurityGroupResourceId string = operations.outputs.networkSecurityGroupResourceId
+output operationsSubscriptionId string = operationsSubscriptionId
+output operationsResourceGroupName string = operationsResourceGroupName
+output operationsResourceGroupResourceId string = resourceId(operationsSubscriptionId, operationsResourceGroupName, 'Microsoft.Resource/resourceGroups', operationsResourceGroupName)
+output operationsVirtualNetworkName string = operationsVirtualNetworkName
+output operationsVirtualNetworkResourceId string = resourceId(operationsSubscriptionId, operationsResourceGroupName, 'Microsoft.Network/virtualNetworks', operationsVirtualNetworkName)
+output operationsSubnetName string = operationsSubnetName
+output operationsSubnetResourceId string = resourceId(operationsSubscriptionId, operationsResourceGroupName, 'Microsoft.Network/Virtualnetworks/subnets', '${operationsVirtualNetworkName}/${operationsSubnetName}')
+output operationsSubnetAddressPrefix string = operationsSubnetAddressPrefix
+output operationsNetworkSecurityGroupName string = operationsNetworkSecurityGroupName
+output operationsNetworkSecurityGroupResourceId string = resourceId(operationsSubscriptionId, operationsResourceGroupName, 'Microsoft.Network/networkSecurityGroups', operationsNetworkSecurityGroupName)
 
-// output sharedServicesSubscriptionId string = sharedServicesSubscriptionId
-// output sharedServicesResourceGroupName string = sharedServicesResourceGroup.outputs.name
-// output sharedServicesResourceGroupResourceId string = sharedServicesResourceGroup.outputs.id
-// output sharedServicesVirtualNetworkName string = sharedServices.outputs.virtualNetworkName
-// output sharedServicesVirtualNetworkResourceId string = sharedServices.outputs.virtualNetworkResourceId
-// output sharedServicesSubnetName string = sharedServices.outputs.subnetName
-// output sharedServicesSubnetResourceId string = sharedServices.outputs.subnetResourceId
-// output sharedServicesSubnetAddressPrefix string = sharedServices.outputs.subnetAddressPrefix
-// output sharedServicesNetworkSecurityGroupName string = sharedServices.outputs.networkSecurityGroupName
-// output sharedServicesNetworkSecurityGroupResourceId string = sharedServices.outputs.networkSecurityGroupResourceId
+output sharedServicesSubscriptionId string = sharedServicesSubscriptionId
+output sharedServicesResourceGroupName string = sharedServicesResourceGroupName
+output sharedServicesResourceGroupResourceId string = resourceId(sharedServicesSubscriptionId, sharedServicesResourceGroupName, 'Microsoft.Resource/resourceGroups', sharedServicesResourceGroupName)
+output sharedServicesVirtualNetworkName string = sharedServicesVirtualNetworkName
+output sharedServicesVirtualNetworkResourceId string = resourceId(sharedServicesSubscriptionId, sharedServicesResourceGroupName, 'Microsoft.Network/virtualNetworks', sharedServicesVirtualNetworkName)
+output sharedServicesSubnetName string = sharedServicesSubnetName
+output sharedServicesSubnetResourceId string = resourceId(sharedServicesSubscriptionId, sharedServicesResourceGroupName, 'Microsoft.Network/Virtualnetworks/subnets', '${sharedServicesVirtualNetworkName}/${sharedServicesSubnetName}')
+output sharedServicesSubnetAddressPrefix string = sharedServicesSubnetAddressPrefix
+output sharedServicesNetworkSecurityGroupName string = sharedServicesNetworkSecurityGroupName
+output sharedServicesNetworkSecurityGroupResourceId string = resourceId(sharedServicesSubscriptionId, sharedServicesResourceGroupName, 'Microsoft.Network/networkSecurityGroups', sharedServicesNetworkSecurityGroupName)

--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -616,6 +616,8 @@ var spokes = [
 
 // outputs
 
+output firewallPrivateIPAddress string = hubNetwork.outputs.firewallPrivateIPAddress
+
 output hub object = {
   subscriptionId: hubSubscriptionId
   resourceGroupName: hubResourceGroup.outputs.name
@@ -627,8 +629,11 @@ output hub object = {
   subnetAddressPrefix: hubNetwork.outputs.subnetAddressPrefix
   networkSecurityGroupName: hubNetwork.outputs.networkSecurityGroupName
   networkSecurityGroupResourceId: hubNetwork.outputs.networkSecurityGroupResourceId
-  firewallPrivateIPAddress: hubNetwork.outputs.firewallPrivateIPAddress
 }
+
+output logAnalyticsWorkspaceName string = logAnalyticsWorkspace.outputs.name
+
+output logAnalyticsWorkspaceResourceId string = logAnalyticsWorkspace.outputs.id
 
 output spokes array = [for (spoke, i) in spokes: {
   name: spoke.name
@@ -638,11 +643,8 @@ output spokes array = [for (spoke, i) in spokes: {
   virtualNetworkName: spokeNetworks[i].outputs.virtualNetworkName
   virtualNetworkResourceId: spokeNetworks[i].outputs.virtualNetworkResourceId
   subnetName: spokeNetworks[i].outputs.subnetName
+  subnetResourceId: spokeNetworks[i].outputs.subnetResourceId
   subnetAddressPrefix: spokeNetworks[i].outputs.subnetAddressPrefix
   networkSecurityGroupName: spokeNetworks[i].outputs.networkSecurityGroupName
   networkSecurityGroupResourceId: spokeNetworks[i].outputs.networkSecurityGroupResourceId
 }]
-
-output logAnalyticsWorkspaceName string = logAnalyticsWorkspace.outputs.name
-output logAnalyticsWorkspaceResourceId string = logAnalyticsWorkspace.outputs.id
-output firewallPrivateIPAddress string = hubNetwork.outputs.firewallPrivateIPAddress

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "17543931080454177897"
+      "templateHash": "15239738373058366803"
     }
   },
   "parameters": {
@@ -466,16 +466,19 @@
     },
     "policy": {
       "type": "string",
-      "defaultValue": "",
+      "defaultValue": "NIST",
       "metadata": {
-        "description": "Built-in policy assignments to assign, default is none. [NIST/IL5/CMMC] IL5 is only availalbe for GOV cloud and will switch to NIST if tried in AzureCloud."
+        "description": "[NIST/IL5/CMMC] Built-in policy assignments to assign, default is NIST. IL5 is only availalbe for GOV cloud and will switch to NIST if tried in AzureCloud."
       },
       "allowedValues": [
         "NIST",
         "IL5",
-        "CMMC",
-        ""
+        "CMMC"
       ]
+    },
+    "deployPolicy": {
+      "type": "bool",
+      "defaultValue": false
     },
     "emailSecurityContact": {
       "type": "string",
@@ -656,13 +659,72 @@
   "functions": [],
   "variables": {
     "firewallClientSubnetName": "AzureFirewallSubnet",
-    "firewallManagementSubnetName": "AzureFirewallManagementSubnet"
+    "firewallManagementSubnetName": "AzureFirewallManagementSubnet",
+    "spokes": [
+      {
+        "type": "operations",
+        "subscriptionId": "[parameters('operationsSubscriptionId')]",
+        "resourceGroupName": "[parameters('operationsResourceGroupName')]",
+        "location": "[parameters('operationsLocation')]",
+        "logStorageAccountName": "[parameters('operationsLogStorageAccountName')]",
+        "logStorageSkuName": "[parameters('operationsLogStorageSkuName')]",
+        "virtualNetworkName": "[parameters('operationsVirtualNetworkName')]",
+        "virtualNetworkAddressPrefix": "[parameters('operationsVirtualNetworkAddressPrefix')]",
+        "virtualNetworkDiagnosticsLogs": "[parameters('operationsVirtualNetworkDiagnosticsLogs')]",
+        "virtualNetworkDiagnosticsMetrics": "[parameters('operationsVirtualNetworkDiagnosticsMetrics')]",
+        "networkSecurityGroupName": "[parameters('operationsNetworkSecurityGroupName')]",
+        "networkSecurityGroupRules": "[parameters('operationsNetworkSecurityGroupRules')]",
+        "networkSecurityGroupDiagnosticsLogs": "[parameters('operationsNetworkSecurityGroupDiagnosticsLogs')]",
+        "networkSecurityGroupDiagnosticsMetrics": "[parameters('operationsNetworkSecurityGroupDiagnosticsMetrics')]",
+        "subnetName": "[parameters('operationsSubnetName')]",
+        "subnetAddressPrefix": "[parameters('operationsSubnetAddressPrefix')]",
+        "subnetServiceEndpoints": "[parameters('operationsSubnetServiceEndpoints')]"
+      },
+      {
+        "type": "identity",
+        "subscriptionId": "[parameters('identitySubscriptionId')]",
+        "resourceGroupName": "[parameters('identityResourceGroupName')]",
+        "location": "[parameters('identityLocation')]",
+        "logStorageAccountName": "[parameters('identityLogStorageAccountName')]",
+        "logStorageSkuName": "[parameters('identityLogStorageSkuName')]",
+        "virtualNetworkName": "[parameters('identityVirtualNetworkName')]",
+        "virtualNetworkAddressPrefix": "[parameters('identityVirtualNetworkAddressPrefix')]",
+        "virtualNetworkDiagnosticsLogs": "[parameters('identityVirtualNetworkDiagnosticsLogs')]",
+        "virtualNetworkDiagnosticsMetrics": "[parameters('identityVirtualNetworkDiagnosticsMetrics')]",
+        "networkSecurityGroupName": "[parameters('identityNetworkSecurityGroupName')]",
+        "networkSecurityGroupRules": "[parameters('identityNetworkSecurityGroupRules')]",
+        "networkSecurityGroupDiagnosticsLogs": "[parameters('identityNetworkSecurityGroupDiagnosticsLogs')]",
+        "networkSecurityGroupDiagnosticsMetrics": "[parameters('identityNetworkSecurityGroupDiagnosticsMetrics')]",
+        "subnetName": "[parameters('identitySubnetName')]",
+        "subnetAddressPrefix": "[parameters('identitySubnetAddressPrefix')]",
+        "subnetServiceEndpoints": "[parameters('identitySubnetServiceEndpoints')]"
+      },
+      {
+        "type": "sharedServices",
+        "subscriptionId": "[parameters('sharedServicesSubscriptionId')]",
+        "resourceGroupName": "[parameters('sharedServicesResourceGroupName')]",
+        "location": "[parameters('sharedServicesLocation')]",
+        "logStorageAccountName": "[parameters('sharedServicesLogStorageAccountName')]",
+        "logStorageSkuName": "[parameters('sharedServicesLogStorageSkuName')]",
+        "virtualNetworkName": "[parameters('sharedServicesVirtualNetworkName')]",
+        "virtualNetworkAddressPrefix": "[parameters('sharedServicesVirtualNetworkAddressPrefix')]",
+        "virtualNetworkDiagnosticsLogs": "[parameters('sharedServicesVirtualNetworkDiagnosticsLogs')]",
+        "virtualNetworkDiagnosticsMetrics": "[parameters('sharedServicesVirtualNetworkDiagnosticsMetrics')]",
+        "networkSecurityGroupName": "[parameters('sharedServicesNetworkSecurityGroupName')]",
+        "networkSecurityGroupRules": "[parameters('sharedServicesNetworkSecurityGroupRules')]",
+        "networkSecurityGroupDiagnosticsLogs": "[parameters('sharedServicesNetworkSecurityGroupDiagnosticsLogs')]",
+        "networkSecurityGroupDiagnosticsMetrics": "[parameters('sharedServicesNetworkSecurityGroupDiagnosticsMetrics')]",
+        "subnetName": "[parameters('sharedServicesSubnetName')]",
+        "subnetAddressPrefix": "[parameters('sharedServicesSubnetAddressPrefix')]",
+        "subnetServiceEndpoints": "[parameters('sharedServicesSubnetServiceEndpoints')]"
+      }
+    ]
   },
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('deploy-hub-rg-{0}', parameters('nowUtc'))]",
+      "name": "[format('deploy-rg-hub-{0}', parameters('nowUtc'))]",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
       "location": "[deployment().location]",
       "properties": {
@@ -676,9 +738,6 @@
           },
           "location": {
             "value": "[parameters('hubLocation')]"
-          },
-          "tags": {
-            "value": "[parameters('tags')]"
           }
         },
         "template": {
@@ -688,7 +747,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "16804784914647536968"
+              "templateHash": "16793551366393102966"
             }
           },
           "parameters": {
@@ -721,16 +780,24 @@
             "name": {
               "type": "string",
               "value": "[parameters('name')]"
+            },
+            "location": {
+              "type": "string",
+              "value": "[reference(subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('name')), '2019-05-01', 'full').location]"
             }
           }
         }
       }
     },
     {
+      "copy": {
+        "name": "spokeResourceGroups",
+        "count": "[length(variables('spokes'))]"
+      },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('deploy-identity-rg-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('identitySubscriptionId')]",
+      "name": "[format('deploy-rg-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))]",
+      "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "location": "[deployment().location]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -739,10 +806,10 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[parameters('identityResourceGroupName')]"
+            "value": "[variables('spokes')[copyIndex()].resourceGroupName]"
           },
           "location": {
-            "value": "[parameters('identityLocation')]"
+            "value": "[variables('spokes')[copyIndex()].location]"
           },
           "tags": {
             "value": "[parameters('tags')]"
@@ -755,7 +822,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "16804784914647536968"
+              "templateHash": "16793551366393102966"
             }
           },
           "parameters": {
@@ -788,140 +855,10 @@
             "name": {
               "type": "string",
               "value": "[parameters('name')]"
-            }
-          }
-        }
-      }
-    },
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
-      "name": "[format('deploy-operations-rg-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('operationsSubscriptionId')]",
-      "location": "[deployment().location]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "name": {
-            "value": "[parameters('operationsResourceGroupName')]"
-          },
-          "location": {
-            "value": "[parameters('operationsLocation')]"
-          },
-          "tags": {
-            "value": "[parameters('tags')]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "16804784914647536968"
-            }
-          },
-          "parameters": {
-            "name": {
-              "type": "string"
             },
             "location": {
-              "type": "string"
-            },
-            "tags": {
-              "type": "object",
-              "defaultValue": {}
-            }
-          },
-          "functions": [],
-          "resources": [
-            {
-              "type": "Microsoft.Resources/resourceGroups",
-              "apiVersion": "2019-05-01",
-              "name": "[parameters('name')]",
-              "location": "[parameters('location')]",
-              "tags": "[parameters('tags')]"
-            }
-          ],
-          "outputs": {
-            "id": {
               "type": "string",
-              "value": "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('name'))]"
-            },
-            "name": {
-              "type": "string",
-              "value": "[parameters('name')]"
-            }
-          }
-        }
-      }
-    },
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
-      "name": "[format('deploy-sharedServices-rg-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('sharedServicesSubscriptionId')]",
-      "location": "[deployment().location]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "name": {
-            "value": "[parameters('sharedServicesResourceGroupName')]"
-          },
-          "location": {
-            "value": "[parameters('sharedServicesLocation')]"
-          },
-          "tags": {
-            "value": "[parameters('tags')]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "16804784914647536968"
-            }
-          },
-          "parameters": {
-            "name": {
-              "type": "string"
-            },
-            "location": {
-              "type": "string"
-            },
-            "tags": {
-              "type": "object",
-              "defaultValue": {}
-            }
-          },
-          "functions": [],
-          "resources": [
-            {
-              "type": "Microsoft.Resources/resourceGroups",
-              "apiVersion": "2019-05-01",
-              "name": "[parameters('name')]",
-              "location": "[parameters('location')]",
-              "tags": "[parameters('tags')]"
-            }
-          ],
-          "outputs": {
-            "id": {
-              "type": "string",
-              "value": "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('name'))]"
-            },
-            "name": {
-              "type": "string",
-              "value": "[parameters('name')]"
+              "value": "[reference(subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('name')), '2019-05-01', 'full').location]"
             }
           }
         }
@@ -965,7 +902,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "1675833802472237460"
+              "templateHash": "12414775351360753156"
             }
           },
           "parameters": {
@@ -1125,18 +1062,22 @@
             "name": {
               "type": "string",
               "value": "[parameters('name')]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "value": "[resourceGroup().name]"
             }
           }
         }
       },
       "dependsOn": [
-        "[subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc')))]"
+        "spokeResourceGroups"
       ]
     },
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('deploy-hub-{0}', parameters('nowUtc'))]",
+      "name": "[format('deploy-vnet-hub-{0}', parameters('nowUtc'))]",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
       "resourceGroup": "[parameters('hubResourceGroupName')]",
       "properties": {
@@ -2793,11 +2734,15 @@
       ]
     },
     {
+      "copy": {
+        "name": "spokeNetworks",
+        "count": "[length(variables('spokes'))]"
+      },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('deploy-identity-spoke-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('identitySubscriptionId')]",
-      "resourceGroup": "[parameters('identityResourceGroupName')]",
+      "name": "[format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))]",
+      "subscriptionId": "[variables('spokes')[copyIndex()].subscription]",
+      "resourceGroup": "[variables('spokes')[copyIndex()].resourceGroupName]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -2805,55 +2750,55 @@
         "mode": "Incremental",
         "parameters": {
           "location": {
-            "value": "[parameters('identityLocation')]"
+            "value": "[variables('spokes')[copyIndex()].location]"
           },
           "tags": {
             "value": "[parameters('tags')]"
           },
           "logStorageAccountName": {
-            "value": "[parameters('identityLogStorageAccountName')]"
+            "value": "[variables('spokes')[copyIndex()].logStorageAccountName]"
           },
           "logStorageSkuName": {
-            "value": "[parameters('identityLogStorageSkuName')]"
+            "value": "[variables('spokes')[copyIndex()].logStorageSkuName]"
           },
           "logAnalyticsWorkspaceResourceId": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
           },
           "firewallPrivateIPAddress": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
           },
           "virtualNetworkName": {
-            "value": "[parameters('identityVirtualNetworkName')]"
+            "value": "[variables('spokes')[copyIndex()].virtualNetworkName]"
           },
           "virtualNetworkAddressPrefix": {
-            "value": "[parameters('identityVirtualNetworkAddressPrefix')]"
+            "value": "[variables('spokes')[copyIndex()].virtualNetworkAddressPrefix]"
           },
           "virtualNetworkDiagnosticsLogs": {
-            "value": "[parameters('identityVirtualNetworkDiagnosticsLogs')]"
+            "value": "[variables('spokes')[copyIndex()].virtualNetworkDiagnosticsLogs]"
           },
           "virtualNetworkDiagnosticsMetrics": {
-            "value": "[parameters('identityVirtualNetworkDiagnosticsMetrics')]"
+            "value": "[variables('spokes')[copyIndex()].virtualNetworkDiagnosticsMetrics]"
           },
           "networkSecurityGroupName": {
-            "value": "[parameters('identityNetworkSecurityGroupName')]"
+            "value": "[variables('spokes')[copyIndex()].networkSecurityGroupName]"
           },
           "networkSecurityGroupRules": {
-            "value": "[parameters('identityNetworkSecurityGroupRules')]"
+            "value": "[variables('spokes')[copyIndex()].networkSecurityGroupRules]"
           },
           "networkSecurityGroupDiagnosticsLogs": {
-            "value": "[parameters('identityNetworkSecurityGroupDiagnosticsLogs')]"
+            "value": "[variables('spokes')[copyIndex()].networkSecurityGroupDiagnosticsLogs]"
           },
           "networkSecurityGroupDiagnosticsMetrics": {
-            "value": "[parameters('identityNetworkSecurityGroupDiagnosticsMetrics')]"
+            "value": "[variables('spokes')[copyIndex()].networkSecurityGroupDiagnosticsMetrics]"
           },
           "subnetName": {
-            "value": "[parameters('identitySubnetName')]"
+            "value": "[variables('spokes')[copyIndex()].subnetName]"
           },
           "subnetAddressPrefix": {
-            "value": "[parameters('identitySubnetAddressPrefix')]"
+            "value": "[variables('spokes')[copyIndex()].subnetAddressPrefix]"
           },
           "subnetServiceEndpoints": {
-            "value": "[parameters('identitySubnetServiceEndpoints')]"
+            "value": "[variables('spokes')[copyIndex()].subnetServiceEndpoints]"
           }
         },
         "template": {
@@ -3412,1262 +3357,14 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc')))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc')))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
       ]
     },
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('deploy-operations-spoke-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('operationsSubscriptionId')]",
-      "resourceGroup": "[parameters('operationsResourceGroupName')]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "location": {
-            "value": "[parameters('operationsLocation')]"
-          },
-          "tags": {
-            "value": "[parameters('tags')]"
-          },
-          "logStorageAccountName": {
-            "value": "[parameters('operationsLogStorageAccountName')]"
-          },
-          "logStorageSkuName": {
-            "value": "[parameters('operationsLogStorageSkuName')]"
-          },
-          "logAnalyticsWorkspaceResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-          },
-          "firewallPrivateIPAddress": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
-          },
-          "virtualNetworkName": {
-            "value": "[parameters('operationsVirtualNetworkName')]"
-          },
-          "virtualNetworkAddressPrefix": {
-            "value": "[parameters('operationsVirtualNetworkAddressPrefix')]"
-          },
-          "virtualNetworkDiagnosticsLogs": {
-            "value": "[parameters('operationsVirtualNetworkDiagnosticsLogs')]"
-          },
-          "virtualNetworkDiagnosticsMetrics": {
-            "value": "[parameters('operationsVirtualNetworkDiagnosticsMetrics')]"
-          },
-          "networkSecurityGroupName": {
-            "value": "[parameters('operationsNetworkSecurityGroupName')]"
-          },
-          "networkSecurityGroupRules": {
-            "value": "[parameters('operationsNetworkSecurityGroupRules')]"
-          },
-          "networkSecurityGroupDiagnosticsLogs": {
-            "value": "[parameters('operationsNetworkSecurityGroupDiagnosticsLogs')]"
-          },
-          "networkSecurityGroupDiagnosticsMetrics": {
-            "value": "[parameters('operationsNetworkSecurityGroupDiagnosticsMetrics')]"
-          },
-          "subnetName": {
-            "value": "[parameters('operationsSubnetName')]"
-          },
-          "subnetAddressPrefix": {
-            "value": "[parameters('operationsSubnetAddressPrefix')]"
-          },
-          "subnetServiceEndpoints": {
-            "value": "[parameters('operationsSubnetServiceEndpoints')]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "17180259987553481892"
-            }
-          },
-          "parameters": {
-            "location": {
-              "type": "string",
-              "defaultValue": "[resourceGroup().location]"
-            },
-            "tags": {
-              "type": "object",
-              "defaultValue": {}
-            },
-            "logStorageAccountName": {
-              "type": "string"
-            },
-            "logStorageSkuName": {
-              "type": "string"
-            },
-            "logAnalyticsWorkspaceResourceId": {
-              "type": "string"
-            },
-            "firewallPrivateIPAddress": {
-              "type": "string"
-            },
-            "virtualNetworkName": {
-              "type": "string"
-            },
-            "virtualNetworkAddressPrefix": {
-              "type": "string"
-            },
-            "virtualNetworkDiagnosticsLogs": {
-              "type": "array"
-            },
-            "virtualNetworkDiagnosticsMetrics": {
-              "type": "array"
-            },
-            "networkSecurityGroupName": {
-              "type": "string"
-            },
-            "networkSecurityGroupRules": {
-              "type": "array"
-            },
-            "networkSecurityGroupDiagnosticsLogs": {
-              "type": "array"
-            },
-            "networkSecurityGroupDiagnosticsMetrics": {
-              "type": "array"
-            },
-            "subnetName": {
-              "type": "string"
-            },
-            "subnetAddressPrefix": {
-              "type": "string"
-            },
-            "subnetServiceEndpoints": {
-              "type": "array"
-            },
-            "routeTableName": {
-              "type": "string",
-              "defaultValue": "[format('{0}-routetable', parameters('subnetName'))]"
-            },
-            "routeTableRouteName": {
-              "type": "string",
-              "defaultValue": "default_route"
-            },
-            "routeTableRouteAddressPrefix": {
-              "type": "string",
-              "defaultValue": "0.0.0.0/0"
-            },
-            "routeTableRouteNextHopIpAddress": {
-              "type": "string",
-              "defaultValue": "[parameters('firewallPrivateIPAddress')]"
-            },
-            "routeTableRouteNextHopType": {
-              "type": "string",
-              "defaultValue": "VirtualAppliance"
-            }
-          },
-          "functions": [],
-          "resources": [
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "logStorage",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "storageAccountName": {
-                    "value": "[parameters('logStorageAccountName')]"
-                  },
-                  "location": {
-                    "value": "[parameters('location')]"
-                  },
-                  "skuName": {
-                    "value": "[parameters('logStorageSkuName')]"
-                  },
-                  "tags": {
-                    "value": "[parameters('tags')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "779275696574787628"
-                    }
-                  },
-                  "parameters": {
-                    "storageAccountName": {
-                      "type": "string"
-                    },
-                    "location": {
-                      "type": "string"
-                    },
-                    "skuName": {
-                      "type": "string"
-                    },
-                    "tags": {
-                      "type": "object",
-                      "defaultValue": {}
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Storage/storageAccounts",
-                      "apiVersion": "2019-06-01",
-                      "name": "[parameters('storageAccountName')]",
-                      "location": "[parameters('location')]",
-                      "kind": "Storage",
-                      "sku": {
-                        "name": "[parameters('skuName')]"
-                      },
-                      "tags": "[parameters('tags')]"
-                    }
-                  ],
-                  "outputs": {
-                    "id": {
-                      "type": "string",
-                      "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "networkSecurityGroup",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "name": {
-                    "value": "[parameters('networkSecurityGroupName')]"
-                  },
-                  "location": {
-                    "value": "[parameters('location')]"
-                  },
-                  "tags": {
-                    "value": "[parameters('tags')]"
-                  },
-                  "securityRules": {
-                    "value": "[parameters('networkSecurityGroupRules')]"
-                  },
-                  "logAnalyticsWorkspaceResourceId": {
-                    "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
-                  },
-                  "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
-                  },
-                  "logs": {
-                    "value": "[parameters('networkSecurityGroupDiagnosticsLogs')]"
-                  },
-                  "metrics": {
-                    "value": "[parameters('networkSecurityGroupDiagnosticsMetrics')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "4497555273030729522"
-                    }
-                  },
-                  "parameters": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "location": {
-                      "type": "string"
-                    },
-                    "tags": {
-                      "type": "object",
-                      "defaultValue": {}
-                    },
-                    "securityRules": {
-                      "type": "array"
-                    },
-                    "logStorageAccountResourceId": {
-                      "type": "string"
-                    },
-                    "logAnalyticsWorkspaceResourceId": {
-                      "type": "string"
-                    },
-                    "logs": {
-                      "type": "array"
-                    },
-                    "metrics": {
-                      "type": "array"
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Network/networkSecurityGroups",
-                      "apiVersion": "2021-02-01",
-                      "name": "[parameters('name')]",
-                      "location": "[parameters('location')]",
-                      "tags": "[parameters('tags')]",
-                      "properties": {
-                        "securityRules": "[parameters('securityRules')]"
-                      }
-                    },
-                    {
-                      "type": "Microsoft.Insights/diagnosticSettings",
-                      "apiVersion": "2017-05-01-preview",
-                      "scope": "[format('Microsoft.Network/networkSecurityGroups/{0}', parameters('name'))]",
-                      "name": "[format('{0}-diagnostics', parameters('name'))]",
-                      "properties": {
-                        "storageAccountId": "[parameters('logStorageAccountResourceId')]",
-                        "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
-                        "logs": "[parameters('logs')]",
-                        "metrics": "[parameters('metrics')]"
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
-                      ]
-                    }
-                  ],
-                  "outputs": {
-                    "id": {
-                      "type": "string",
-                      "value": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
-                    },
-                    "name": {
-                      "type": "string",
-                      "value": "[parameters('name')]"
-                    }
-                  }
-                }
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'logStorage')]"
-              ]
-            },
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "routeTable",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "name": {
-                    "value": "[parameters('routeTableName')]"
-                  },
-                  "location": {
-                    "value": "[parameters('location')]"
-                  },
-                  "tags": {
-                    "value": "[parameters('tags')]"
-                  },
-                  "routeName": {
-                    "value": "[parameters('routeTableRouteName')]"
-                  },
-                  "routeAddressPrefix": {
-                    "value": "[parameters('routeTableRouteAddressPrefix')]"
-                  },
-                  "routeNextHopIpAddress": {
-                    "value": "[parameters('routeTableRouteNextHopIpAddress')]"
-                  },
-                  "routeNextHopType": {
-                    "value": "[parameters('routeTableRouteNextHopType')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "12136081248191573008"
-                    }
-                  },
-                  "parameters": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "location": {
-                      "type": "string"
-                    },
-                    "tags": {
-                      "type": "object",
-                      "defaultValue": {}
-                    },
-                    "routeName": {
-                      "type": "string"
-                    },
-                    "routeAddressPrefix": {
-                      "type": "string"
-                    },
-                    "routeNextHopIpAddress": {
-                      "type": "string"
-                    },
-                    "routeNextHopType": {
-                      "type": "string"
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Network/routeTables",
-                      "apiVersion": "2021-02-01",
-                      "name": "[parameters('name')]",
-                      "location": "[parameters('location')]",
-                      "tags": "[parameters('tags')]",
-                      "properties": {
-                        "routes": [
-                          {
-                            "name": "[parameters('routeName')]",
-                            "properties": {
-                              "addressPrefix": "[parameters('routeAddressPrefix')]",
-                              "nextHopIpAddress": "[parameters('routeNextHopIpAddress')]",
-                              "nextHopType": "[parameters('routeNextHopType')]"
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "outputs": {
-                    "id": {
-                      "type": "string",
-                      "value": "[resourceId('Microsoft.Network/routeTables', parameters('name'))]"
-                    },
-                    "name": {
-                      "type": "string",
-                      "value": "[parameters('name')]"
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "virtualNetwork",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "name": {
-                    "value": "[parameters('virtualNetworkName')]"
-                  },
-                  "location": {
-                    "value": "[parameters('location')]"
-                  },
-                  "tags": {
-                    "value": "[parameters('tags')]"
-                  },
-                  "addressPrefix": {
-                    "value": "[parameters('virtualNetworkAddressPrefix')]"
-                  },
-                  "subnets": {
-                    "value": [
-                      {
-                        "name": "[parameters('subnetName')]",
-                        "properties": {
-                          "addressPrefix": "[parameters('subnetAddressPrefix')]",
-                          "networkSecurityGroup": {
-                            "id": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2020-06-01').outputs.id.value]"
-                          },
-                          "routeTable": {
-                            "id": "[reference(resourceId('Microsoft.Resources/deployments', 'routeTable'), '2020-06-01').outputs.id.value]"
-                          },
-                          "serviceEndpoints": "[parameters('subnetServiceEndpoints')]"
-                        }
-                      }
-                    ]
-                  },
-                  "logAnalyticsWorkspaceResourceId": {
-                    "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
-                  },
-                  "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
-                  },
-                  "logs": {
-                    "value": "[parameters('virtualNetworkDiagnosticsLogs')]"
-                  },
-                  "metrics": {
-                    "value": "[parameters('virtualNetworkDiagnosticsMetrics')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "12119421388421560495"
-                    }
-                  },
-                  "parameters": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "location": {
-                      "type": "string"
-                    },
-                    "tags": {
-                      "type": "object",
-                      "defaultValue": {}
-                    },
-                    "addressPrefix": {
-                      "type": "string"
-                    },
-                    "logAnalyticsWorkspaceResourceId": {
-                      "type": "string"
-                    },
-                    "logStorageAccountResourceId": {
-                      "type": "string"
-                    },
-                    "subnets": {
-                      "type": "array"
-                    },
-                    "logs": {
-                      "type": "array"
-                    },
-                    "metrics": {
-                      "type": "array"
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Network/virtualNetworks",
-                      "apiVersion": "2021-02-01",
-                      "name": "[parameters('name')]",
-                      "location": "[parameters('location')]",
-                      "tags": "[parameters('tags')]",
-                      "properties": {
-                        "addressSpace": {
-                          "addressPrefixes": [
-                            "[parameters('addressPrefix')]"
-                          ]
-                        },
-                        "subnets": "[parameters('subnets')]"
-                      }
-                    },
-                    {
-                      "type": "Microsoft.Insights/diagnosticSettings",
-                      "apiVersion": "2017-05-01-preview",
-                      "scope": "[format('Microsoft.Network/virtualNetworks/{0}', parameters('name'))]",
-                      "name": "[format('{0}-diagnostics', parameters('name'))]",
-                      "properties": {
-                        "storageAccountId": "[parameters('logStorageAccountResourceId')]",
-                        "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
-                        "logs": "[parameters('logs')]",
-                        "metrics": "[parameters('metrics')]"
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.Network/virtualNetworks', parameters('name'))]"
-                      ]
-                    }
-                  ],
-                  "outputs": {
-                    "name": {
-                      "type": "string",
-                      "value": "[parameters('name')]"
-                    },
-                    "id": {
-                      "type": "string",
-                      "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('name'))]"
-                    },
-                    "subnets": {
-                      "type": "array",
-                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name'))).subnets]"
-                    }
-                  }
-                }
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'logStorage')]",
-                "[resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup')]",
-                "[resourceId('Microsoft.Resources/deployments', 'routeTable')]"
-              ]
-            }
-          ],
-          "outputs": {
-            "virtualNetworkName": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2020-06-01').outputs.name.value]"
-            },
-            "virtualNetworkResourceId": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2020-06-01').outputs.id.value]"
-            },
-            "subnetName": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2020-06-01').outputs.subnets.value[0].name]"
-            },
-            "subnetAddressPrefix": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2020-06-01').outputs.subnets.value[0].properties.addressPrefix]"
-            },
-            "subnetResourceId": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2020-06-01').outputs.subnets.value[0].id]"
-            },
-            "networkSecurityGroupName": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2020-06-01').outputs.name.value]"
-            },
-            "networkSecurityGroupResourceId": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2020-06-01').outputs.id.value]"
-            }
-          }
-        }
-      },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
-      "name": "[format('deploy-sharedServices-spoke-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('sharedServicesSubscriptionId')]",
-      "resourceGroup": "[parameters('sharedServicesResourceGroupName')]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "location": {
-            "value": "[parameters('sharedServicesLocation')]"
-          },
-          "tags": {
-            "value": "[parameters('tags')]"
-          },
-          "logStorageAccountName": {
-            "value": "[parameters('sharedServicesLogStorageAccountName')]"
-          },
-          "logStorageSkuName": {
-            "value": "[parameters('sharedServicesLogStorageSkuName')]"
-          },
-          "logAnalyticsWorkspaceResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-          },
-          "firewallPrivateIPAddress": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
-          },
-          "virtualNetworkName": {
-            "value": "[parameters('sharedServicesVirtualNetworkName')]"
-          },
-          "virtualNetworkAddressPrefix": {
-            "value": "[parameters('sharedServicesVirtualNetworkAddressPrefix')]"
-          },
-          "virtualNetworkDiagnosticsLogs": {
-            "value": "[parameters('sharedServicesVirtualNetworkDiagnosticsLogs')]"
-          },
-          "virtualNetworkDiagnosticsMetrics": {
-            "value": "[parameters('sharedServicesVirtualNetworkDiagnosticsMetrics')]"
-          },
-          "networkSecurityGroupName": {
-            "value": "[parameters('sharedServicesNetworkSecurityGroupName')]"
-          },
-          "networkSecurityGroupRules": {
-            "value": "[parameters('sharedServicesNetworkSecurityGroupRules')]"
-          },
-          "networkSecurityGroupDiagnosticsLogs": {
-            "value": "[parameters('sharedServicesNetworkSecurityGroupDiagnosticsLogs')]"
-          },
-          "networkSecurityGroupDiagnosticsMetrics": {
-            "value": "[parameters('sharedServicesNetworkSecurityGroupDiagnosticsMetrics')]"
-          },
-          "subnetName": {
-            "value": "[parameters('sharedServicesSubnetName')]"
-          },
-          "subnetAddressPrefix": {
-            "value": "[parameters('sharedServicesSubnetAddressPrefix')]"
-          },
-          "subnetServiceEndpoints": {
-            "value": "[parameters('sharedServicesSubnetServiceEndpoints')]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "17180259987553481892"
-            }
-          },
-          "parameters": {
-            "location": {
-              "type": "string",
-              "defaultValue": "[resourceGroup().location]"
-            },
-            "tags": {
-              "type": "object",
-              "defaultValue": {}
-            },
-            "logStorageAccountName": {
-              "type": "string"
-            },
-            "logStorageSkuName": {
-              "type": "string"
-            },
-            "logAnalyticsWorkspaceResourceId": {
-              "type": "string"
-            },
-            "firewallPrivateIPAddress": {
-              "type": "string"
-            },
-            "virtualNetworkName": {
-              "type": "string"
-            },
-            "virtualNetworkAddressPrefix": {
-              "type": "string"
-            },
-            "virtualNetworkDiagnosticsLogs": {
-              "type": "array"
-            },
-            "virtualNetworkDiagnosticsMetrics": {
-              "type": "array"
-            },
-            "networkSecurityGroupName": {
-              "type": "string"
-            },
-            "networkSecurityGroupRules": {
-              "type": "array"
-            },
-            "networkSecurityGroupDiagnosticsLogs": {
-              "type": "array"
-            },
-            "networkSecurityGroupDiagnosticsMetrics": {
-              "type": "array"
-            },
-            "subnetName": {
-              "type": "string"
-            },
-            "subnetAddressPrefix": {
-              "type": "string"
-            },
-            "subnetServiceEndpoints": {
-              "type": "array"
-            },
-            "routeTableName": {
-              "type": "string",
-              "defaultValue": "[format('{0}-routetable', parameters('subnetName'))]"
-            },
-            "routeTableRouteName": {
-              "type": "string",
-              "defaultValue": "default_route"
-            },
-            "routeTableRouteAddressPrefix": {
-              "type": "string",
-              "defaultValue": "0.0.0.0/0"
-            },
-            "routeTableRouteNextHopIpAddress": {
-              "type": "string",
-              "defaultValue": "[parameters('firewallPrivateIPAddress')]"
-            },
-            "routeTableRouteNextHopType": {
-              "type": "string",
-              "defaultValue": "VirtualAppliance"
-            }
-          },
-          "functions": [],
-          "resources": [
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "logStorage",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "storageAccountName": {
-                    "value": "[parameters('logStorageAccountName')]"
-                  },
-                  "location": {
-                    "value": "[parameters('location')]"
-                  },
-                  "skuName": {
-                    "value": "[parameters('logStorageSkuName')]"
-                  },
-                  "tags": {
-                    "value": "[parameters('tags')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "779275696574787628"
-                    }
-                  },
-                  "parameters": {
-                    "storageAccountName": {
-                      "type": "string"
-                    },
-                    "location": {
-                      "type": "string"
-                    },
-                    "skuName": {
-                      "type": "string"
-                    },
-                    "tags": {
-                      "type": "object",
-                      "defaultValue": {}
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Storage/storageAccounts",
-                      "apiVersion": "2019-06-01",
-                      "name": "[parameters('storageAccountName')]",
-                      "location": "[parameters('location')]",
-                      "kind": "Storage",
-                      "sku": {
-                        "name": "[parameters('skuName')]"
-                      },
-                      "tags": "[parameters('tags')]"
-                    }
-                  ],
-                  "outputs": {
-                    "id": {
-                      "type": "string",
-                      "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "networkSecurityGroup",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "name": {
-                    "value": "[parameters('networkSecurityGroupName')]"
-                  },
-                  "location": {
-                    "value": "[parameters('location')]"
-                  },
-                  "tags": {
-                    "value": "[parameters('tags')]"
-                  },
-                  "securityRules": {
-                    "value": "[parameters('networkSecurityGroupRules')]"
-                  },
-                  "logAnalyticsWorkspaceResourceId": {
-                    "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
-                  },
-                  "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
-                  },
-                  "logs": {
-                    "value": "[parameters('networkSecurityGroupDiagnosticsLogs')]"
-                  },
-                  "metrics": {
-                    "value": "[parameters('networkSecurityGroupDiagnosticsMetrics')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "4497555273030729522"
-                    }
-                  },
-                  "parameters": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "location": {
-                      "type": "string"
-                    },
-                    "tags": {
-                      "type": "object",
-                      "defaultValue": {}
-                    },
-                    "securityRules": {
-                      "type": "array"
-                    },
-                    "logStorageAccountResourceId": {
-                      "type": "string"
-                    },
-                    "logAnalyticsWorkspaceResourceId": {
-                      "type": "string"
-                    },
-                    "logs": {
-                      "type": "array"
-                    },
-                    "metrics": {
-                      "type": "array"
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Network/networkSecurityGroups",
-                      "apiVersion": "2021-02-01",
-                      "name": "[parameters('name')]",
-                      "location": "[parameters('location')]",
-                      "tags": "[parameters('tags')]",
-                      "properties": {
-                        "securityRules": "[parameters('securityRules')]"
-                      }
-                    },
-                    {
-                      "type": "Microsoft.Insights/diagnosticSettings",
-                      "apiVersion": "2017-05-01-preview",
-                      "scope": "[format('Microsoft.Network/networkSecurityGroups/{0}', parameters('name'))]",
-                      "name": "[format('{0}-diagnostics', parameters('name'))]",
-                      "properties": {
-                        "storageAccountId": "[parameters('logStorageAccountResourceId')]",
-                        "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
-                        "logs": "[parameters('logs')]",
-                        "metrics": "[parameters('metrics')]"
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
-                      ]
-                    }
-                  ],
-                  "outputs": {
-                    "id": {
-                      "type": "string",
-                      "value": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
-                    },
-                    "name": {
-                      "type": "string",
-                      "value": "[parameters('name')]"
-                    }
-                  }
-                }
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'logStorage')]"
-              ]
-            },
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "routeTable",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "name": {
-                    "value": "[parameters('routeTableName')]"
-                  },
-                  "location": {
-                    "value": "[parameters('location')]"
-                  },
-                  "tags": {
-                    "value": "[parameters('tags')]"
-                  },
-                  "routeName": {
-                    "value": "[parameters('routeTableRouteName')]"
-                  },
-                  "routeAddressPrefix": {
-                    "value": "[parameters('routeTableRouteAddressPrefix')]"
-                  },
-                  "routeNextHopIpAddress": {
-                    "value": "[parameters('routeTableRouteNextHopIpAddress')]"
-                  },
-                  "routeNextHopType": {
-                    "value": "[parameters('routeTableRouteNextHopType')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "12136081248191573008"
-                    }
-                  },
-                  "parameters": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "location": {
-                      "type": "string"
-                    },
-                    "tags": {
-                      "type": "object",
-                      "defaultValue": {}
-                    },
-                    "routeName": {
-                      "type": "string"
-                    },
-                    "routeAddressPrefix": {
-                      "type": "string"
-                    },
-                    "routeNextHopIpAddress": {
-                      "type": "string"
-                    },
-                    "routeNextHopType": {
-                      "type": "string"
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Network/routeTables",
-                      "apiVersion": "2021-02-01",
-                      "name": "[parameters('name')]",
-                      "location": "[parameters('location')]",
-                      "tags": "[parameters('tags')]",
-                      "properties": {
-                        "routes": [
-                          {
-                            "name": "[parameters('routeName')]",
-                            "properties": {
-                              "addressPrefix": "[parameters('routeAddressPrefix')]",
-                              "nextHopIpAddress": "[parameters('routeNextHopIpAddress')]",
-                              "nextHopType": "[parameters('routeNextHopType')]"
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "outputs": {
-                    "id": {
-                      "type": "string",
-                      "value": "[resourceId('Microsoft.Network/routeTables', parameters('name'))]"
-                    },
-                    "name": {
-                      "type": "string",
-                      "value": "[parameters('name')]"
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "virtualNetwork",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "name": {
-                    "value": "[parameters('virtualNetworkName')]"
-                  },
-                  "location": {
-                    "value": "[parameters('location')]"
-                  },
-                  "tags": {
-                    "value": "[parameters('tags')]"
-                  },
-                  "addressPrefix": {
-                    "value": "[parameters('virtualNetworkAddressPrefix')]"
-                  },
-                  "subnets": {
-                    "value": [
-                      {
-                        "name": "[parameters('subnetName')]",
-                        "properties": {
-                          "addressPrefix": "[parameters('subnetAddressPrefix')]",
-                          "networkSecurityGroup": {
-                            "id": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2020-06-01').outputs.id.value]"
-                          },
-                          "routeTable": {
-                            "id": "[reference(resourceId('Microsoft.Resources/deployments', 'routeTable'), '2020-06-01').outputs.id.value]"
-                          },
-                          "serviceEndpoints": "[parameters('subnetServiceEndpoints')]"
-                        }
-                      }
-                    ]
-                  },
-                  "logAnalyticsWorkspaceResourceId": {
-                    "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
-                  },
-                  "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2020-06-01').outputs.id.value]"
-                  },
-                  "logs": {
-                    "value": "[parameters('virtualNetworkDiagnosticsLogs')]"
-                  },
-                  "metrics": {
-                    "value": "[parameters('virtualNetworkDiagnosticsMetrics')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "12119421388421560495"
-                    }
-                  },
-                  "parameters": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "location": {
-                      "type": "string"
-                    },
-                    "tags": {
-                      "type": "object",
-                      "defaultValue": {}
-                    },
-                    "addressPrefix": {
-                      "type": "string"
-                    },
-                    "logAnalyticsWorkspaceResourceId": {
-                      "type": "string"
-                    },
-                    "logStorageAccountResourceId": {
-                      "type": "string"
-                    },
-                    "subnets": {
-                      "type": "array"
-                    },
-                    "logs": {
-                      "type": "array"
-                    },
-                    "metrics": {
-                      "type": "array"
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Network/virtualNetworks",
-                      "apiVersion": "2021-02-01",
-                      "name": "[parameters('name')]",
-                      "location": "[parameters('location')]",
-                      "tags": "[parameters('tags')]",
-                      "properties": {
-                        "addressSpace": {
-                          "addressPrefixes": [
-                            "[parameters('addressPrefix')]"
-                          ]
-                        },
-                        "subnets": "[parameters('subnets')]"
-                      }
-                    },
-                    {
-                      "type": "Microsoft.Insights/diagnosticSettings",
-                      "apiVersion": "2017-05-01-preview",
-                      "scope": "[format('Microsoft.Network/virtualNetworks/{0}', parameters('name'))]",
-                      "name": "[format('{0}-diagnostics', parameters('name'))]",
-                      "properties": {
-                        "storageAccountId": "[parameters('logStorageAccountResourceId')]",
-                        "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
-                        "logs": "[parameters('logs')]",
-                        "metrics": "[parameters('metrics')]"
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.Network/virtualNetworks', parameters('name'))]"
-                      ]
-                    }
-                  ],
-                  "outputs": {
-                    "name": {
-                      "type": "string",
-                      "value": "[parameters('name')]"
-                    },
-                    "id": {
-                      "type": "string",
-                      "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('name'))]"
-                    },
-                    "subnets": {
-                      "type": "array",
-                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name'))).subnets]"
-                    }
-                  }
-                }
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'logStorage')]",
-                "[resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup')]",
-                "[resourceId('Microsoft.Resources/deployments', 'routeTable')]"
-              ]
-            }
-          ],
-          "outputs": {
-            "virtualNetworkName": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2020-06-01').outputs.name.value]"
-            },
-            "virtualNetworkResourceId": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2020-06-01').outputs.id.value]"
-            },
-            "subnetName": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2020-06-01').outputs.subnets.value[0].name]"
-            },
-            "subnetAddressPrefix": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2020-06-01').outputs.subnets.value[0].properties.addressPrefix]"
-            },
-            "subnetResourceId": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2020-06-01').outputs.subnets.value[0].id]"
-            },
-            "networkSecurityGroupName": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2020-06-01').outputs.name.value]"
-            },
-            "networkSecurityGroupResourceId": {
-              "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2020-06-01').outputs.id.value]"
-            }
-          }
-        }
-      },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
-      "name": "[format('deploy-hub-peerings-{0}', parameters('nowUtc'))]",
+      "name": "[format('deploy-vnet-peerings-hub-{0}', parameters('nowUtc'))]",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
       "location": "[deployment().location]",
       "properties": {
@@ -4677,28 +3374,19 @@
         "mode": "Incremental",
         "parameters": {
           "hubResourceGroupName": {
-            "value": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-hub-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
+            "value": "[parameters('hubResourceGroupName')]"
           },
           "hubVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
           },
-          "identityVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('identitySubscriptionId'), parameters('identityResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-identity-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
-          },
-          "operationsVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
-          },
-          "sharedServicesVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-sharedServices-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
-          },
-          "identityVirtualNetworkResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('identitySubscriptionId'), parameters('identityResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-identity-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
-          },
-          "operationsVirtualNetworkResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
-          },
-          "sharedServicesVirtualNetworkResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-sharedServices-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
+          "spokeNetworks": {
+            "copy": [
+              {
+                "name": "value",
+                "count": "[length(variables('spokes'))]",
+                "input": "[createObject('type', variables('spokes')[copyIndex('value')].type, 'name', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscription, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].type, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value, 'virtualNetworkResourceId', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscription, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].type, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value)]"
+              }
+            ]
           }
         },
         "template": {
@@ -4708,7 +3396,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "11059781605005391925"
+              "templateHash": "4265705882628417745"
             }
           },
           "parameters": {
@@ -4718,31 +3406,20 @@
             "hubVirtualNetworkName": {
               "type": "string"
             },
-            "identityVirtualNetworkName": {
-              "type": "string"
-            },
-            "identityVirtualNetworkResourceId": {
-              "type": "string"
-            },
-            "operationsVirtualNetworkName": {
-              "type": "string"
-            },
-            "operationsVirtualNetworkResourceId": {
-              "type": "string"
-            },
-            "sharedServicesVirtualNetworkName": {
-              "type": "string"
-            },
-            "sharedServicesVirtualNetworkResourceId": {
-              "type": "string"
+            "spokeNetworks": {
+              "type": "array"
             }
           },
           "functions": [],
           "resources": [
             {
+              "copy": {
+                "name": "hubToSpokePeering",
+                "count": "[length(parameters('spokeNetworks'))]"
+              },
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-06-01",
-              "name": "hubToIdentityVirtualNetworkPeering",
+              "name": "[format('hubTo{0}VirtualNetworkPeering', parameters('spokeNetworks')[copyIndex()].type)]",
               "resourceGroup": "[parameters('hubResourceGroupName')]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -4751,114 +3428,10 @@
                 "mode": "Incremental",
                 "parameters": {
                   "name": {
-                    "value": "[format('{0}/to-{1}', parameters('hubVirtualNetworkName'), parameters('identityVirtualNetworkName'))]"
+                    "value": "[format('{0}/to-{1}', parameters('hubVirtualNetworkName'), parameters('spokeNetworks')[copyIndex()].virtualNetworkName)]"
                   },
                   "remoteVirtualNetworkResourceId": {
-                    "value": "[parameters('identityVirtualNetworkResourceId')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "17516021996853951284"
-                    }
-                  },
-                  "parameters": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "remoteVirtualNetworkResourceId": {
-                      "type": "string"
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-                      "apiVersion": "2021-02-01",
-                      "name": "[parameters('name')]",
-                      "properties": {
-                        "remoteVirtualNetwork": {
-                          "id": "[parameters('remoteVirtualNetworkResourceId')]"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "hubToOperationsVirtualNetworkPeering",
-              "resourceGroup": "[parameters('hubResourceGroupName')]",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "name": {
-                    "value": "[format('{0}/to-{1}', parameters('hubVirtualNetworkName'), parameters('operationsVirtualNetworkName'))]"
-                  },
-                  "remoteVirtualNetworkResourceId": {
-                    "value": "[parameters('operationsVirtualNetworkResourceId')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "17516021996853951284"
-                    }
-                  },
-                  "parameters": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "remoteVirtualNetworkResourceId": {
-                      "type": "string"
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-                      "apiVersion": "2021-02-01",
-                      "name": "[parameters('name')]",
-                      "properties": {
-                        "remoteVirtualNetwork": {
-                          "id": "[parameters('remoteVirtualNetworkResourceId')]"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "hubToSharedServicesVirtualNetworkPeering",
-              "resourceGroup": "[parameters('hubResourceGroupName')]",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "name": {
-                    "value": "[format('{0}/to-{1}', parameters('hubVirtualNetworkName'), parameters('sharedServicesVirtualNetworkName'))]"
-                  },
-                  "remoteVirtualNetworkResourceId": {
-                    "value": "[parameters('sharedServicesVirtualNetworkResourceId')]"
+                    "value": "[parameters('spokeNetworks')[copyIndex()].virtualNetworkResourceId]"
                   }
                 },
                 "template": {
@@ -4899,18 +3472,19 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc')))]",
-        "[subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-hub-rg-{0}', parameters('nowUtc')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('identitySubscriptionId'), parameters('identityResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-identity-spoke-{0}', parameters('nowUtc')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-sharedServices-spoke-{0}', parameters('nowUtc')))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc')))]",
+        "spokeNetworks"
       ]
     },
     {
+      "copy": {
+        "name": "spokeVirtualNetworkPeerings",
+        "count": "[length(variables('spokes'))]"
+      },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('deploy-identity-peerings-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('identitySubscriptionId')]",
+      "name": "[format('deploy-vnet-peerings-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))]",
+      "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "location": "[deployment().location]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -4919,16 +3493,16 @@
         "mode": "Incremental",
         "parameters": {
           "spokeResourceGroupName": {
-            "value": "[reference(subscriptionResourceId(parameters('identitySubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-identity-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
+            "value": "[variables('spokes')[copyIndex()].resourceGroupName]"
           },
           "spokeVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('identitySubscriptionId'), parameters('identityResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-identity-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscription, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
           },
           "hubVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
           },
           "hubVirtualNetworkResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
           }
         },
         "template": {
@@ -5013,236 +3587,12 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('identitySubscriptionId'), parameters('identityResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-identity-spoke-{0}', parameters('nowUtc')))]",
-        "[subscriptionResourceId(parameters('identitySubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-identity-rg-{0}', parameters('nowUtc')))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc')))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscription, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc')))]"
       ]
     },
     {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
-      "name": "[format('deploy-operations-peerings-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('operationsSubscriptionId')]",
-      "location": "[deployment().location]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "spokeResourceGroupName": {
-            "value": "[reference(subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-          },
-          "spokeVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
-          },
-          "hubVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
-          },
-          "hubVirtualNetworkResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "312016847830445837"
-            }
-          },
-          "parameters": {
-            "spokeResourceGroupName": {
-              "type": "string"
-            },
-            "spokeVirtualNetworkName": {
-              "type": "string"
-            },
-            "hubVirtualNetworkName": {
-              "type": "string"
-            },
-            "hubVirtualNetworkResourceId": {
-              "type": "string"
-            }
-          },
-          "functions": [],
-          "resources": [
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "spokeNetworkPeering",
-              "resourceGroup": "[parameters('spokeResourceGroupName')]",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "name": {
-                    "value": "[format('{0}/to-{1}', parameters('spokeVirtualNetworkName'), parameters('hubVirtualNetworkName'))]"
-                  },
-                  "remoteVirtualNetworkResourceId": {
-                    "value": "[parameters('hubVirtualNetworkResourceId')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "17516021996853951284"
-                    }
-                  },
-                  "parameters": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "remoteVirtualNetworkResourceId": {
-                      "type": "string"
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-                      "apiVersion": "2021-02-01",
-                      "name": "[parameters('name')]",
-                      "properties": {
-                        "remoteVirtualNetwork": {
-                          "id": "[parameters('remoteVirtualNetworkResourceId')]"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc')))]",
-        "[subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc')))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
-      "name": "[format('deploy-sharedServices-peerings-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('sharedServicesSubscriptionId')]",
-      "location": "[deployment().location]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "spokeResourceGroupName": {
-            "value": "[reference(subscriptionResourceId(parameters('sharedServicesSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-sharedServices-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-          },
-          "spokeVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-sharedServices-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
-          },
-          "hubVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
-          },
-          "hubVirtualNetworkResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "312016847830445837"
-            }
-          },
-          "parameters": {
-            "spokeResourceGroupName": {
-              "type": "string"
-            },
-            "spokeVirtualNetworkName": {
-              "type": "string"
-            },
-            "hubVirtualNetworkName": {
-              "type": "string"
-            },
-            "hubVirtualNetworkResourceId": {
-              "type": "string"
-            }
-          },
-          "functions": [],
-          "resources": [
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "spokeNetworkPeering",
-              "resourceGroup": "[parameters('spokeResourceGroupName')]",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "name": {
-                    "value": "[format('{0}/to-{1}', parameters('spokeVirtualNetworkName'), parameters('hubVirtualNetworkName'))]"
-                  },
-                  "remoteVirtualNetworkResourceId": {
-                    "value": "[parameters('hubVirtualNetworkResourceId')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "17516021996853951284"
-                    }
-                  },
-                  "parameters": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "remoteVirtualNetworkResourceId": {
-                      "type": "string"
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-                      "apiVersion": "2021-02-01",
-                      "name": "[parameters('name')]",
-                      "properties": {
-                        "remoteVirtualNetwork": {
-                          "id": "[parameters('remoteVirtualNetworkResourceId')]"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-sharedServices-spoke-{0}', parameters('nowUtc')))]",
-        "[subscriptionResourceId(parameters('sharedServicesSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-sharedServices-rg-{0}', parameters('nowUtc')))]"
-      ]
-    },
-    {
+      "condition": "[parameters('deployPolicy')]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
       "name": "[format('assign-policy-hub-{0}', parameters('nowUtc'))]",
@@ -5261,7 +3611,7 @@
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
           },
           "logAnalyticsWorkspaceResourceGroupName": {
-            "value": "[reference(subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.resourceGroupName.value]"
           },
           "operationsSubscriptionId": {
             "value": "[parameters('operationsSubscriptionId')]"
@@ -5274,13 +3624,20 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "943351948581975691"
+              "templateHash": "1020471899502580649"
             }
           },
           "parameters": {
             "builtInAssignment": {
               "type": "string",
-              "defaultValue": ""
+              "metadata": {
+                "description": "[NIST/IL5/CMMC] Built-in policy assignments to assign, default is NIST. IL5 is only availalbe for GOV cloud and will switch to NIST if tried in AzureCloud."
+              },
+              "allowedValues": [
+                "NIST",
+                "IL5",
+                "CMMC"
+              ]
             },
             "logAnalyticsWorkspaceName": {
               "type": "string"
@@ -5310,7 +3667,6 @@
           },
           "resources": [
             {
-              "condition": "[not(empty(variables('modifiedAssignment')))]",
               "type": "Microsoft.Authorization/policyAssignments",
               "apiVersion": "2020-09-01",
               "name": "[variables('assignmentName')]",
@@ -5358,7 +3714,6 @@
               }
             },
             {
-              "condition": "[not(empty(variables('modifiedAssignment')))]",
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2020-04-01-preview",
               "name": "[guid(variables('contributorRoleDefinitionId'), variables('assignmentName'))]",
@@ -5497,16 +3852,20 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]",
-        "[subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc')))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
       ]
     },
     {
+      "condition": "[parameters('deployPolicy')]",
+      "copy": {
+        "name": "spokePolicyAssignment",
+        "count": "[length(variables('spokes'))]"
+      },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('assign-policy-operations-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('operationsSubscriptionId')]",
-      "resourceGroup": "[parameters('operationsResourceGroupName')]",
+      "name": "[format('assign-policy-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))]",
+      "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
+      "resourceGroup": "[variables('spokes')[copyIndex()].resourceGroupName]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -5520,7 +3879,7 @@
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
           },
           "logAnalyticsWorkspaceResourceGroupName": {
-            "value": "[reference(subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.resourceGroupName.value]"
           },
           "operationsSubscriptionId": {
             "value": "[parameters('operationsSubscriptionId')]"
@@ -5533,13 +3892,20 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "943351948581975691"
+              "templateHash": "1020471899502580649"
             }
           },
           "parameters": {
             "builtInAssignment": {
               "type": "string",
-              "defaultValue": ""
+              "metadata": {
+                "description": "[NIST/IL5/CMMC] Built-in policy assignments to assign, default is NIST. IL5 is only availalbe for GOV cloud and will switch to NIST if tried in AzureCloud."
+              },
+              "allowedValues": [
+                "NIST",
+                "IL5",
+                "CMMC"
+              ]
             },
             "logAnalyticsWorkspaceName": {
               "type": "string"
@@ -5569,7 +3935,6 @@
           },
           "resources": [
             {
-              "condition": "[not(empty(variables('modifiedAssignment')))]",
               "type": "Microsoft.Authorization/policyAssignments",
               "apiVersion": "2020-09-01",
               "name": "[variables('assignmentName')]",
@@ -5617,7 +3982,6 @@
               }
             },
             {
-              "condition": "[not(empty(variables('modifiedAssignment')))]",
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2020-04-01-preview",
               "name": "[guid(variables('contributorRoleDefinitionId'), variables('assignmentName'))]",
@@ -5756,526 +4120,7 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]",
-        "[subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc')))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
-      "name": "[format('assign-policy-sharedServices-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('sharedServicesSubscriptionId')]",
-      "resourceGroup": "[parameters('sharedServicesResourceGroupName')]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "builtInAssignment": {
-            "value": "[parameters('policy')]"
-          },
-          "logAnalyticsWorkspaceName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-          },
-          "logAnalyticsWorkspaceResourceGroupName": {
-            "value": "[reference(subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-          },
-          "operationsSubscriptionId": {
-            "value": "[parameters('operationsSubscriptionId')]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "943351948581975691"
-            }
-          },
-          "parameters": {
-            "builtInAssignment": {
-              "type": "string",
-              "defaultValue": ""
-            },
-            "logAnalyticsWorkspaceName": {
-              "type": "string"
-            },
-            "logAnalyticsWorkspaceResourceGroupName": {
-              "type": "string"
-            },
-            "operationsSubscriptionId": {
-              "type": "string"
-            },
-            "deployRemediation": {
-              "type": "bool",
-              "defaultValue": false,
-              "metadata": {
-                "description": "Starts a policy remediation for the VM Agent policies in hub RG. Set to false by default since this is time consuming in deployment."
-              }
-            }
-          },
-          "functions": [],
-          "variables": {
-            "modifiedAssignment": "[if(and(equals(toLower(environment().name), toLower('AzureCloud')), equals(toLower(parameters('builtInAssignment')), toLower('IL5'))), 'NIST', parameters('builtInAssignment'))]",
-            "assignmentName": "[format('{0} {1}', variables('modifiedAssignment'), resourceGroup().name)]",
-            "agentVmssAssignmentName": "[format('Deploy VMSS Agents {0}', resourceGroup().name)]",
-            "agentVmAssignmentName": "[format('Deploy VM Agents {0}', resourceGroup().name)]",
-            "contributorRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-            "lawsReaderRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')]"
-          },
-          "resources": [
-            {
-              "condition": "[not(empty(variables('modifiedAssignment')))]",
-              "type": "Microsoft.Authorization/policyAssignments",
-              "apiVersion": "2020-09-01",
-              "name": "[variables('assignmentName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "policyDefinitionId": "[createObject('NIST', createObject('id', '/providers/Microsoft.Authorization/policySetDefinitions/cf25b9c1-bd23-4eb6-bd2c-f4f3ac644a5f', 'parameters', json(replace('    {\n        \"listOfMembersToExcludeFromWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"admin\"\n        },\n        \"listOfMembersToIncludeInWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"azureuser\"\n        },\n        \"logAnalyticsWorkspaceIdforVMReporting\": \n        {\n        \"value\": \"<LAWORKSPACE>\"\n        },\n        \"IncludeArcMachines\": \n        {\n            \"value\": \"true\"\n        },\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \n        {\n            \"value\": \"1.2\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \n        {\n            \"value\": \"Compliant\"\n        },\n        \"requiredRetentionDays\": \n        {\n            \"value\": \"365\"\n        },\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \n        {\n            \"value\": \"NetworkWatcherRG\"\n        }\n    }', '<LAWORKSPACE>', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))))), 'IL5', createObject('id', '/providers/Microsoft.Authorization/policySetDefinitions/f9a961fa-3241-4b20-adc4-bbf8ad9d7197', 'parameters', json(replace('{\n    \"IncludeArcMachines\" : { \n        \"value\" : \"false\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\" : { \n        \"value\" : \"Compliant\"\n        },\n        \"MinimumTLSVersionForWindowsServers\" : { \n        \"value\" : \"1.2\"\n        },\n        \"requiredRetentionDays\" : { \n        \"value\" : \"365\"\n        },\n        \"effect-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"audit\"\n        },\n        \"allowedContainerImagesRegex-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"^(.+){0}$\"\n        },\n        \"effect-95edb821-ddaf-4404-9732-666045e056b4\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-440b515e-a580-421e-abeb-b159a61ddcbc\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-233a2a17-77ca-4fb1-9b6b-69223d272a44\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"audit\"\n        },\n        \"cpuLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"memoryLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"effect-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"audit\"\n        },\n        \"runAsUserRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"MustRunAsNonRoot\"\n        },\n        \"runAsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"supplementalGroupsRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"fsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"effect-1c6e92c9-99f0-4e55-9cf2-0c234dc48f99\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-47a1ee2f-2a2a-4576-bf2a-e0e36709c2b8\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-df49d893-a74c-421d-bc95-c663042e5b80\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-1a5b4dca-0b6f-4cf5-907c-56316bc1bf3d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-c26596ff-4d70-4e6a-9a30-c2506bd2f80c\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-511f5417-5d12-434d-ab2e-816901e72a5e\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-82985f06-dc18-4a48-bc1c-b9f4f0098cfe\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-098fc59e-46c7-4d99-9b16-64990e543d75\" : { \n        \"value\" : \"audit\"\n        },\n        \"NetworkWatcherResourceGroupName\" : { \n        \"value\" : \"NetworkWatcherRG\"\n        },\n        \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n        \"value\" : \"enabled\"\n        },\n        \"aadAuthenticationInServiceFabricMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-71ef260a-8f18-47b7-abcb-62d0673d94dc\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-862e97cf-49fc-4a5c-9de4-40d4e2e7c8eb\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d9da03a1-f3c3-412a-9709-947156872263\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-b4ac1030-89c5-4697-8e00-28b5ba6a8811\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-ea0dfaed-95fb-448c-934e-d6e713ce393d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-41425d9f-d1a5-499a-9932-f8ed8453932c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fc4d8e41-e223-45ea-9bf5-eada37891d87\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-86efb160-8de7-451d-bc08-5d475b0aadae\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-4ec52d6d-beb7-40c4-9a9e-fe753254690e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-64d314f6-6062-4780-a861-c23e8951bee5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fd32ebd-e4c3-4e13-a54a-d7422d4d95f6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fa298e57-9444-42ba-bf04-86e8470e32c7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f905d99-2ab7-462c-a6b0-f709acca6c8f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ba769a63-b8cc-4b2d-abf6-ac33c7204be8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0aa61e00-0a01-4a3c-9945-e93cffedf0e6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-47031206-ce96-41f8-861b-6a915f3de284\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-51522a96-0869-4791-82f3-981000c2c67f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-b5ec538c-daa0-4006-8596-35468b9148e8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-56a5ee18-2ae6-4810-86f7-18e39ce5629b\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2e94d99a-8a36-4563-bc77-810d8893b671\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fafeaf6-7927-4059-a50a-8eb2a7a6f2b5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-99e9ccd8-3db9-4592-b0d1-14b1715a4d8a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f68a601-6e6d-4e42-babf-3f643a047ea2\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ca91455f-eace-4f96-be59-e6e2c35b4816\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-702dd420-7fcc-42c5-afe8-4026edd20fe0\" : { \n        \"value\" : \"Audit\"\n        },\n        \"diagnosticsLogsInRedisCacheMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"secureTransferToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d092e0a-7acd-40d2-a975-dca21cae48c4\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"disableUnrestrictedNetworkToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-55615ac9-af46-4a59-874e-391cc3dfb490\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1b8ca024-1d5c-4dec-8995-b1a932b41780\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-53503636-bcc9-4748-9663-5348217f160f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-40cec1dd-a100-4920-b15b-3024fe8901ab\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-a049bf77-880b-470f-ba6d-9f21c530cf83\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ee980b6d-0eca-4501-8d54-f6290fd512c3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1d84d5fb-01f6-4d12-ba4f-4a26081d403d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-37e0d2fe-28a5-43d6-a273-67d37d1f5606\" : { \n        \"value\" : \"Audit\"\n        },\n        \"identityDesignateMoreThanOneOwnerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"diskEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"emailNotificationToSubscriptionOwnerHighSeverityAlertsEnabledEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlDbEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"aadAuthenticationInSqlServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssEndpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssOsVulnerabilitiesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"adaptiveApplicationControlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForPostgreSQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensureJavaVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityDesignateLessThanOwnersMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"securityContactEmailAddressForSubscriptionEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRestrictCORSAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensurePythonVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForMySQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"systemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"nextGenerationFirewallMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"useRbacRulesMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"webAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlServerAuditingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vnetEnableDDoSProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlServerAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"endpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"jitNetworkAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"geoRedundantStorageShouldBeEnabledForStorageAccountsEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"vmssSystemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"longtermGeoRedundantBackupEnabledAzureSQLDatabasesEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"systemConfigurationsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"containerBenchmarkMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"kubernetesServiceVersionUpToDateMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlDbVulnerabilityAssesmentMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"membersToIncludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"membersToExcludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"logAnalyticsWorkspaceIDForVMAgents\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n        },\n        \"PHPLatestVersionForAppServices\" : { \n        \"value\" : \"7.4\"\n        },\n        \"JavaLatestVersionForAppServices\" : { \n        \"value\" : \"11\"\n        },\n        \"WindowsPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.6\"\n        },\n        \"LinuxPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.9\"\n        },\n        \"ensureDotNetFrameworkLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"vulnerabilityAssessmentMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForWebAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"microsoftIaaSAntimalwareExtensionShouldBeDeployedOnWindowsServersEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityCenterStandardPricingTierShouldBeSelectedEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachinesEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensurePHPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityContactPhoneNumberShouldBeProvidedForSubscriptionEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForAPIAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnServerMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachineScaleSetsEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        }\n}', '<LAWORKSPACE>', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))))), 'CMMC', createObject('id', '/providers/Microsoft.Authorization/policySetDefinitions/b5629c75-5c77-4422-87b9-2509e680f8de', 'parameters', json(replace('{\n    \"logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n    },\n    \"effect-09024ccc-0c5f-475e-9457-b7c0d9ed487b\" : { \n        \"value\" : \"AuditIfNotExists\"\n    },\n    \"MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f\" :{\n        \"value\": \"\"\n    },\n    \"MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7\": {\n        \"value\": \"\"\n    },\n    \"effect-0961003e-5a0a-4549-abde-af6a37f2724d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b15565f-aa9e-48ba-8619-45960f2c314d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0e60b895-3786-45da-8377-9c6b4b6ac5f9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-17k78e20-9358-41c9-923c-fb736d382a12\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1bc1795e-d44a-4d48-9b3b-6fff0fd5f9ba\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"PHPLatestVersion\" : { \n    \"value\" : \"7.3\"\n    },\n    \"effect-22bee202-a82f-4305-9a2a-6d7f44d4dedb\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-26a828e1-e88f-464e-bbb3-c134a282b9de\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-34c877ad-507e-4c82-993e-3452a6e0ad3c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3c735d8a-a4ba-4a3a-b7cf-db7754cf57f4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-404c3081-a854-4457-ae30-26a93ef643f9\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-47a6b606-51aa-4496-8bb7-64b11cf66adc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-496223c3-ad65-4ecd-878a-bae78737e9ed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"JavaLatestVersion\" : { \n    \"value\" : \"11\"\n    },\n    \"effect-4f11b553-d42e-4e3a-89be-32ca364cad4c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4f4f78b8-e367-4b10-a341-d9a4ad5cf1c7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5c607a2e-c700-4744-8254-d77e7c9eb5e4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5f76cf89-fbf2-47fd-a3f4-b891fa780b60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6b1cbf55-e8b6-442f-ba4c-7246b6381474\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6d555dd1-86f2-4f1c-8ed7-5abae7c6cbab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7008174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"LinuxPythonLatestVersion\" : { \n    \"value\" : \"3.8\"\n    },\n    \"effect-7238174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7261b898-8a84-4db8-9e04-18527132abb3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-74c3584d-afae-46f7-a20a-6f8adba71a16\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-86b3d65f-7626-441e-b690-81a8b71cff60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-88999f4c-376a-45c8-bcb3-4058f713cf39\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8c122334-9d20-4eb8-89ea-ac9a705b74ae\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8cb6aa8b-9e41-4f4e-aa25-089a7ac2581e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9297c21d-2ed6-4474-b48f-163f75654ce3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-991310cd-e9f3-47bc-b7b6-f57b557d07db\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9b597639-28e4-48eb-b506-56b05d366257\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9d0b6ea4-93e2-4578-bf2f-6bb17d22b4bc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9daedab3-fb2d-461e-b861-71790eead4f6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a4af4a39-4135-47fb-b175-47fbdf85311d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"enabled\"\n    },\n    \"effect-a70ca396-0a34-413a-88e1-b956c1e683be\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-aa633080-8b72-40c4-a2d7-d00c03e80bed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb4388-5bf4-4ad7-ba82-2cd2f41ceae9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb7388-5bf4-4ad7-ba99-2cd2f41cebb9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-af6cd1bd-1635-48cb-bde7-5b15693900b9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\" : { \n    \"value\" : \"NetworkWatcherRG\"\n    },\n    \"effect-b7ddfbdc-1260-477d-91fd-98bd9be789a6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c3f317a7-a95c-4547-b7e7-11017ebdf2fe\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-cb510bfd-1cba-4d9f-a230-cb0976f4bb71\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e2c1c086-2d84-4019-bff3-c44ccd95113c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e3576e28-8b17-4677-84c3-db2990658d64\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e8cbc669-f12d-49eb-93e7-9273119e9933\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e9c8d085-d9cc-4b17-9cdc-059f1f01f19e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ebb62a0c-3560-49e1-89ed-27e074e9f8ad\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-efbde977-ba53-4479-b8e9-10b957924fbf\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f0e6e85b-9b9f-4a4b-b67b-f730d42f1b0b\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f6de0be7-9a8a-4b8a-b349-43cf02d22f7c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f8456c1c-aa66-4dfb-861a-25d127b775c9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f9d614c5-c173-4d56-95a7-b4437057d193\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-fb893a29-21bb-418c-a157-e99480ec364c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-feedbf84-6b99-488c-acc2-71c829aa5ffc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-3b980d31-7904-4bb7-8575-5665739a8052\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6e2593d9-add6-4083-9c9b-4b7d2188c899\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b607c5de-e7d9-4eee-9e5c-83f1bcee4fa0\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-013e242c-8828-4970-87b3-ab247555486d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d38fc420-0735-4ef3-ac11-c806f651a570\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a1181c5f-672a-477a-979a-7d58aa086233\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-308fbb08-4ab8-4e67-9b29-592e93fb94fa\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4da35fc9-c9e7-4960-aec9-797fe7d9051d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-523b5cd1-3e23-492f-a539-13118b6d1e3a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7fe3b40f-802b-4cdd-8bd4-fd799c948cc2\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c25d9a16-bc35-4e15-a7e5-9db606bf9ed4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b0f33259-77d7-4c9e-aac6-3aabcfae693c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0820b7b9-23aa-4725-a1ce-ae4558f718e5\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-358c20a6-3f9e-4f0e-97ff-c6ce485e2aac\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5744710e-cc2f-4ee8-8809-3b11e89f4bc9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ac4a19c2-fa67-49b4-8ae5-0b2e78c49457\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c9d007d0-c057-4772-b18c-01e546713bcd\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e372f825-a257-4fb8-9175-797a8a8627d6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d158790f-bfb0-486c-8631-2dc6b4e8e6af\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e802a67a-daf5-4436-9ea6-f6d821dd0c5d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a451c1ef-c6ca-483d-87ed-f49761e3ffb5\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftSql-servers-firewallRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ae89ebca-1c92-4898-ac2c-9f63decb045c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d26f7642-7545-4e18-9b75-8c9bbdee3a9a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1a4e592a-6a6e-44a5-9814-e36264ca96e7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7796937f-307b-4598-941c-67d3a05ebfe7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c5447c04-a4d7-4ba8-a263-c9ee321a6858\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-41388f1c-2db0-4c25-95b2-35d7f5ccbfa9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b02aacc0-b073-424e-8298-42b22829ee0a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-057d6cfe-9c4f-4a6d-bc60-14420ea1f1a9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0ec47710-77ff-4a3d-9181-6aa50af424d0\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-48af4db5-9b8b-401c-8e74-076be876a430\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-82339799-d096-41ae-8538-b108becf0970\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1b7aa243-30e4-4c9e-bca8-d0d3022b634a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ef2a8f2a-b3d9-49cd-a8a8-9a3aaaf647d9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-bb91dfba-c30d-4263-9add-9c2384e659a6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e71308d3-144b-4262-b144-efdc3cc90517\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2bdd0062-9d75-436e-89df-487dd8e4b3c7\" : { \n    \"value\" : \"Disabled\"\n    },\n    \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-6fac406b-40ca-413b-bf8e-0bf964659c25\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-048248b0-55cd-46da-b1ff-39efd52db260\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0d134df8-db83-46fb-ad72-fe0c9428c8dd\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fb2\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n    \"value\" : \"audit\"\n    },\n    \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c43e4a30-77cb-48ab-a4dd-93f175c63b57\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1f314764-cb73-4fc9-b863-8eca98ac36e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-123a3936-f020-408a-ba0c-47873faf1534\" : { \n    \"value\" : \"AuditIfNotExists\"\n    }\n}\n', '<LAWORKSPACE>', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName')), '2021-06-01').customerId))))[variables('modifiedAssignment')].id]",
-                "parameters": "[createObject('NIST', createObject('id', '/providers/Microsoft.Authorization/policySetDefinitions/cf25b9c1-bd23-4eb6-bd2c-f4f3ac644a5f', 'parameters', json(replace('    {\n        \"listOfMembersToExcludeFromWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"admin\"\n        },\n        \"listOfMembersToIncludeInWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"azureuser\"\n        },\n        \"logAnalyticsWorkspaceIdforVMReporting\": \n        {\n        \"value\": \"<LAWORKSPACE>\"\n        },\n        \"IncludeArcMachines\": \n        {\n            \"value\": \"true\"\n        },\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \n        {\n            \"value\": \"1.2\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \n        {\n            \"value\": \"Compliant\"\n        },\n        \"requiredRetentionDays\": \n        {\n            \"value\": \"365\"\n        },\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \n        {\n            \"value\": \"NetworkWatcherRG\"\n        }\n    }', '<LAWORKSPACE>', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))))), 'IL5', createObject('id', '/providers/Microsoft.Authorization/policySetDefinitions/f9a961fa-3241-4b20-adc4-bbf8ad9d7197', 'parameters', json(replace('{\n    \"IncludeArcMachines\" : { \n        \"value\" : \"false\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\" : { \n        \"value\" : \"Compliant\"\n        },\n        \"MinimumTLSVersionForWindowsServers\" : { \n        \"value\" : \"1.2\"\n        },\n        \"requiredRetentionDays\" : { \n        \"value\" : \"365\"\n        },\n        \"effect-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"audit\"\n        },\n        \"allowedContainerImagesRegex-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"^(.+){0}$\"\n        },\n        \"effect-95edb821-ddaf-4404-9732-666045e056b4\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-440b515e-a580-421e-abeb-b159a61ddcbc\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-233a2a17-77ca-4fb1-9b6b-69223d272a44\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"audit\"\n        },\n        \"cpuLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"memoryLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"effect-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"audit\"\n        },\n        \"runAsUserRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"MustRunAsNonRoot\"\n        },\n        \"runAsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"supplementalGroupsRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"fsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"effect-1c6e92c9-99f0-4e55-9cf2-0c234dc48f99\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-47a1ee2f-2a2a-4576-bf2a-e0e36709c2b8\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-df49d893-a74c-421d-bc95-c663042e5b80\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-1a5b4dca-0b6f-4cf5-907c-56316bc1bf3d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-c26596ff-4d70-4e6a-9a30-c2506bd2f80c\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-511f5417-5d12-434d-ab2e-816901e72a5e\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-82985f06-dc18-4a48-bc1c-b9f4f0098cfe\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-098fc59e-46c7-4d99-9b16-64990e543d75\" : { \n        \"value\" : \"audit\"\n        },\n        \"NetworkWatcherResourceGroupName\" : { \n        \"value\" : \"NetworkWatcherRG\"\n        },\n        \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n        \"value\" : \"enabled\"\n        },\n        \"aadAuthenticationInServiceFabricMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-71ef260a-8f18-47b7-abcb-62d0673d94dc\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-862e97cf-49fc-4a5c-9de4-40d4e2e7c8eb\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d9da03a1-f3c3-412a-9709-947156872263\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-b4ac1030-89c5-4697-8e00-28b5ba6a8811\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-ea0dfaed-95fb-448c-934e-d6e713ce393d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-41425d9f-d1a5-499a-9932-f8ed8453932c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fc4d8e41-e223-45ea-9bf5-eada37891d87\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-86efb160-8de7-451d-bc08-5d475b0aadae\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-4ec52d6d-beb7-40c4-9a9e-fe753254690e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-64d314f6-6062-4780-a861-c23e8951bee5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fd32ebd-e4c3-4e13-a54a-d7422d4d95f6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fa298e57-9444-42ba-bf04-86e8470e32c7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f905d99-2ab7-462c-a6b0-f709acca6c8f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ba769a63-b8cc-4b2d-abf6-ac33c7204be8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0aa61e00-0a01-4a3c-9945-e93cffedf0e6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-47031206-ce96-41f8-861b-6a915f3de284\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-51522a96-0869-4791-82f3-981000c2c67f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-b5ec538c-daa0-4006-8596-35468b9148e8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-56a5ee18-2ae6-4810-86f7-18e39ce5629b\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2e94d99a-8a36-4563-bc77-810d8893b671\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fafeaf6-7927-4059-a50a-8eb2a7a6f2b5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-99e9ccd8-3db9-4592-b0d1-14b1715a4d8a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f68a601-6e6d-4e42-babf-3f643a047ea2\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ca91455f-eace-4f96-be59-e6e2c35b4816\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-702dd420-7fcc-42c5-afe8-4026edd20fe0\" : { \n        \"value\" : \"Audit\"\n        },\n        \"diagnosticsLogsInRedisCacheMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"secureTransferToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d092e0a-7acd-40d2-a975-dca21cae48c4\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"disableUnrestrictedNetworkToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-55615ac9-af46-4a59-874e-391cc3dfb490\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1b8ca024-1d5c-4dec-8995-b1a932b41780\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-53503636-bcc9-4748-9663-5348217f160f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-40cec1dd-a100-4920-b15b-3024fe8901ab\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-a049bf77-880b-470f-ba6d-9f21c530cf83\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ee980b6d-0eca-4501-8d54-f6290fd512c3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1d84d5fb-01f6-4d12-ba4f-4a26081d403d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-37e0d2fe-28a5-43d6-a273-67d37d1f5606\" : { \n        \"value\" : \"Audit\"\n        },\n        \"identityDesignateMoreThanOneOwnerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"diskEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"emailNotificationToSubscriptionOwnerHighSeverityAlertsEnabledEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlDbEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"aadAuthenticationInSqlServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssEndpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssOsVulnerabilitiesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"adaptiveApplicationControlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForPostgreSQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensureJavaVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityDesignateLessThanOwnersMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"securityContactEmailAddressForSubscriptionEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRestrictCORSAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensurePythonVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForMySQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"systemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"nextGenerationFirewallMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"useRbacRulesMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"webAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlServerAuditingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vnetEnableDDoSProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlServerAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"endpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"jitNetworkAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"geoRedundantStorageShouldBeEnabledForStorageAccountsEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"vmssSystemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"longtermGeoRedundantBackupEnabledAzureSQLDatabasesEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"systemConfigurationsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"containerBenchmarkMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"kubernetesServiceVersionUpToDateMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlDbVulnerabilityAssesmentMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"membersToIncludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"membersToExcludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"logAnalyticsWorkspaceIDForVMAgents\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n        },\n        \"PHPLatestVersionForAppServices\" : { \n        \"value\" : \"7.4\"\n        },\n        \"JavaLatestVersionForAppServices\" : { \n        \"value\" : \"11\"\n        },\n        \"WindowsPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.6\"\n        },\n        \"LinuxPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.9\"\n        },\n        \"ensureDotNetFrameworkLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"vulnerabilityAssessmentMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForWebAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"microsoftIaaSAntimalwareExtensionShouldBeDeployedOnWindowsServersEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityCenterStandardPricingTierShouldBeSelectedEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachinesEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensurePHPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityContactPhoneNumberShouldBeProvidedForSubscriptionEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForAPIAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnServerMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachineScaleSetsEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        }\n}', '<LAWORKSPACE>', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))))), 'CMMC', createObject('id', '/providers/Microsoft.Authorization/policySetDefinitions/b5629c75-5c77-4422-87b9-2509e680f8de', 'parameters', json(replace('{\n    \"logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n    },\n    \"effect-09024ccc-0c5f-475e-9457-b7c0d9ed487b\" : { \n        \"value\" : \"AuditIfNotExists\"\n    },\n    \"MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f\" :{\n        \"value\": \"\"\n    },\n    \"MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7\": {\n        \"value\": \"\"\n    },\n    \"effect-0961003e-5a0a-4549-abde-af6a37f2724d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b15565f-aa9e-48ba-8619-45960f2c314d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0e60b895-3786-45da-8377-9c6b4b6ac5f9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-17k78e20-9358-41c9-923c-fb736d382a12\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1bc1795e-d44a-4d48-9b3b-6fff0fd5f9ba\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"PHPLatestVersion\" : { \n    \"value\" : \"7.3\"\n    },\n    \"effect-22bee202-a82f-4305-9a2a-6d7f44d4dedb\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-26a828e1-e88f-464e-bbb3-c134a282b9de\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-34c877ad-507e-4c82-993e-3452a6e0ad3c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3c735d8a-a4ba-4a3a-b7cf-db7754cf57f4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-404c3081-a854-4457-ae30-26a93ef643f9\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-47a6b606-51aa-4496-8bb7-64b11cf66adc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-496223c3-ad65-4ecd-878a-bae78737e9ed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"JavaLatestVersion\" : { \n    \"value\" : \"11\"\n    },\n    \"effect-4f11b553-d42e-4e3a-89be-32ca364cad4c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4f4f78b8-e367-4b10-a341-d9a4ad5cf1c7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5c607a2e-c700-4744-8254-d77e7c9eb5e4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5f76cf89-fbf2-47fd-a3f4-b891fa780b60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6b1cbf55-e8b6-442f-ba4c-7246b6381474\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6d555dd1-86f2-4f1c-8ed7-5abae7c6cbab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7008174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"LinuxPythonLatestVersion\" : { \n    \"value\" : \"3.8\"\n    },\n    \"effect-7238174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7261b898-8a84-4db8-9e04-18527132abb3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-74c3584d-afae-46f7-a20a-6f8adba71a16\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-86b3d65f-7626-441e-b690-81a8b71cff60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-88999f4c-376a-45c8-bcb3-4058f713cf39\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8c122334-9d20-4eb8-89ea-ac9a705b74ae\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8cb6aa8b-9e41-4f4e-aa25-089a7ac2581e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9297c21d-2ed6-4474-b48f-163f75654ce3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-991310cd-e9f3-47bc-b7b6-f57b557d07db\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9b597639-28e4-48eb-b506-56b05d366257\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9d0b6ea4-93e2-4578-bf2f-6bb17d22b4bc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9daedab3-fb2d-461e-b861-71790eead4f6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a4af4a39-4135-47fb-b175-47fbdf85311d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"enabled\"\n    },\n    \"effect-a70ca396-0a34-413a-88e1-b956c1e683be\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-aa633080-8b72-40c4-a2d7-d00c03e80bed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb4388-5bf4-4ad7-ba82-2cd2f41ceae9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb7388-5bf4-4ad7-ba99-2cd2f41cebb9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-af6cd1bd-1635-48cb-bde7-5b15693900b9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\" : { \n    \"value\" : \"NetworkWatcherRG\"\n    },\n    \"effect-b7ddfbdc-1260-477d-91fd-98bd9be789a6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c3f317a7-a95c-4547-b7e7-11017ebdf2fe\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-cb510bfd-1cba-4d9f-a230-cb0976f4bb71\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e2c1c086-2d84-4019-bff3-c44ccd95113c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e3576e28-8b17-4677-84c3-db2990658d64\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e8cbc669-f12d-49eb-93e7-9273119e9933\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e9c8d085-d9cc-4b17-9cdc-059f1f01f19e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ebb62a0c-3560-49e1-89ed-27e074e9f8ad\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-efbde977-ba53-4479-b8e9-10b957924fbf\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f0e6e85b-9b9f-4a4b-b67b-f730d42f1b0b\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f6de0be7-9a8a-4b8a-b349-43cf02d22f7c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f8456c1c-aa66-4dfb-861a-25d127b775c9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f9d614c5-c173-4d56-95a7-b4437057d193\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-fb893a29-21bb-418c-a157-e99480ec364c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-feedbf84-6b99-488c-acc2-71c829aa5ffc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-3b980d31-7904-4bb7-8575-5665739a8052\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6e2593d9-add6-4083-9c9b-4b7d2188c899\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b607c5de-e7d9-4eee-9e5c-83f1bcee4fa0\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-013e242c-8828-4970-87b3-ab247555486d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d38fc420-0735-4ef3-ac11-c806f651a570\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a1181c5f-672a-477a-979a-7d58aa086233\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-308fbb08-4ab8-4e67-9b29-592e93fb94fa\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4da35fc9-c9e7-4960-aec9-797fe7d9051d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-523b5cd1-3e23-492f-a539-13118b6d1e3a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7fe3b40f-802b-4cdd-8bd4-fd799c948cc2\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c25d9a16-bc35-4e15-a7e5-9db606bf9ed4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b0f33259-77d7-4c9e-aac6-3aabcfae693c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0820b7b9-23aa-4725-a1ce-ae4558f718e5\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-358c20a6-3f9e-4f0e-97ff-c6ce485e2aac\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5744710e-cc2f-4ee8-8809-3b11e89f4bc9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ac4a19c2-fa67-49b4-8ae5-0b2e78c49457\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c9d007d0-c057-4772-b18c-01e546713bcd\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e372f825-a257-4fb8-9175-797a8a8627d6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d158790f-bfb0-486c-8631-2dc6b4e8e6af\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e802a67a-daf5-4436-9ea6-f6d821dd0c5d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a451c1ef-c6ca-483d-87ed-f49761e3ffb5\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftSql-servers-firewallRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ae89ebca-1c92-4898-ac2c-9f63decb045c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d26f7642-7545-4e18-9b75-8c9bbdee3a9a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1a4e592a-6a6e-44a5-9814-e36264ca96e7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7796937f-307b-4598-941c-67d3a05ebfe7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c5447c04-a4d7-4ba8-a263-c9ee321a6858\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-41388f1c-2db0-4c25-95b2-35d7f5ccbfa9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b02aacc0-b073-424e-8298-42b22829ee0a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-057d6cfe-9c4f-4a6d-bc60-14420ea1f1a9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0ec47710-77ff-4a3d-9181-6aa50af424d0\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-48af4db5-9b8b-401c-8e74-076be876a430\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-82339799-d096-41ae-8538-b108becf0970\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1b7aa243-30e4-4c9e-bca8-d0d3022b634a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ef2a8f2a-b3d9-49cd-a8a8-9a3aaaf647d9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-bb91dfba-c30d-4263-9add-9c2384e659a6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e71308d3-144b-4262-b144-efdc3cc90517\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2bdd0062-9d75-436e-89df-487dd8e4b3c7\" : { \n    \"value\" : \"Disabled\"\n    },\n    \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-6fac406b-40ca-413b-bf8e-0bf964659c25\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-048248b0-55cd-46da-b1ff-39efd52db260\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0d134df8-db83-46fb-ad72-fe0c9428c8dd\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fb2\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n    \"value\" : \"audit\"\n    },\n    \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c43e4a30-77cb-48ab-a4dd-93f175c63b57\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1f314764-cb73-4fc9-b863-8eca98ac36e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-123a3936-f020-408a-ba0c-47873faf1534\" : { \n    \"value\" : \"AuditIfNotExists\"\n    }\n}\n', '<LAWORKSPACE>', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName')), '2021-06-01').customerId))))[variables('modifiedAssignment')].parameters]"
-              },
-              "identity": {
-                "type": "SystemAssigned"
-              }
-            },
-            {
-              "type": "Microsoft.Authorization/policyAssignments",
-              "apiVersion": "2020-09-01",
-              "name": "[variables('agentVmssAssignmentName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/75714362-cae7-409e-9b99-a8e5075b7fad",
-                "parameters": {
-                  "logAnalytics_1": {
-                    "value": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
-                  }
-                }
-              },
-              "identity": {
-                "type": "SystemAssigned"
-              }
-            },
-            {
-              "type": "Microsoft.Authorization/policyAssignments",
-              "apiVersion": "2020-09-01",
-              "name": "[variables('agentVmAssignmentName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/55f3eceb-5573-4f18-9695-226972c6d74a",
-                "parameters": {
-                  "logAnalytics_1": {
-                    "value": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
-                  }
-                }
-              },
-              "identity": {
-                "type": "SystemAssigned"
-              }
-            },
-            {
-              "condition": "[not(empty(variables('modifiedAssignment')))]",
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2020-04-01-preview",
-              "name": "[guid(variables('contributorRoleDefinitionId'), variables('assignmentName'))]",
-              "properties": {
-                "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
-                "principalId": "[if(empty(variables('modifiedAssignment')), '', reference(resourceId('Microsoft.Authorization/policyAssignments', variables('assignmentName')), '2020-09-01', 'full').identity.principalId)]",
-                "principalType": "ServicePrincipal"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Authorization/policyAssignments', variables('assignmentName'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2020-04-01-preview",
-              "name": "[guid(variables('contributorRoleDefinitionId'), variables('agentVmssAssignmentName'))]",
-              "properties": {
-                "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
-                "principalId": "[reference(resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmssAssignmentName')), '2020-09-01', 'full').identity.principalId]",
-                "principalType": "ServicePrincipal"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmssAssignmentName'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2020-04-01-preview",
-              "name": "[guid(variables('contributorRoleDefinitionId'), variables('agentVmAssignmentName'))]",
-              "properties": {
-                "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
-                "principalId": "[reference(resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmAssignmentName')), '2020-09-01', 'full').identity.principalId]",
-                "principalType": "ServicePrincipal"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmAssignmentName'))]"
-              ]
-            },
-            {
-              "condition": "[parameters('deployRemediation')]",
-              "type": "Microsoft.PolicyInsights/remediations",
-              "apiVersion": "2019-07-01",
-              "name": "VM-Agent-Policy-Remediation",
-              "properties": {
-                "policyAssignmentId": "[resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmAssignmentName'))]",
-                "resourceDiscoveryMode": "ReEvaluateCompliance"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmAssignmentName'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "[format('Assign-Laws-Role-Policy-{0}', resourceGroup().name)]",
-              "subscriptionId": "[parameters('operationsSubscriptionId')]",
-              "resourceGroup": "[parameters('logAnalyticsWorkspaceResourceGroupName')]",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "targetResourceId": {
-                    "value": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
-                  },
-                  "roleDefinitionId": {
-                    "value": "[variables('lawsReaderRoleDefinitionId')]"
-                  },
-                  "principalId": {
-                    "value": "[reference(resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmAssignmentName')), '2020-09-01', 'full').identity.principalId]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "7736875138030857363"
-                    }
-                  },
-                  "parameters": {
-                    "targetResourceId": {
-                      "type": "string"
-                    },
-                    "roleDefinitionId": {
-                      "type": "string"
-                    },
-                    "principalId": {
-                      "type": "string"
-                    },
-                    "principalType": {
-                      "type": "string",
-                      "defaultValue": "ServicePrincipal",
-                      "allowedValues": [
-                        "User",
-                        "Group",
-                        "ServicePrincipal",
-                        "Unknown",
-                        "DirectoryRoleTemplate",
-                        "ForeignGroup",
-                        "Application",
-                        "MSI",
-                        "DirectoryObjectOrGroup",
-                        "Everyone"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "defaultValue": ""
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Authorization/roleAssignments",
-                      "apiVersion": "2020-04-01-preview",
-                      "name": "[guid(parameters('targetResourceId'), parameters('roleDefinitionId'), parameters('principalId'))]",
-                      "properties": {
-                        "principalId": "[parameters('principalId')]",
-                        "principalType": "[parameters('principalType')]",
-                        "roleDefinitionId": "[parameters('roleDefinitionId')]",
-                        "description": "[parameters('description')]"
-                      }
-                    }
-                  ]
-                }
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmAssignmentName'))]"
-              ]
-            }
-          ]
-        }
-      },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]",
-        "[subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc')))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
-      "name": "[format('assign-policy-identity-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('identitySubscriptionId')]",
-      "resourceGroup": "[parameters('identityResourceGroupName')]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "builtInAssignment": {
-            "value": "[parameters('policy')]"
-          },
-          "logAnalyticsWorkspaceName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-          },
-          "logAnalyticsWorkspaceResourceGroupName": {
-            "value": "[reference(subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-          },
-          "operationsSubscriptionId": {
-            "value": "[parameters('operationsSubscriptionId')]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "943351948581975691"
-            }
-          },
-          "parameters": {
-            "builtInAssignment": {
-              "type": "string",
-              "defaultValue": ""
-            },
-            "logAnalyticsWorkspaceName": {
-              "type": "string"
-            },
-            "logAnalyticsWorkspaceResourceGroupName": {
-              "type": "string"
-            },
-            "operationsSubscriptionId": {
-              "type": "string"
-            },
-            "deployRemediation": {
-              "type": "bool",
-              "defaultValue": false,
-              "metadata": {
-                "description": "Starts a policy remediation for the VM Agent policies in hub RG. Set to false by default since this is time consuming in deployment."
-              }
-            }
-          },
-          "functions": [],
-          "variables": {
-            "modifiedAssignment": "[if(and(equals(toLower(environment().name), toLower('AzureCloud')), equals(toLower(parameters('builtInAssignment')), toLower('IL5'))), 'NIST', parameters('builtInAssignment'))]",
-            "assignmentName": "[format('{0} {1}', variables('modifiedAssignment'), resourceGroup().name)]",
-            "agentVmssAssignmentName": "[format('Deploy VMSS Agents {0}', resourceGroup().name)]",
-            "agentVmAssignmentName": "[format('Deploy VM Agents {0}', resourceGroup().name)]",
-            "contributorRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-            "lawsReaderRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')]"
-          },
-          "resources": [
-            {
-              "condition": "[not(empty(variables('modifiedAssignment')))]",
-              "type": "Microsoft.Authorization/policyAssignments",
-              "apiVersion": "2020-09-01",
-              "name": "[variables('assignmentName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "policyDefinitionId": "[createObject('NIST', createObject('id', '/providers/Microsoft.Authorization/policySetDefinitions/cf25b9c1-bd23-4eb6-bd2c-f4f3ac644a5f', 'parameters', json(replace('    {\n        \"listOfMembersToExcludeFromWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"admin\"\n        },\n        \"listOfMembersToIncludeInWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"azureuser\"\n        },\n        \"logAnalyticsWorkspaceIdforVMReporting\": \n        {\n        \"value\": \"<LAWORKSPACE>\"\n        },\n        \"IncludeArcMachines\": \n        {\n            \"value\": \"true\"\n        },\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \n        {\n            \"value\": \"1.2\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \n        {\n            \"value\": \"Compliant\"\n        },\n        \"requiredRetentionDays\": \n        {\n            \"value\": \"365\"\n        },\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \n        {\n            \"value\": \"NetworkWatcherRG\"\n        }\n    }', '<LAWORKSPACE>', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))))), 'IL5', createObject('id', '/providers/Microsoft.Authorization/policySetDefinitions/f9a961fa-3241-4b20-adc4-bbf8ad9d7197', 'parameters', json(replace('{\n    \"IncludeArcMachines\" : { \n        \"value\" : \"false\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\" : { \n        \"value\" : \"Compliant\"\n        },\n        \"MinimumTLSVersionForWindowsServers\" : { \n        \"value\" : \"1.2\"\n        },\n        \"requiredRetentionDays\" : { \n        \"value\" : \"365\"\n        },\n        \"effect-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"audit\"\n        },\n        \"allowedContainerImagesRegex-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"^(.+){0}$\"\n        },\n        \"effect-95edb821-ddaf-4404-9732-666045e056b4\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-440b515e-a580-421e-abeb-b159a61ddcbc\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-233a2a17-77ca-4fb1-9b6b-69223d272a44\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"audit\"\n        },\n        \"cpuLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"memoryLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"effect-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"audit\"\n        },\n        \"runAsUserRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"MustRunAsNonRoot\"\n        },\n        \"runAsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"supplementalGroupsRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"fsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"effect-1c6e92c9-99f0-4e55-9cf2-0c234dc48f99\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-47a1ee2f-2a2a-4576-bf2a-e0e36709c2b8\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-df49d893-a74c-421d-bc95-c663042e5b80\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-1a5b4dca-0b6f-4cf5-907c-56316bc1bf3d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-c26596ff-4d70-4e6a-9a30-c2506bd2f80c\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-511f5417-5d12-434d-ab2e-816901e72a5e\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-82985f06-dc18-4a48-bc1c-b9f4f0098cfe\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-098fc59e-46c7-4d99-9b16-64990e543d75\" : { \n        \"value\" : \"audit\"\n        },\n        \"NetworkWatcherResourceGroupName\" : { \n        \"value\" : \"NetworkWatcherRG\"\n        },\n        \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n        \"value\" : \"enabled\"\n        },\n        \"aadAuthenticationInServiceFabricMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-71ef260a-8f18-47b7-abcb-62d0673d94dc\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-862e97cf-49fc-4a5c-9de4-40d4e2e7c8eb\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d9da03a1-f3c3-412a-9709-947156872263\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-b4ac1030-89c5-4697-8e00-28b5ba6a8811\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-ea0dfaed-95fb-448c-934e-d6e713ce393d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-41425d9f-d1a5-499a-9932-f8ed8453932c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fc4d8e41-e223-45ea-9bf5-eada37891d87\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-86efb160-8de7-451d-bc08-5d475b0aadae\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-4ec52d6d-beb7-40c4-9a9e-fe753254690e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-64d314f6-6062-4780-a861-c23e8951bee5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fd32ebd-e4c3-4e13-a54a-d7422d4d95f6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fa298e57-9444-42ba-bf04-86e8470e32c7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f905d99-2ab7-462c-a6b0-f709acca6c8f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ba769a63-b8cc-4b2d-abf6-ac33c7204be8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0aa61e00-0a01-4a3c-9945-e93cffedf0e6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-47031206-ce96-41f8-861b-6a915f3de284\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-51522a96-0869-4791-82f3-981000c2c67f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-b5ec538c-daa0-4006-8596-35468b9148e8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-56a5ee18-2ae6-4810-86f7-18e39ce5629b\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2e94d99a-8a36-4563-bc77-810d8893b671\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fafeaf6-7927-4059-a50a-8eb2a7a6f2b5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-99e9ccd8-3db9-4592-b0d1-14b1715a4d8a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f68a601-6e6d-4e42-babf-3f643a047ea2\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ca91455f-eace-4f96-be59-e6e2c35b4816\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-702dd420-7fcc-42c5-afe8-4026edd20fe0\" : { \n        \"value\" : \"Audit\"\n        },\n        \"diagnosticsLogsInRedisCacheMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"secureTransferToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d092e0a-7acd-40d2-a975-dca21cae48c4\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"disableUnrestrictedNetworkToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-55615ac9-af46-4a59-874e-391cc3dfb490\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1b8ca024-1d5c-4dec-8995-b1a932b41780\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-53503636-bcc9-4748-9663-5348217f160f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-40cec1dd-a100-4920-b15b-3024fe8901ab\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-a049bf77-880b-470f-ba6d-9f21c530cf83\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ee980b6d-0eca-4501-8d54-f6290fd512c3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1d84d5fb-01f6-4d12-ba4f-4a26081d403d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-37e0d2fe-28a5-43d6-a273-67d37d1f5606\" : { \n        \"value\" : \"Audit\"\n        },\n        \"identityDesignateMoreThanOneOwnerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"diskEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"emailNotificationToSubscriptionOwnerHighSeverityAlertsEnabledEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlDbEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"aadAuthenticationInSqlServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssEndpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssOsVulnerabilitiesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"adaptiveApplicationControlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForPostgreSQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensureJavaVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityDesignateLessThanOwnersMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"securityContactEmailAddressForSubscriptionEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRestrictCORSAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensurePythonVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForMySQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"systemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"nextGenerationFirewallMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"useRbacRulesMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"webAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlServerAuditingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vnetEnableDDoSProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlServerAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"endpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"jitNetworkAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"geoRedundantStorageShouldBeEnabledForStorageAccountsEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"vmssSystemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"longtermGeoRedundantBackupEnabledAzureSQLDatabasesEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"systemConfigurationsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"containerBenchmarkMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"kubernetesServiceVersionUpToDateMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlDbVulnerabilityAssesmentMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"membersToIncludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"membersToExcludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"logAnalyticsWorkspaceIDForVMAgents\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n        },\n        \"PHPLatestVersionForAppServices\" : { \n        \"value\" : \"7.4\"\n        },\n        \"JavaLatestVersionForAppServices\" : { \n        \"value\" : \"11\"\n        },\n        \"WindowsPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.6\"\n        },\n        \"LinuxPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.9\"\n        },\n        \"ensureDotNetFrameworkLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"vulnerabilityAssessmentMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForWebAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"microsoftIaaSAntimalwareExtensionShouldBeDeployedOnWindowsServersEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityCenterStandardPricingTierShouldBeSelectedEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachinesEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensurePHPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityContactPhoneNumberShouldBeProvidedForSubscriptionEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForAPIAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnServerMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachineScaleSetsEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        }\n}', '<LAWORKSPACE>', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))))), 'CMMC', createObject('id', '/providers/Microsoft.Authorization/policySetDefinitions/b5629c75-5c77-4422-87b9-2509e680f8de', 'parameters', json(replace('{\n    \"logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n    },\n    \"effect-09024ccc-0c5f-475e-9457-b7c0d9ed487b\" : { \n        \"value\" : \"AuditIfNotExists\"\n    },\n    \"MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f\" :{\n        \"value\": \"\"\n    },\n    \"MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7\": {\n        \"value\": \"\"\n    },\n    \"effect-0961003e-5a0a-4549-abde-af6a37f2724d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b15565f-aa9e-48ba-8619-45960f2c314d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0e60b895-3786-45da-8377-9c6b4b6ac5f9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-17k78e20-9358-41c9-923c-fb736d382a12\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1bc1795e-d44a-4d48-9b3b-6fff0fd5f9ba\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"PHPLatestVersion\" : { \n    \"value\" : \"7.3\"\n    },\n    \"effect-22bee202-a82f-4305-9a2a-6d7f44d4dedb\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-26a828e1-e88f-464e-bbb3-c134a282b9de\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-34c877ad-507e-4c82-993e-3452a6e0ad3c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3c735d8a-a4ba-4a3a-b7cf-db7754cf57f4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-404c3081-a854-4457-ae30-26a93ef643f9\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-47a6b606-51aa-4496-8bb7-64b11cf66adc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-496223c3-ad65-4ecd-878a-bae78737e9ed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"JavaLatestVersion\" : { \n    \"value\" : \"11\"\n    },\n    \"effect-4f11b553-d42e-4e3a-89be-32ca364cad4c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4f4f78b8-e367-4b10-a341-d9a4ad5cf1c7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5c607a2e-c700-4744-8254-d77e7c9eb5e4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5f76cf89-fbf2-47fd-a3f4-b891fa780b60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6b1cbf55-e8b6-442f-ba4c-7246b6381474\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6d555dd1-86f2-4f1c-8ed7-5abae7c6cbab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7008174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"LinuxPythonLatestVersion\" : { \n    \"value\" : \"3.8\"\n    },\n    \"effect-7238174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7261b898-8a84-4db8-9e04-18527132abb3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-74c3584d-afae-46f7-a20a-6f8adba71a16\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-86b3d65f-7626-441e-b690-81a8b71cff60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-88999f4c-376a-45c8-bcb3-4058f713cf39\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8c122334-9d20-4eb8-89ea-ac9a705b74ae\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8cb6aa8b-9e41-4f4e-aa25-089a7ac2581e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9297c21d-2ed6-4474-b48f-163f75654ce3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-991310cd-e9f3-47bc-b7b6-f57b557d07db\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9b597639-28e4-48eb-b506-56b05d366257\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9d0b6ea4-93e2-4578-bf2f-6bb17d22b4bc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9daedab3-fb2d-461e-b861-71790eead4f6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a4af4a39-4135-47fb-b175-47fbdf85311d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"enabled\"\n    },\n    \"effect-a70ca396-0a34-413a-88e1-b956c1e683be\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-aa633080-8b72-40c4-a2d7-d00c03e80bed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb4388-5bf4-4ad7-ba82-2cd2f41ceae9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb7388-5bf4-4ad7-ba99-2cd2f41cebb9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-af6cd1bd-1635-48cb-bde7-5b15693900b9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\" : { \n    \"value\" : \"NetworkWatcherRG\"\n    },\n    \"effect-b7ddfbdc-1260-477d-91fd-98bd9be789a6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c3f317a7-a95c-4547-b7e7-11017ebdf2fe\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-cb510bfd-1cba-4d9f-a230-cb0976f4bb71\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e2c1c086-2d84-4019-bff3-c44ccd95113c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e3576e28-8b17-4677-84c3-db2990658d64\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e8cbc669-f12d-49eb-93e7-9273119e9933\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e9c8d085-d9cc-4b17-9cdc-059f1f01f19e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ebb62a0c-3560-49e1-89ed-27e074e9f8ad\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-efbde977-ba53-4479-b8e9-10b957924fbf\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f0e6e85b-9b9f-4a4b-b67b-f730d42f1b0b\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f6de0be7-9a8a-4b8a-b349-43cf02d22f7c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f8456c1c-aa66-4dfb-861a-25d127b775c9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f9d614c5-c173-4d56-95a7-b4437057d193\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-fb893a29-21bb-418c-a157-e99480ec364c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-feedbf84-6b99-488c-acc2-71c829aa5ffc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-3b980d31-7904-4bb7-8575-5665739a8052\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6e2593d9-add6-4083-9c9b-4b7d2188c899\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b607c5de-e7d9-4eee-9e5c-83f1bcee4fa0\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-013e242c-8828-4970-87b3-ab247555486d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d38fc420-0735-4ef3-ac11-c806f651a570\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a1181c5f-672a-477a-979a-7d58aa086233\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-308fbb08-4ab8-4e67-9b29-592e93fb94fa\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4da35fc9-c9e7-4960-aec9-797fe7d9051d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-523b5cd1-3e23-492f-a539-13118b6d1e3a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7fe3b40f-802b-4cdd-8bd4-fd799c948cc2\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c25d9a16-bc35-4e15-a7e5-9db606bf9ed4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b0f33259-77d7-4c9e-aac6-3aabcfae693c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0820b7b9-23aa-4725-a1ce-ae4558f718e5\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-358c20a6-3f9e-4f0e-97ff-c6ce485e2aac\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5744710e-cc2f-4ee8-8809-3b11e89f4bc9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ac4a19c2-fa67-49b4-8ae5-0b2e78c49457\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c9d007d0-c057-4772-b18c-01e546713bcd\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e372f825-a257-4fb8-9175-797a8a8627d6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d158790f-bfb0-486c-8631-2dc6b4e8e6af\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e802a67a-daf5-4436-9ea6-f6d821dd0c5d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a451c1ef-c6ca-483d-87ed-f49761e3ffb5\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftSql-servers-firewallRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ae89ebca-1c92-4898-ac2c-9f63decb045c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d26f7642-7545-4e18-9b75-8c9bbdee3a9a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1a4e592a-6a6e-44a5-9814-e36264ca96e7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7796937f-307b-4598-941c-67d3a05ebfe7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c5447c04-a4d7-4ba8-a263-c9ee321a6858\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-41388f1c-2db0-4c25-95b2-35d7f5ccbfa9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b02aacc0-b073-424e-8298-42b22829ee0a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-057d6cfe-9c4f-4a6d-bc60-14420ea1f1a9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0ec47710-77ff-4a3d-9181-6aa50af424d0\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-48af4db5-9b8b-401c-8e74-076be876a430\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-82339799-d096-41ae-8538-b108becf0970\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1b7aa243-30e4-4c9e-bca8-d0d3022b634a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ef2a8f2a-b3d9-49cd-a8a8-9a3aaaf647d9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-bb91dfba-c30d-4263-9add-9c2384e659a6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e71308d3-144b-4262-b144-efdc3cc90517\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2bdd0062-9d75-436e-89df-487dd8e4b3c7\" : { \n    \"value\" : \"Disabled\"\n    },\n    \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-6fac406b-40ca-413b-bf8e-0bf964659c25\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-048248b0-55cd-46da-b1ff-39efd52db260\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0d134df8-db83-46fb-ad72-fe0c9428c8dd\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fb2\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n    \"value\" : \"audit\"\n    },\n    \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c43e4a30-77cb-48ab-a4dd-93f175c63b57\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1f314764-cb73-4fc9-b863-8eca98ac36e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-123a3936-f020-408a-ba0c-47873faf1534\" : { \n    \"value\" : \"AuditIfNotExists\"\n    }\n}\n', '<LAWORKSPACE>', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName')), '2021-06-01').customerId))))[variables('modifiedAssignment')].id]",
-                "parameters": "[createObject('NIST', createObject('id', '/providers/Microsoft.Authorization/policySetDefinitions/cf25b9c1-bd23-4eb6-bd2c-f4f3ac644a5f', 'parameters', json(replace('    {\n        \"listOfMembersToExcludeFromWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"admin\"\n        },\n        \"listOfMembersToIncludeInWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"azureuser\"\n        },\n        \"logAnalyticsWorkspaceIdforVMReporting\": \n        {\n        \"value\": \"<LAWORKSPACE>\"\n        },\n        \"IncludeArcMachines\": \n        {\n            \"value\": \"true\"\n        },\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \n        {\n            \"value\": \"1.2\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \n        {\n            \"value\": \"Compliant\"\n        },\n        \"requiredRetentionDays\": \n        {\n            \"value\": \"365\"\n        },\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \n        {\n            \"value\": \"NetworkWatcherRG\"\n        }\n    }', '<LAWORKSPACE>', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))))), 'IL5', createObject('id', '/providers/Microsoft.Authorization/policySetDefinitions/f9a961fa-3241-4b20-adc4-bbf8ad9d7197', 'parameters', json(replace('{\n    \"IncludeArcMachines\" : { \n        \"value\" : \"false\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\" : { \n        \"value\" : \"Compliant\"\n        },\n        \"MinimumTLSVersionForWindowsServers\" : { \n        \"value\" : \"1.2\"\n        },\n        \"requiredRetentionDays\" : { \n        \"value\" : \"365\"\n        },\n        \"effect-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"audit\"\n        },\n        \"allowedContainerImagesRegex-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"^(.+){0}$\"\n        },\n        \"effect-95edb821-ddaf-4404-9732-666045e056b4\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-440b515e-a580-421e-abeb-b159a61ddcbc\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-233a2a17-77ca-4fb1-9b6b-69223d272a44\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"audit\"\n        },\n        \"cpuLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"memoryLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"effect-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"audit\"\n        },\n        \"runAsUserRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"MustRunAsNonRoot\"\n        },\n        \"runAsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"supplementalGroupsRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"fsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"effect-1c6e92c9-99f0-4e55-9cf2-0c234dc48f99\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-47a1ee2f-2a2a-4576-bf2a-e0e36709c2b8\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-df49d893-a74c-421d-bc95-c663042e5b80\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-1a5b4dca-0b6f-4cf5-907c-56316bc1bf3d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-c26596ff-4d70-4e6a-9a30-c2506bd2f80c\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-511f5417-5d12-434d-ab2e-816901e72a5e\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-82985f06-dc18-4a48-bc1c-b9f4f0098cfe\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-098fc59e-46c7-4d99-9b16-64990e543d75\" : { \n        \"value\" : \"audit\"\n        },\n        \"NetworkWatcherResourceGroupName\" : { \n        \"value\" : \"NetworkWatcherRG\"\n        },\n        \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n        \"value\" : \"enabled\"\n        },\n        \"aadAuthenticationInServiceFabricMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-71ef260a-8f18-47b7-abcb-62d0673d94dc\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-862e97cf-49fc-4a5c-9de4-40d4e2e7c8eb\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d9da03a1-f3c3-412a-9709-947156872263\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-b4ac1030-89c5-4697-8e00-28b5ba6a8811\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-ea0dfaed-95fb-448c-934e-d6e713ce393d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-41425d9f-d1a5-499a-9932-f8ed8453932c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fc4d8e41-e223-45ea-9bf5-eada37891d87\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-86efb160-8de7-451d-bc08-5d475b0aadae\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-4ec52d6d-beb7-40c4-9a9e-fe753254690e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-64d314f6-6062-4780-a861-c23e8951bee5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fd32ebd-e4c3-4e13-a54a-d7422d4d95f6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fa298e57-9444-42ba-bf04-86e8470e32c7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f905d99-2ab7-462c-a6b0-f709acca6c8f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ba769a63-b8cc-4b2d-abf6-ac33c7204be8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0aa61e00-0a01-4a3c-9945-e93cffedf0e6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-47031206-ce96-41f8-861b-6a915f3de284\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-51522a96-0869-4791-82f3-981000c2c67f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-b5ec538c-daa0-4006-8596-35468b9148e8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-56a5ee18-2ae6-4810-86f7-18e39ce5629b\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2e94d99a-8a36-4563-bc77-810d8893b671\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fafeaf6-7927-4059-a50a-8eb2a7a6f2b5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-99e9ccd8-3db9-4592-b0d1-14b1715a4d8a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f68a601-6e6d-4e42-babf-3f643a047ea2\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ca91455f-eace-4f96-be59-e6e2c35b4816\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-702dd420-7fcc-42c5-afe8-4026edd20fe0\" : { \n        \"value\" : \"Audit\"\n        },\n        \"diagnosticsLogsInRedisCacheMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"secureTransferToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d092e0a-7acd-40d2-a975-dca21cae48c4\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"disableUnrestrictedNetworkToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-55615ac9-af46-4a59-874e-391cc3dfb490\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1b8ca024-1d5c-4dec-8995-b1a932b41780\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-53503636-bcc9-4748-9663-5348217f160f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-40cec1dd-a100-4920-b15b-3024fe8901ab\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-a049bf77-880b-470f-ba6d-9f21c530cf83\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ee980b6d-0eca-4501-8d54-f6290fd512c3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1d84d5fb-01f6-4d12-ba4f-4a26081d403d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-37e0d2fe-28a5-43d6-a273-67d37d1f5606\" : { \n        \"value\" : \"Audit\"\n        },\n        \"identityDesignateMoreThanOneOwnerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"diskEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"emailNotificationToSubscriptionOwnerHighSeverityAlertsEnabledEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlDbEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"aadAuthenticationInSqlServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssEndpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssOsVulnerabilitiesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"adaptiveApplicationControlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForPostgreSQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensureJavaVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityDesignateLessThanOwnersMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"securityContactEmailAddressForSubscriptionEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRestrictCORSAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensurePythonVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForMySQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"systemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"nextGenerationFirewallMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"useRbacRulesMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"webAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlServerAuditingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vnetEnableDDoSProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlServerAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"endpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"jitNetworkAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"geoRedundantStorageShouldBeEnabledForStorageAccountsEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"vmssSystemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"longtermGeoRedundantBackupEnabledAzureSQLDatabasesEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"systemConfigurationsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"containerBenchmarkMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"kubernetesServiceVersionUpToDateMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlDbVulnerabilityAssesmentMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"membersToIncludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"membersToExcludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"logAnalyticsWorkspaceIDForVMAgents\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n        },\n        \"PHPLatestVersionForAppServices\" : { \n        \"value\" : \"7.4\"\n        },\n        \"JavaLatestVersionForAppServices\" : { \n        \"value\" : \"11\"\n        },\n        \"WindowsPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.6\"\n        },\n        \"LinuxPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.9\"\n        },\n        \"ensureDotNetFrameworkLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"vulnerabilityAssessmentMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForWebAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"microsoftIaaSAntimalwareExtensionShouldBeDeployedOnWindowsServersEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityCenterStandardPricingTierShouldBeSelectedEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachinesEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensurePHPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityContactPhoneNumberShouldBeProvidedForSubscriptionEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForAPIAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnServerMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachineScaleSetsEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        }\n}', '<LAWORKSPACE>', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))))), 'CMMC', createObject('id', '/providers/Microsoft.Authorization/policySetDefinitions/b5629c75-5c77-4422-87b9-2509e680f8de', 'parameters', json(replace('{\n    \"logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n    },\n    \"effect-09024ccc-0c5f-475e-9457-b7c0d9ed487b\" : { \n        \"value\" : \"AuditIfNotExists\"\n    },\n    \"MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f\" :{\n        \"value\": \"\"\n    },\n    \"MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7\": {\n        \"value\": \"\"\n    },\n    \"effect-0961003e-5a0a-4549-abde-af6a37f2724d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b15565f-aa9e-48ba-8619-45960f2c314d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0e60b895-3786-45da-8377-9c6b4b6ac5f9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-17k78e20-9358-41c9-923c-fb736d382a12\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1bc1795e-d44a-4d48-9b3b-6fff0fd5f9ba\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"PHPLatestVersion\" : { \n    \"value\" : \"7.3\"\n    },\n    \"effect-22bee202-a82f-4305-9a2a-6d7f44d4dedb\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-26a828e1-e88f-464e-bbb3-c134a282b9de\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-34c877ad-507e-4c82-993e-3452a6e0ad3c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3c735d8a-a4ba-4a3a-b7cf-db7754cf57f4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-404c3081-a854-4457-ae30-26a93ef643f9\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-47a6b606-51aa-4496-8bb7-64b11cf66adc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-496223c3-ad65-4ecd-878a-bae78737e9ed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"JavaLatestVersion\" : { \n    \"value\" : \"11\"\n    },\n    \"effect-4f11b553-d42e-4e3a-89be-32ca364cad4c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4f4f78b8-e367-4b10-a341-d9a4ad5cf1c7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5c607a2e-c700-4744-8254-d77e7c9eb5e4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5f76cf89-fbf2-47fd-a3f4-b891fa780b60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6b1cbf55-e8b6-442f-ba4c-7246b6381474\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6d555dd1-86f2-4f1c-8ed7-5abae7c6cbab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7008174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"LinuxPythonLatestVersion\" : { \n    \"value\" : \"3.8\"\n    },\n    \"effect-7238174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7261b898-8a84-4db8-9e04-18527132abb3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-74c3584d-afae-46f7-a20a-6f8adba71a16\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-86b3d65f-7626-441e-b690-81a8b71cff60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-88999f4c-376a-45c8-bcb3-4058f713cf39\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8c122334-9d20-4eb8-89ea-ac9a705b74ae\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8cb6aa8b-9e41-4f4e-aa25-089a7ac2581e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9297c21d-2ed6-4474-b48f-163f75654ce3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-991310cd-e9f3-47bc-b7b6-f57b557d07db\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9b597639-28e4-48eb-b506-56b05d366257\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9d0b6ea4-93e2-4578-bf2f-6bb17d22b4bc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9daedab3-fb2d-461e-b861-71790eead4f6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a4af4a39-4135-47fb-b175-47fbdf85311d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"enabled\"\n    },\n    \"effect-a70ca396-0a34-413a-88e1-b956c1e683be\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-aa633080-8b72-40c4-a2d7-d00c03e80bed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb4388-5bf4-4ad7-ba82-2cd2f41ceae9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb7388-5bf4-4ad7-ba99-2cd2f41cebb9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-af6cd1bd-1635-48cb-bde7-5b15693900b9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\" : { \n    \"value\" : \"NetworkWatcherRG\"\n    },\n    \"effect-b7ddfbdc-1260-477d-91fd-98bd9be789a6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c3f317a7-a95c-4547-b7e7-11017ebdf2fe\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-cb510bfd-1cba-4d9f-a230-cb0976f4bb71\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e2c1c086-2d84-4019-bff3-c44ccd95113c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e3576e28-8b17-4677-84c3-db2990658d64\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e8cbc669-f12d-49eb-93e7-9273119e9933\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e9c8d085-d9cc-4b17-9cdc-059f1f01f19e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ebb62a0c-3560-49e1-89ed-27e074e9f8ad\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-efbde977-ba53-4479-b8e9-10b957924fbf\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f0e6e85b-9b9f-4a4b-b67b-f730d42f1b0b\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f6de0be7-9a8a-4b8a-b349-43cf02d22f7c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f8456c1c-aa66-4dfb-861a-25d127b775c9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f9d614c5-c173-4d56-95a7-b4437057d193\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-fb893a29-21bb-418c-a157-e99480ec364c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-feedbf84-6b99-488c-acc2-71c829aa5ffc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-3b980d31-7904-4bb7-8575-5665739a8052\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6e2593d9-add6-4083-9c9b-4b7d2188c899\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b607c5de-e7d9-4eee-9e5c-83f1bcee4fa0\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-013e242c-8828-4970-87b3-ab247555486d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d38fc420-0735-4ef3-ac11-c806f651a570\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a1181c5f-672a-477a-979a-7d58aa086233\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-308fbb08-4ab8-4e67-9b29-592e93fb94fa\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4da35fc9-c9e7-4960-aec9-797fe7d9051d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-523b5cd1-3e23-492f-a539-13118b6d1e3a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7fe3b40f-802b-4cdd-8bd4-fd799c948cc2\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c25d9a16-bc35-4e15-a7e5-9db606bf9ed4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b0f33259-77d7-4c9e-aac6-3aabcfae693c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0820b7b9-23aa-4725-a1ce-ae4558f718e5\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-358c20a6-3f9e-4f0e-97ff-c6ce485e2aac\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5744710e-cc2f-4ee8-8809-3b11e89f4bc9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ac4a19c2-fa67-49b4-8ae5-0b2e78c49457\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c9d007d0-c057-4772-b18c-01e546713bcd\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e372f825-a257-4fb8-9175-797a8a8627d6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d158790f-bfb0-486c-8631-2dc6b4e8e6af\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e802a67a-daf5-4436-9ea6-f6d821dd0c5d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a451c1ef-c6ca-483d-87ed-f49761e3ffb5\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftSql-servers-firewallRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ae89ebca-1c92-4898-ac2c-9f63decb045c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d26f7642-7545-4e18-9b75-8c9bbdee3a9a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1a4e592a-6a6e-44a5-9814-e36264ca96e7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7796937f-307b-4598-941c-67d3a05ebfe7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c5447c04-a4d7-4ba8-a263-c9ee321a6858\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-41388f1c-2db0-4c25-95b2-35d7f5ccbfa9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b02aacc0-b073-424e-8298-42b22829ee0a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-057d6cfe-9c4f-4a6d-bc60-14420ea1f1a9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0ec47710-77ff-4a3d-9181-6aa50af424d0\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-48af4db5-9b8b-401c-8e74-076be876a430\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-82339799-d096-41ae-8538-b108becf0970\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1b7aa243-30e4-4c9e-bca8-d0d3022b634a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ef2a8f2a-b3d9-49cd-a8a8-9a3aaaf647d9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-bb91dfba-c30d-4263-9add-9c2384e659a6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e71308d3-144b-4262-b144-efdc3cc90517\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2bdd0062-9d75-436e-89df-487dd8e4b3c7\" : { \n    \"value\" : \"Disabled\"\n    },\n    \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-6fac406b-40ca-413b-bf8e-0bf964659c25\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-048248b0-55cd-46da-b1ff-39efd52db260\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0d134df8-db83-46fb-ad72-fe0c9428c8dd\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fb2\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n    \"value\" : \"audit\"\n    },\n    \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c43e4a30-77cb-48ab-a4dd-93f175c63b57\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1f314764-cb73-4fc9-b863-8eca98ac36e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-123a3936-f020-408a-ba0c-47873faf1534\" : { \n    \"value\" : \"AuditIfNotExists\"\n    }\n}\n', '<LAWORKSPACE>', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName')), '2021-06-01').customerId))))[variables('modifiedAssignment')].parameters]"
-              },
-              "identity": {
-                "type": "SystemAssigned"
-              }
-            },
-            {
-              "type": "Microsoft.Authorization/policyAssignments",
-              "apiVersion": "2020-09-01",
-              "name": "[variables('agentVmssAssignmentName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/75714362-cae7-409e-9b99-a8e5075b7fad",
-                "parameters": {
-                  "logAnalytics_1": {
-                    "value": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
-                  }
-                }
-              },
-              "identity": {
-                "type": "SystemAssigned"
-              }
-            },
-            {
-              "type": "Microsoft.Authorization/policyAssignments",
-              "apiVersion": "2020-09-01",
-              "name": "[variables('agentVmAssignmentName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/55f3eceb-5573-4f18-9695-226972c6d74a",
-                "parameters": {
-                  "logAnalytics_1": {
-                    "value": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
-                  }
-                }
-              },
-              "identity": {
-                "type": "SystemAssigned"
-              }
-            },
-            {
-              "condition": "[not(empty(variables('modifiedAssignment')))]",
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2020-04-01-preview",
-              "name": "[guid(variables('contributorRoleDefinitionId'), variables('assignmentName'))]",
-              "properties": {
-                "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
-                "principalId": "[if(empty(variables('modifiedAssignment')), '', reference(resourceId('Microsoft.Authorization/policyAssignments', variables('assignmentName')), '2020-09-01', 'full').identity.principalId)]",
-                "principalType": "ServicePrincipal"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Authorization/policyAssignments', variables('assignmentName'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2020-04-01-preview",
-              "name": "[guid(variables('contributorRoleDefinitionId'), variables('agentVmssAssignmentName'))]",
-              "properties": {
-                "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
-                "principalId": "[reference(resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmssAssignmentName')), '2020-09-01', 'full').identity.principalId]",
-                "principalType": "ServicePrincipal"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmssAssignmentName'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2020-04-01-preview",
-              "name": "[guid(variables('contributorRoleDefinitionId'), variables('agentVmAssignmentName'))]",
-              "properties": {
-                "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
-                "principalId": "[reference(resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmAssignmentName')), '2020-09-01', 'full').identity.principalId]",
-                "principalType": "ServicePrincipal"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmAssignmentName'))]"
-              ]
-            },
-            {
-              "condition": "[parameters('deployRemediation')]",
-              "type": "Microsoft.PolicyInsights/remediations",
-              "apiVersion": "2019-07-01",
-              "name": "VM-Agent-Policy-Remediation",
-              "properties": {
-                "policyAssignmentId": "[resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmAssignmentName'))]",
-                "resourceDiscoveryMode": "ReEvaluateCompliance"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmAssignmentName'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
-              "name": "[format('Assign-Laws-Role-Policy-{0}', resourceGroup().name)]",
-              "subscriptionId": "[parameters('operationsSubscriptionId')]",
-              "resourceGroup": "[parameters('logAnalyticsWorkspaceResourceGroupName')]",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "targetResourceId": {
-                    "value": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('logAnalyticsWorkspaceResourceGroupName')), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
-                  },
-                  "roleDefinitionId": {
-                    "value": "[variables('lawsReaderRoleDefinitionId')]"
-                  },
-                  "principalId": {
-                    "value": "[reference(resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmAssignmentName')), '2020-09-01', 'full').identity.principalId]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "7736875138030857363"
-                    }
-                  },
-                  "parameters": {
-                    "targetResourceId": {
-                      "type": "string"
-                    },
-                    "roleDefinitionId": {
-                      "type": "string"
-                    },
-                    "principalId": {
-                      "type": "string"
-                    },
-                    "principalType": {
-                      "type": "string",
-                      "defaultValue": "ServicePrincipal",
-                      "allowedValues": [
-                        "User",
-                        "Group",
-                        "ServicePrincipal",
-                        "Unknown",
-                        "DirectoryRoleTemplate",
-                        "ForeignGroup",
-                        "Application",
-                        "MSI",
-                        "DirectoryObjectOrGroup",
-                        "Everyone"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "defaultValue": ""
-                    }
-                  },
-                  "functions": [],
-                  "resources": [
-                    {
-                      "type": "Microsoft.Authorization/roleAssignments",
-                      "apiVersion": "2020-04-01-preview",
-                      "name": "[guid(parameters('targetResourceId'), parameters('roleDefinitionId'), parameters('principalId'))]",
-                      "properties": {
-                        "principalId": "[parameters('principalId')]",
-                        "principalType": "[parameters('principalType')]",
-                        "roleDefinitionId": "[parameters('roleDefinitionId')]",
-                        "description": "[parameters('description')]"
-                      }
-                    }
-                  ]
-                }
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Authorization/policyAssignments', variables('agentVmAssignmentName'))]"
-              ]
-            }
-          ]
-        }
-      },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]",
-        "[subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc')))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
       ]
     },
     {
@@ -6375,108 +4220,15 @@
       ]
     },
     {
-      "condition": "[not(equals(parameters('hubSubscriptionId'), parameters('operationsSubscriptionId')))]",
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
-      "name": "[format('activity-logs-operations-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('operationsSubscriptionId')]",
-      "location": "[deployment().location]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "diagnosticSettingName": {
-            "value": "[format('log-operations-sub-activity-to-{0}', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value)]"
-          },
-          "logAnalyticsWorkspaceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "14308840348818246166"
-            }
-          },
-          "parameters": {
-            "diagnosticSettingName": {
-              "type": "string"
-            },
-            "logAnalyticsWorkspaceId": {
-              "type": "string"
-            },
-            "supportedClouds": {
-              "type": "array",
-              "defaultValue": [
-                "AzureCloud",
-                "AzureUSGovernment"
-              ]
-            }
-          },
-          "functions": [],
-          "resources": [
-            {
-              "condition": "[contains(parameters('supportedClouds'), environment().name)]",
-              "type": "Microsoft.Insights/diagnosticSettings",
-              "apiVersion": "2017-05-01-preview",
-              "name": "[parameters('diagnosticSettingName')]",
-              "properties": {
-                "workspaceId": "[parameters('logAnalyticsWorkspaceId')]",
-                "logs": [
-                  {
-                    "category": "Administrative",
-                    "enabled": true
-                  },
-                  {
-                    "category": "Security",
-                    "enabled": true
-                  },
-                  {
-                    "category": "ServiceHealth",
-                    "enabled": true
-                  },
-                  {
-                    "category": "Alert",
-                    "enabled": true
-                  },
-                  {
-                    "category": "Recommendation",
-                    "enabled": true
-                  },
-                  {
-                    "category": "Policy",
-                    "enabled": true
-                  },
-                  {
-                    "category": "Autoscale",
-                    "enabled": true
-                  },
-                  {
-                    "category": "ResourceHealth",
-                    "enabled": true
-                  }
-                ]
-              }
-            }
-          ]
-        }
+      "condition": "[not(equals(variables('spokes')[copyIndex()].subscriptionId, parameters('hubSubscriptionId')))]",
+      "copy": {
+        "name": "spokeSubscriptionActivityLogging",
+        "count": "[length(variables('spokes'))]"
       },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
-      ]
-    },
-    {
-      "condition": "[not(equals(parameters('hubSubscriptionId'), parameters('identitySubscriptionId')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('activity-logs-identity-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('identitySubscriptionId')]",
+      "name": "[format('activity-logs-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))]",
+      "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "location": "[deployment().location]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -6485,104 +4237,7 @@
         "mode": "Incremental",
         "parameters": {
           "diagnosticSettingName": {
-            "value": "[format('log-identity-sub-activity-to-{0}', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value)]"
-          },
-          "logAnalyticsWorkspaceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "14308840348818246166"
-            }
-          },
-          "parameters": {
-            "diagnosticSettingName": {
-              "type": "string"
-            },
-            "logAnalyticsWorkspaceId": {
-              "type": "string"
-            },
-            "supportedClouds": {
-              "type": "array",
-              "defaultValue": [
-                "AzureCloud",
-                "AzureUSGovernment"
-              ]
-            }
-          },
-          "functions": [],
-          "resources": [
-            {
-              "condition": "[contains(parameters('supportedClouds'), environment().name)]",
-              "type": "Microsoft.Insights/diagnosticSettings",
-              "apiVersion": "2017-05-01-preview",
-              "name": "[parameters('diagnosticSettingName')]",
-              "properties": {
-                "workspaceId": "[parameters('logAnalyticsWorkspaceId')]",
-                "logs": [
-                  {
-                    "category": "Administrative",
-                    "enabled": true
-                  },
-                  {
-                    "category": "Security",
-                    "enabled": true
-                  },
-                  {
-                    "category": "ServiceHealth",
-                    "enabled": true
-                  },
-                  {
-                    "category": "Alert",
-                    "enabled": true
-                  },
-                  {
-                    "category": "Recommendation",
-                    "enabled": true
-                  },
-                  {
-                    "category": "Policy",
-                    "enabled": true
-                  },
-                  {
-                    "category": "Autoscale",
-                    "enabled": true
-                  },
-                  {
-                    "category": "ResourceHealth",
-                    "enabled": true
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
-      ]
-    },
-    {
-      "condition": "[not(equals(parameters('hubSubscriptionId'), parameters('sharedServicesSubscriptionId')))]",
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
-      "name": "[format('activity-logs-sharedServices-{0}', parameters('nowUtc'))]",
-      "subscriptionId": "[parameters('sharedServicesSubscriptionId')]",
-      "location": "[deployment().location]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "diagnosticSettingName": {
-            "value": "[format('log-sharedServices-sub-activity-to-{0}', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value)]"
+            "value": "[format('log-{0}-sub-activity-to-{1}', variables('spokes')[copyIndex()].type, reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value)]"
           },
           "logAnalyticsWorkspaceId": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
@@ -6668,7 +4323,7 @@
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "delpoy-diagnostic-logging-LAWS",
+      "name": "deploy-diagnostic-logging-LAWS",
       "subscriptionId": "[parameters('operationsSubscriptionId')]",
       "resourceGroup": "[parameters('operationsResourceGroupName')]",
       "properties": {
@@ -6738,8 +4393,7 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc')))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
       ]
     },
     {
@@ -6884,293 +4538,15 @@
       ]
     },
     {
-      "condition": "[and(parameters('deployASC'), not(equals(parameters('hubSubscriptionId'), parameters('operationsSubscriptionId'))))]",
+      "condition": "[and(parameters('deployASC'), not(equals(variables('spokes')[copyIndex()].subscriptionId, parameters('hubSubscriptionId'))))]",
+      "copy": {
+        "name": "spokeSecurityCenter",
+        "count": "[length(variables('spokes'))]"
+      },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "set-operations-sub-security-center",
+      "name": "[format('set-{0}-sub-security-center', variables('spokes')[copyIndex()].type)]",
       "subscriptionId": "[parameters('operationsSubscriptionId')]",
-      "location": "[deployment().location]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "logAnalyticsWorkspaceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-          },
-          "emailSecurityContact": {
-            "value": "[parameters('emailSecurityContact')]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "5100455574031231618"
-            }
-          },
-          "parameters": {
-            "enableAutoProvisioning": {
-              "type": "bool",
-              "defaultValue": true,
-              "metadata": {
-                "description": "Turn automatic deployment by ASC of the MMA (OMS VM extension) on or off"
-              }
-            },
-            "enableSecuritySettings": {
-              "type": "bool",
-              "defaultValue": true,
-              "metadata": {
-                "description": "Turn security policy settings On or Off."
-              }
-            },
-            "logAnalyticsWorkspaceId": {
-              "type": "string",
-              "metadata": {
-                "description": "Specify the ID of your custom Log Analytics workspace to collect ASC data."
-              }
-            },
-            "emailSecurityContact": {
-              "type": "string",
-              "metadata": {
-                "description": "Email address of the contact, in the form of john@doe.com"
-              }
-            }
-          },
-          "functions": [],
-          "variables": {
-            "bundle": "[if(not(equals(environment().name, 'AzureUSGovernment')), createArray('KeyVaults', 'SqlServers', 'VirtualMachines', 'StorageAccounts', 'ContainerRegistry', 'KubernetesService', 'SqlServerVirtualMachines', 'AppServices', 'Dns', 'Arm'), createArray('SqlServers', 'VirtualMachines', 'StorageAccounts', 'ContainerRegistry', 'KubernetesService', 'Dns', 'Arm'))]",
-            "autoProvisioning": "[if(parameters('enableAutoProvisioning'), 'On', 'Off')]",
-            "securitySettings": "[if(parameters('enableSecuritySettings'), 'On', 'Off')]"
-          },
-          "resources": [
-            {
-              "copy": {
-                "name": "securityCenterPricing",
-                "count": "[length(variables('bundle'))]"
-              },
-              "type": "Microsoft.Security/pricings",
-              "apiVersion": "2018-06-01",
-              "name": "[variables('bundle')[copyIndex()]]",
-              "properties": {
-                "pricingTier": "Standard"
-              }
-            },
-            {
-              "type": "Microsoft.Security/autoProvisioningSettings",
-              "apiVersion": "2017-08-01-preview",
-              "name": "default",
-              "properties": {
-                "autoProvision": "[variables('autoProvisioning')]"
-              }
-            },
-            {
-              "type": "Microsoft.Security/workspaceSettings",
-              "apiVersion": "2017-08-01-preview",
-              "name": "default",
-              "properties": {
-                "workspaceId": "[parameters('logAnalyticsWorkspaceId')]",
-                "scope": "[subscription().id]"
-              }
-            },
-            {
-              "condition": "[not(empty(parameters('emailSecurityContact')))]",
-              "type": "Microsoft.Security/securityContacts",
-              "apiVersion": "2017-08-01-preview",
-              "name": "securityNotifications",
-              "properties": {
-                "alertsToAdmins": "On",
-                "alertNotifications": "On",
-                "email": "[parameters('emailSecurityContact')]"
-              }
-            },
-            {
-              "type": "Microsoft.Security/policies",
-              "apiVersion": "2015-06-01-preview",
-              "name": "default",
-              "properties": {
-                "policyLevel": "Subscription",
-                "name": "default",
-                "unique": "Off",
-                "logCollection": "On",
-                "recommendations": {
-                  "patch": "[variables('securitySettings')]",
-                  "baseline": "[variables('securitySettings')]",
-                  "antimalware": "[variables('securitySettings')]",
-                  "diskEncryption": "[variables('securitySettings')]",
-                  "acls": "[variables('securitySettings')]",
-                  "nsgs": "[variables('securitySettings')]",
-                  "waf": "[variables('securitySettings')]",
-                  "sqlAuditing": "[variables('securitySettings')]",
-                  "sqlTde": "[variables('securitySettings')]",
-                  "ngfw": "[variables('securitySettings')]",
-                  "vulnerabilityAssessment": "[variables('securitySettings')]",
-                  "storageEncryption": "[variables('securitySettings')]",
-                  "jitNetworkAccess": "[variables('securitySettings')]"
-                },
-                "pricingConfiguration": {
-                  "selectedPricingTier": "Standard"
-                }
-              }
-            }
-          ]
-        }
-      },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
-      ]
-    },
-    {
-      "condition": "[and(parameters('deployASC'), not(equals(parameters('hubSubscriptionId'), parameters('identitySubscriptionId'))))]",
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
-      "name": "set-identity-sub-security-center",
-      "subscriptionId": "[parameters('identitySubscriptionId')]",
-      "location": "[deployment().location]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "logAnalyticsWorkspaceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-          },
-          "emailSecurityContact": {
-            "value": "[parameters('emailSecurityContact')]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "5100455574031231618"
-            }
-          },
-          "parameters": {
-            "enableAutoProvisioning": {
-              "type": "bool",
-              "defaultValue": true,
-              "metadata": {
-                "description": "Turn automatic deployment by ASC of the MMA (OMS VM extension) on or off"
-              }
-            },
-            "enableSecuritySettings": {
-              "type": "bool",
-              "defaultValue": true,
-              "metadata": {
-                "description": "Turn security policy settings On or Off."
-              }
-            },
-            "logAnalyticsWorkspaceId": {
-              "type": "string",
-              "metadata": {
-                "description": "Specify the ID of your custom Log Analytics workspace to collect ASC data."
-              }
-            },
-            "emailSecurityContact": {
-              "type": "string",
-              "metadata": {
-                "description": "Email address of the contact, in the form of john@doe.com"
-              }
-            }
-          },
-          "functions": [],
-          "variables": {
-            "bundle": "[if(not(equals(environment().name, 'AzureUSGovernment')), createArray('KeyVaults', 'SqlServers', 'VirtualMachines', 'StorageAccounts', 'ContainerRegistry', 'KubernetesService', 'SqlServerVirtualMachines', 'AppServices', 'Dns', 'Arm'), createArray('SqlServers', 'VirtualMachines', 'StorageAccounts', 'ContainerRegistry', 'KubernetesService', 'Dns', 'Arm'))]",
-            "autoProvisioning": "[if(parameters('enableAutoProvisioning'), 'On', 'Off')]",
-            "securitySettings": "[if(parameters('enableSecuritySettings'), 'On', 'Off')]"
-          },
-          "resources": [
-            {
-              "copy": {
-                "name": "securityCenterPricing",
-                "count": "[length(variables('bundle'))]"
-              },
-              "type": "Microsoft.Security/pricings",
-              "apiVersion": "2018-06-01",
-              "name": "[variables('bundle')[copyIndex()]]",
-              "properties": {
-                "pricingTier": "Standard"
-              }
-            },
-            {
-              "type": "Microsoft.Security/autoProvisioningSettings",
-              "apiVersion": "2017-08-01-preview",
-              "name": "default",
-              "properties": {
-                "autoProvision": "[variables('autoProvisioning')]"
-              }
-            },
-            {
-              "type": "Microsoft.Security/workspaceSettings",
-              "apiVersion": "2017-08-01-preview",
-              "name": "default",
-              "properties": {
-                "workspaceId": "[parameters('logAnalyticsWorkspaceId')]",
-                "scope": "[subscription().id]"
-              }
-            },
-            {
-              "condition": "[not(empty(parameters('emailSecurityContact')))]",
-              "type": "Microsoft.Security/securityContacts",
-              "apiVersion": "2017-08-01-preview",
-              "name": "securityNotifications",
-              "properties": {
-                "alertsToAdmins": "On",
-                "alertNotifications": "On",
-                "email": "[parameters('emailSecurityContact')]"
-              }
-            },
-            {
-              "type": "Microsoft.Security/policies",
-              "apiVersion": "2015-06-01-preview",
-              "name": "default",
-              "properties": {
-                "policyLevel": "Subscription",
-                "name": "default",
-                "unique": "Off",
-                "logCollection": "On",
-                "recommendations": {
-                  "patch": "[variables('securitySettings')]",
-                  "baseline": "[variables('securitySettings')]",
-                  "antimalware": "[variables('securitySettings')]",
-                  "diskEncryption": "[variables('securitySettings')]",
-                  "acls": "[variables('securitySettings')]",
-                  "nsgs": "[variables('securitySettings')]",
-                  "waf": "[variables('securitySettings')]",
-                  "sqlAuditing": "[variables('securitySettings')]",
-                  "sqlTde": "[variables('securitySettings')]",
-                  "ngfw": "[variables('securitySettings')]",
-                  "vulnerabilityAssessment": "[variables('securitySettings')]",
-                  "storageEncryption": "[variables('securitySettings')]",
-                  "jitNetworkAccess": "[variables('securitySettings')]"
-                },
-                "pricingConfiguration": {
-                  "selectedPricingTier": "Standard"
-                }
-              }
-            }
-          ]
-        }
-      },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
-      ]
-    },
-    {
-      "condition": "[and(parameters('deployASC'), not(equals(parameters('hubSubscriptionId'), parameters('sharedServicesSubscriptionId'))))]",
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
-      "name": "set-sharedServices-sub-security-center",
-      "subscriptionId": "[parameters('sharedServicesSubscriptionId')]",
       "location": "[deployment().location]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -7323,13 +4699,13 @@
             "value": "[parameters('hubLocation')]"
           },
           "hubVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
           },
           "hubSubnetResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetResourceId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetResourceId.value]"
           },
           "hubNetworkSecurityGroupResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]"
           },
           "bastionHostName": {
             "value": "[parameters('bastionHostName')]"
@@ -8414,187 +5790,9 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc')))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc')))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
       ]
     }
-  ],
-  "outputs": {
-    "hubSubscriptionId": {
-      "type": "string",
-      "value": "[parameters('hubSubscriptionId')]"
-    },
-    "hubResourceGroupName": {
-      "type": "string",
-      "value": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-hub-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-    },
-    "hubResourceGroupResourceId": {
-      "type": "string",
-      "value": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-hub-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-    },
-    "hubVirtualNetworkName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
-    },
-    "hubVirtualNetworkResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
-    },
-    "hubSubnetName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetName.value]"
-    },
-    "hubSubnetResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetResourceId.value]"
-    },
-    "hubSubnetAddressPrefix": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetAddressPrefix.value]"
-    },
-    "hubNetworkSecurityGroupName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupName.value]"
-    },
-    "hubNetworkSecurityGroupResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]"
-    },
-    "hubFirewallPrivateIPAddress": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
-    },
-    "logAnalyticsWorkspaceName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-    },
-    "logAnalyticsWorkspaceResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-    },
-    "firewallPrivateIPAddress": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
-    },
-    "identitySubscriptionId": {
-      "type": "string",
-      "value": "[parameters('identitySubscriptionId')]"
-    },
-    "identityResourceGroupName": {
-      "type": "string",
-      "value": "[reference(subscriptionResourceId(parameters('identitySubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-identity-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-    },
-    "identityResourceGroupResourceId": {
-      "type": "string",
-      "value": "[reference(subscriptionResourceId(parameters('identitySubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-identity-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-    },
-    "identityVirtualNetworkName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('identitySubscriptionId'), parameters('identityResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-identity-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
-    },
-    "identityVirtualNetworkResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('identitySubscriptionId'), parameters('identityResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-identity-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
-    },
-    "identitySubnetName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('identitySubscriptionId'), parameters('identityResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-identity-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetName.value]"
-    },
-    "identitySubnetResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('identitySubscriptionId'), parameters('identityResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-identity-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetResourceId.value]"
-    },
-    "identitySubnetAddressPrefix": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('identitySubscriptionId'), parameters('identityResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-identity-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetAddressPrefix.value]"
-    },
-    "identityNetworkSecurityGroupName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('identitySubscriptionId'), parameters('identityResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-identity-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupName.value]"
-    },
-    "identityNetworkSecurityGroupResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('identitySubscriptionId'), parameters('identityResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-identity-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]"
-    },
-    "operationsSubscriptionId": {
-      "type": "string",
-      "value": "[parameters('operationsSubscriptionId')]"
-    },
-    "operationsResourceGroupName": {
-      "type": "string",
-      "value": "[reference(subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-    },
-    "operationsResourceGroupResourceId": {
-      "type": "string",
-      "value": "[reference(subscriptionResourceId(parameters('operationsSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-operations-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-    },
-    "operationsVirtualNetworkName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
-    },
-    "operationsVirtualNetworkResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
-    },
-    "operationsSubnetName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetName.value]"
-    },
-    "operationsSubnetResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetResourceId.value]"
-    },
-    "operationsSubnetAddressPrefix": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetAddressPrefix.value]"
-    },
-    "operationsNetworkSecurityGroupName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupName.value]"
-    },
-    "operationsNetworkSecurityGroupResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-operations-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]"
-    },
-    "sharedServicesSubscriptionId": {
-      "type": "string",
-      "value": "[parameters('sharedServicesSubscriptionId')]"
-    },
-    "sharedServicesResourceGroupName": {
-      "type": "string",
-      "value": "[reference(subscriptionResourceId(parameters('sharedServicesSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-sharedServices-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-    },
-    "sharedServicesResourceGroupResourceId": {
-      "type": "string",
-      "value": "[reference(subscriptionResourceId(parameters('sharedServicesSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-sharedServices-rg-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-    },
-    "sharedServicesVirtualNetworkName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-sharedServices-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
-    },
-    "sharedServicesVirtualNetworkResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-sharedServices-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
-    },
-    "sharedServicesSubnetName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-sharedServices-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetName.value]"
-    },
-    "sharedServicesSubnetResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-sharedServices-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetResourceId.value]"
-    },
-    "sharedServicesSubnetAddressPrefix": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-sharedServices-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetAddressPrefix.value]"
-    },
-    "sharedServicesNetworkSecurityGroupName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-sharedServices-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupName.value]"
-    },
-    "sharedServicesNetworkSecurityGroupResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-sharedServices-spoke-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]"
-    }
-  }
+  ]
 }

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "16140145053270604410"
+      "templateHash": "10064184964306816737"
     }
   },
   "parameters": {
@@ -2741,7 +2741,7 @@
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
       "name": "[format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))]",
-      "subscriptionId": "[variables('spokes')[copyIndex()].subscription]",
+      "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "resourceGroup": "[variables('spokes')[copyIndex()].resourceGroupName]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -3376,12 +3376,12 @@
           "hubVirtualNetworkName": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
           },
-          "spokeNetworks": {
+          "spokes": {
             "copy": [
               {
                 "name": "value",
                 "count": "[length(variables('spokes'))]",
-                "input": "[createObject('type', variables('spokes')[copyIndex('value')].type, 'virtualNetworkName', variables('spokes')[copyIndex('value')].virtualNetworkName, 'virtualNetworkResourceId', resourceId(variables('spokes')[copyIndex('value')].subscriptionId, variables('spokes')[copyIndex('value')].resourceGroupName, 'Microsoft.Network/virtualNetworks@2021-02-01', variables('spokes')[copyIndex('value')].virtualNetworkName))]"
+                "input": "[createObject('type', variables('spokes')[copyIndex('value')].type, 'virtualNetworkName', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscriptionId, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].type, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value, 'virtualNetworkResourceId', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscriptionId, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].type, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value)]"
               }
             ]
           }
@@ -3393,14 +3393,14 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "5598014082902284098"
+              "templateHash": "9442892592859818002"
             }
           },
           "parameters": {
             "hubVirtualNetworkName": {
               "type": "string"
             },
-            "spokeNetworks": {
+            "spokes": {
               "type": "array"
             }
           },
@@ -3409,11 +3409,11 @@
             {
               "copy": {
                 "name": "hubToSpokePeering",
-                "count": "[length(parameters('spokeNetworks'))]"
+                "count": "[length(parameters('spokes'))]"
               },
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-06-01",
-              "name": "[format('hubTo{0}VirtualNetworkPeering', parameters('spokeNetworks')[copyIndex()].type)]",
+              "name": "[format('hub-to-{0}-vnet-peering', parameters('spokes')[copyIndex()].type)]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
@@ -3421,10 +3421,10 @@
                 "mode": "Incremental",
                 "parameters": {
                   "name": {
-                    "value": "[format('{0}/to-{1}', parameters('hubVirtualNetworkName'), parameters('spokeNetworks')[copyIndex()].virtualNetworkName)]"
+                    "value": "[format('{0}/to-{1}', parameters('hubVirtualNetworkName'), parameters('spokes')[copyIndex()].virtualNetworkName)]"
                   },
                   "remoteVirtualNetworkResourceId": {
-                    "value": "[parameters('spokeNetworks')[copyIndex()].virtualNetworkResourceId]"
+                    "value": "[parameters('spokes')[copyIndex()].virtualNetworkResourceId]"
                   }
                 },
                 "template": {
@@ -3485,11 +3485,14 @@
         },
         "mode": "Incremental",
         "parameters": {
+          "spokeType": {
+            "value": "[variables('spokes')[copyIndex()].type]"
+          },
           "spokeResourceGroupName": {
             "value": "[variables('spokes')[copyIndex()].resourceGroupName]"
           },
           "spokeVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscription, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
           },
           "hubVirtualNetworkName": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
@@ -3505,10 +3508,13 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "312016847830445837"
+              "templateHash": "17578836695451833276"
             }
           },
           "parameters": {
+            "spokeType": {
+              "type": "string"
+            },
             "spokeResourceGroupName": {
               "type": "string"
             },
@@ -3527,7 +3533,7 @@
             {
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-06-01",
-              "name": "spokeNetworkPeering",
+              "name": "[format('{0}-to-hub-vnet-peering', parameters('spokeType'))]",
               "resourceGroup": "[parameters('spokeResourceGroupName')]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3581,7 +3587,7 @@
       },
       "dependsOn": [
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscription, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc')))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc')))]"
       ]
     },
     {
@@ -3617,12 +3623,13 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "1020471899502580649"
+              "templateHash": "15589676685182392061"
             }
           },
           "parameters": {
             "builtInAssignment": {
               "type": "string",
+              "defaultValue": "NIST",
               "metadata": {
                 "description": "[NIST/IL5/CMMC] Built-in policy assignments to assign, default is NIST. IL5 is only availalbe for GOV cloud and will switch to NIST if tried in AzureCloud."
               },
@@ -3885,12 +3892,13 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "1020471899502580649"
+              "templateHash": "15589676685182392061"
             }
           },
           "parameters": {
             "builtInAssignment": {
               "type": "string",
+              "defaultValue": "NIST",
               "metadata": {
                 "description": "[NIST/IL5/CMMC] Built-in policy assignments to assign, default is NIST. IL5 is only availalbe for GOV cloud and will switch to NIST if tried in AzureCloud."
               },
@@ -4209,6 +4217,7 @@
         }
       },
       "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc')))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
       ]
     },
@@ -4310,7 +4319,8 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]",
+        "spokeNetworks"
       ]
     },
     {
@@ -4386,7 +4396,9 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc')))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]",
+        "spokeNetworks"
       ]
     },
     {
@@ -5787,5 +5799,183 @@
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc')))]"
       ]
     }
-  ]
+  ],
+  "outputs": {
+    "hubSubscriptionId": {
+      "type": "string",
+      "value": "[parameters('hubSubscriptionId')]"
+    },
+    "hubResourceGroupName": {
+      "type": "string",
+      "value": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-rg-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
+    },
+    "hubResourceGroupResourceId": {
+      "type": "string",
+      "value": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-rg-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
+    },
+    "hubVirtualNetworkName": {
+      "type": "string",
+      "value": "[parameters('hubVirtualNetworkName')]"
+    },
+    "hubVirtualNetworkResourceId": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
+    },
+    "hubSubnetName": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetName.value]"
+    },
+    "hubSubnetResourceId": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetResourceId.value]"
+    },
+    "hubSubnetAddressPrefix": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetAddressPrefix.value]"
+    },
+    "hubNetworkSecurityGroupName": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupName.value]"
+    },
+    "hubNetworkSecurityGroupResourceId": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]"
+    },
+    "hubFirewallPrivateIPAddress": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
+    },
+    "logAnalyticsWorkspaceName": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
+    },
+    "logAnalyticsWorkspaceResourceId": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
+    },
+    "firewallPrivateIPAddress": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
+    },
+    "identitySubscriptionId": {
+      "type": "string",
+      "value": "[parameters('identitySubscriptionId')]"
+    },
+    "identityResourceGroupName": {
+      "type": "string",
+      "value": "[parameters('identityResourceGroupName')]"
+    },
+    "identityResourceGroupResourceId": {
+      "type": "string",
+      "value": "[resourceId(parameters('identitySubscriptionId'), parameters('identityResourceGroupName'), 'Microsoft.Resource/resourceGroups', parameters('identityResourceGroupName'))]"
+    },
+    "identityVirtualNetworkName": {
+      "type": "string",
+      "value": "[parameters('identityVirtualNetworkName')]"
+    },
+    "identityVirtualNetworkResourceId": {
+      "type": "string",
+      "value": "[resourceId(parameters('identitySubscriptionId'), parameters('identityResourceGroupName'), 'Microsoft.Network/virtualNetworks', parameters('identityVirtualNetworkName'))]"
+    },
+    "identitySubnetName": {
+      "type": "string",
+      "value": "[parameters('identitySubnetName')]"
+    },
+    "identitySubnetResourceId": {
+      "type": "string",
+      "value": "[resourceId(parameters('identitySubscriptionId'), parameters('identityResourceGroupName'), 'Microsoft.Network/Virtualnetworks/subnets', format('{0}/{1}', parameters('identityVirtualNetworkName'), parameters('identitySubnetName')))]"
+    },
+    "identitySubnetAddressPrefix": {
+      "type": "string",
+      "value": "[parameters('identitySubnetAddressPrefix')]"
+    },
+    "identityNetworkSecurityGroupName": {
+      "type": "string",
+      "value": "[parameters('identityNetworkSecurityGroupName')]"
+    },
+    "identityNetworkSecurityGroupResourceId": {
+      "type": "string",
+      "value": "[resourceId(parameters('identitySubscriptionId'), parameters('identityResourceGroupName'), 'Microsoft.Network/networkSecurityGroups', parameters('identityNetworkSecurityGroupName'))]"
+    },
+    "operationsSubscriptionId": {
+      "type": "string",
+      "value": "[parameters('operationsSubscriptionId')]"
+    },
+    "operationsResourceGroupName": {
+      "type": "string",
+      "value": "[parameters('operationsResourceGroupName')]"
+    },
+    "operationsResourceGroupResourceId": {
+      "type": "string",
+      "value": "[resourceId(parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName'), 'Microsoft.Resource/resourceGroups', parameters('operationsResourceGroupName'))]"
+    },
+    "operationsVirtualNetworkName": {
+      "type": "string",
+      "value": "[parameters('operationsVirtualNetworkName')]"
+    },
+    "operationsVirtualNetworkResourceId": {
+      "type": "string",
+      "value": "[resourceId(parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName'), 'Microsoft.Network/virtualNetworks', parameters('operationsVirtualNetworkName'))]"
+    },
+    "operationsSubnetName": {
+      "type": "string",
+      "value": "[parameters('operationsSubnetName')]"
+    },
+    "operationsSubnetResourceId": {
+      "type": "string",
+      "value": "[resourceId(parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName'), 'Microsoft.Network/Virtualnetworks/subnets', format('{0}/{1}', parameters('operationsVirtualNetworkName'), parameters('operationsSubnetName')))]"
+    },
+    "operationsSubnetAddressPrefix": {
+      "type": "string",
+      "value": "[parameters('operationsSubnetAddressPrefix')]"
+    },
+    "operationsNetworkSecurityGroupName": {
+      "type": "string",
+      "value": "[parameters('operationsNetworkSecurityGroupName')]"
+    },
+    "operationsNetworkSecurityGroupResourceId": {
+      "type": "string",
+      "value": "[resourceId(parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName'), 'Microsoft.Network/networkSecurityGroups', parameters('operationsNetworkSecurityGroupName'))]"
+    },
+    "sharedServicesSubscriptionId": {
+      "type": "string",
+      "value": "[parameters('sharedServicesSubscriptionId')]"
+    },
+    "sharedServicesResourceGroupName": {
+      "type": "string",
+      "value": "[parameters('sharedServicesResourceGroupName')]"
+    },
+    "sharedServicesResourceGroupResourceId": {
+      "type": "string",
+      "value": "[resourceId(parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName'), 'Microsoft.Resource/resourceGroups', parameters('sharedServicesResourceGroupName'))]"
+    },
+    "sharedServicesVirtualNetworkName": {
+      "type": "string",
+      "value": "[parameters('sharedServicesVirtualNetworkName')]"
+    },
+    "sharedServicesVirtualNetworkResourceId": {
+      "type": "string",
+      "value": "[resourceId(parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName'), 'Microsoft.Network/virtualNetworks', parameters('sharedServicesVirtualNetworkName'))]"
+    },
+    "sharedServicesSubnetName": {
+      "type": "string",
+      "value": "[parameters('sharedServicesSubnetName')]"
+    },
+    "sharedServicesSubnetResourceId": {
+      "type": "string",
+      "value": "[resourceId(parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName'), 'Microsoft.Network/Virtualnetworks/subnets', format('{0}/{1}', parameters('sharedServicesVirtualNetworkName'), parameters('sharedServicesSubnetName')))]"
+    },
+    "sharedServicesSubnetAddressPrefix": {
+      "type": "string",
+      "value": "[parameters('sharedServicesSubnetAddressPrefix')]"
+    },
+    "sharedServicesNetworkSecurityGroupName": {
+      "type": "string",
+      "value": "[parameters('sharedServicesNetworkSecurityGroupName')]"
+    },
+    "sharedServicesNetworkSecurityGroupResourceId": {
+      "type": "string",
+      "value": "[resourceId(parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName'), 'Microsoft.Network/networkSecurityGroups', parameters('sharedServicesNetworkSecurityGroupName'))]"
+    }
+  }
 }

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "2369337694531344795"
+      "templateHash": "10390826664819648825"
     }
   },
   "parameters": {
@@ -662,7 +662,7 @@
     "firewallManagementSubnetName": "AzureFirewallManagementSubnet",
     "spokes": [
       {
-        "type": "operations",
+        "name": "operations",
         "subscriptionId": "[parameters('operationsSubscriptionId')]",
         "resourceGroupName": "[parameters('operationsResourceGroupName')]",
         "location": "[parameters('operationsLocation')]",
@@ -681,7 +681,7 @@
         "subnetServiceEndpoints": "[parameters('operationsSubnetServiceEndpoints')]"
       },
       {
-        "type": "identity",
+        "name": "identity",
         "subscriptionId": "[parameters('identitySubscriptionId')]",
         "resourceGroupName": "[parameters('identityResourceGroupName')]",
         "location": "[parameters('identityLocation')]",
@@ -700,7 +700,7 @@
         "subnetServiceEndpoints": "[parameters('identitySubnetServiceEndpoints')]"
       },
       {
-        "type": "sharedServices",
+        "name": "sharedServices",
         "subscriptionId": "[parameters('sharedServicesSubscriptionId')]",
         "resourceGroupName": "[parameters('sharedServicesResourceGroupName')]",
         "location": "[parameters('sharedServicesLocation')]",
@@ -796,7 +796,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('deploy-rg-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))]",
+      "name": "[format('deploy-rg-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))]",
       "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "location": "[deployment().location]",
       "properties": {
@@ -2740,7 +2740,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))]",
+      "name": "[format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))]",
       "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "resourceGroup": "[variables('spokes')[copyIndex()].resourceGroupName]",
       "properties": {
@@ -3381,7 +3381,7 @@
               {
                 "name": "value",
                 "count": "[length(variables('spokes'))]",
-                "input": "[createObject('type', variables('spokes')[copyIndex('value')].type, 'virtualNetworkName', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscriptionId, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].type, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value, 'virtualNetworkResourceId', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscriptionId, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].type, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value)]"
+                "input": "[createObject('type', variables('spokes')[copyIndex('value')].name, 'virtualNetworkName', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscriptionId, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].name, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value, 'virtualNetworkResourceId', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscriptionId, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].name, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value)]"
               }
             ]
           }
@@ -3476,7 +3476,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('deploy-vnet-peerings-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))]",
+      "name": "[format('deploy-vnet-peerings-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))]",
       "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "location": "[deployment().location]",
       "properties": {
@@ -3486,13 +3486,13 @@
         "mode": "Incremental",
         "parameters": {
           "spokeType": {
-            "value": "[variables('spokes')[copyIndex()].type]"
+            "value": "[variables('spokes')[copyIndex()].name]"
           },
           "spokeResourceGroupName": {
             "value": "[variables('spokes')[copyIndex()].resourceGroupName]"
           },
           "spokeVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
           },
           "hubVirtualNetworkName": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
@@ -3587,7 +3587,7 @@
       },
       "dependsOn": [
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc')))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc')))]"
       ]
     },
     {
@@ -3858,12 +3858,12 @@
     {
       "condition": "[parameters('deployPolicy')]",
       "copy": {
-        "name": "spokePolicyAssignment",
+        "name": "spokePolicyAssignments",
         "count": "[length(variables('spokes'))]"
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('assign-policy-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))]",
+      "name": "[format('assign-policy-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))]",
       "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "resourceGroup": "[variables('spokes')[copyIndex()].resourceGroupName]",
       "properties": {
@@ -4229,7 +4229,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('activity-logs-{0}-{1}', variables('spokes')[copyIndex()].type, parameters('nowUtc'))]",
+      "name": "[format('activity-logs-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))]",
       "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "location": "[deployment().location]",
       "properties": {
@@ -4239,7 +4239,7 @@
         "mode": "Incremental",
         "parameters": {
           "diagnosticSettingName": {
-            "value": "[format('log-{0}-sub-activity-to-{1}', variables('spokes')[copyIndex()].type, reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value)]"
+            "value": "[format('log-{0}-sub-activity-to-{1}', variables('spokes')[copyIndex()].name, reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value)]"
           },
           "logAnalyticsWorkspaceId": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
@@ -4550,7 +4550,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
-      "name": "[format('set-{0}-sub-security-center', variables('spokes')[copyIndex()].type)]",
+      "name": "[format('set-{0}-sub-security-center', variables('spokes')[copyIndex()].name)]",
       "subscriptionId": "[parameters('operationsSubscriptionId')]",
       "location": "[deployment().location]",
       "properties": {
@@ -5801,49 +5801,39 @@
     }
   ],
   "outputs": {
-    "hubSubscriptionId": {
-      "type": "string",
-      "value": "[parameters('hubSubscriptionId')]"
+    "hub": {
+      "type": "object",
+      "value": {
+        "subscriptionId": "[parameters('hubSubscriptionId')]",
+        "resourceGroupName": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-rg-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]",
+        "resourceGroupResourceId": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-rg-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]",
+        "virtualNetworkName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]",
+        "virtualNetworkResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]",
+        "subnetName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetName.value]",
+        "subnetResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetResourceId.value]",
+        "subnetAddressPrefix": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetAddressPrefix.value]",
+        "networkSecurityGroupName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupName.value]",
+        "networkSecurityGroupResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]",
+        "firewallPrivateIPAddress": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
+      }
     },
-    "hubResourceGroupName": {
-      "type": "string",
-      "value": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-rg-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-    },
-    "hubResourceGroupResourceId": {
-      "type": "string",
-      "value": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-rg-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-    },
-    "hubVirtualNetworkName": {
-      "type": "string",
-      "value": "[parameters('hubVirtualNetworkName')]"
-    },
-    "hubVirtualNetworkResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]"
-    },
-    "hubSubnetName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetName.value]"
-    },
-    "hubSubnetResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetResourceId.value]"
-    },
-    "hubSubnetAddressPrefix": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetAddressPrefix.value]"
-    },
-    "hubNetworkSecurityGroupName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupName.value]"
-    },
-    "hubNetworkSecurityGroupResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]"
-    },
-    "hubFirewallPrivateIPAddress": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
+    "spokes": {
+      "type": "array",
+      "copy": {
+        "count": "[length(variables('spokes'))]",
+        "input": {
+          "name": "[variables('spokes')[copyIndex()].name]",
+          "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
+          "resourceGroupName": "[reference(subscriptionResourceId(variables('spokes')[copyIndex()].subscriptionId, 'Microsoft.Resources/deployments', format('deploy-rg-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.name.value]",
+          "resourceGroupId": "[reference(subscriptionResourceId(variables('spokes')[copyIndex()].subscriptionId, 'Microsoft.Resources/deployments', format('deploy-rg-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.id.value]",
+          "virtualNetworkName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]",
+          "virtualNetworkResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]",
+          "subnetName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.subnetName.value]",
+          "subnetAddressPrefix": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.subnetAddressPrefix.value]",
+          "networkSecurityGroupName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupName.value]",
+          "networkSecurityGroupResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]"
+        }
+      }
     },
     "logAnalyticsWorkspaceName": {
       "type": "string",
@@ -5856,126 +5846,6 @@
     "firewallPrivateIPAddress": {
       "type": "string",
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
-    },
-    "identitySubscriptionId": {
-      "type": "string",
-      "value": "[parameters('identitySubscriptionId')]"
-    },
-    "identityResourceGroupName": {
-      "type": "string",
-      "value": "[parameters('identityResourceGroupName')]"
-    },
-    "identityResourceGroupResourceId": {
-      "type": "string",
-      "value": "[resourceId(parameters('identitySubscriptionId'), parameters('identityResourceGroupName'), 'Microsoft.Resource/resourceGroups', parameters('identityResourceGroupName'))]"
-    },
-    "identityVirtualNetworkName": {
-      "type": "string",
-      "value": "[parameters('identityVirtualNetworkName')]"
-    },
-    "identityVirtualNetworkResourceId": {
-      "type": "string",
-      "value": "[resourceId(parameters('identitySubscriptionId'), parameters('identityResourceGroupName'), 'Microsoft.Network/virtualNetworks', parameters('identityVirtualNetworkName'))]"
-    },
-    "identitySubnetName": {
-      "type": "string",
-      "value": "[parameters('identitySubnetName')]"
-    },
-    "identitySubnetResourceId": {
-      "type": "string",
-      "value": "[resourceId(parameters('identitySubscriptionId'), parameters('identityResourceGroupName'), 'Microsoft.Network/Virtualnetworks/subnets', format('{0}/{1}', parameters('identityVirtualNetworkName'), parameters('identitySubnetName')))]"
-    },
-    "identitySubnetAddressPrefix": {
-      "type": "string",
-      "value": "[parameters('identitySubnetAddressPrefix')]"
-    },
-    "identityNetworkSecurityGroupName": {
-      "type": "string",
-      "value": "[parameters('identityNetworkSecurityGroupName')]"
-    },
-    "identityNetworkSecurityGroupResourceId": {
-      "type": "string",
-      "value": "[resourceId(parameters('identitySubscriptionId'), parameters('identityResourceGroupName'), 'Microsoft.Network/networkSecurityGroups', parameters('identityNetworkSecurityGroupName'))]"
-    },
-    "operationsSubscriptionId": {
-      "type": "string",
-      "value": "[parameters('operationsSubscriptionId')]"
-    },
-    "operationsResourceGroupName": {
-      "type": "string",
-      "value": "[parameters('operationsResourceGroupName')]"
-    },
-    "operationsResourceGroupResourceId": {
-      "type": "string",
-      "value": "[resourceId(parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName'), 'Microsoft.Resource/resourceGroups', parameters('operationsResourceGroupName'))]"
-    },
-    "operationsVirtualNetworkName": {
-      "type": "string",
-      "value": "[parameters('operationsVirtualNetworkName')]"
-    },
-    "operationsVirtualNetworkResourceId": {
-      "type": "string",
-      "value": "[resourceId(parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName'), 'Microsoft.Network/virtualNetworks', parameters('operationsVirtualNetworkName'))]"
-    },
-    "operationsSubnetName": {
-      "type": "string",
-      "value": "[parameters('operationsSubnetName')]"
-    },
-    "operationsSubnetResourceId": {
-      "type": "string",
-      "value": "[resourceId(parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName'), 'Microsoft.Network/Virtualnetworks/subnets', format('{0}/{1}', parameters('operationsVirtualNetworkName'), parameters('operationsSubnetName')))]"
-    },
-    "operationsSubnetAddressPrefix": {
-      "type": "string",
-      "value": "[parameters('operationsSubnetAddressPrefix')]"
-    },
-    "operationsNetworkSecurityGroupName": {
-      "type": "string",
-      "value": "[parameters('operationsNetworkSecurityGroupName')]"
-    },
-    "operationsNetworkSecurityGroupResourceId": {
-      "type": "string",
-      "value": "[resourceId(parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName'), 'Microsoft.Network/networkSecurityGroups', parameters('operationsNetworkSecurityGroupName'))]"
-    },
-    "sharedServicesSubscriptionId": {
-      "type": "string",
-      "value": "[parameters('sharedServicesSubscriptionId')]"
-    },
-    "sharedServicesResourceGroupName": {
-      "type": "string",
-      "value": "[parameters('sharedServicesResourceGroupName')]"
-    },
-    "sharedServicesResourceGroupResourceId": {
-      "type": "string",
-      "value": "[resourceId(parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName'), 'Microsoft.Resource/resourceGroups', parameters('sharedServicesResourceGroupName'))]"
-    },
-    "sharedServicesVirtualNetworkName": {
-      "type": "string",
-      "value": "[parameters('sharedServicesVirtualNetworkName')]"
-    },
-    "sharedServicesVirtualNetworkResourceId": {
-      "type": "string",
-      "value": "[resourceId(parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName'), 'Microsoft.Network/virtualNetworks', parameters('sharedServicesVirtualNetworkName'))]"
-    },
-    "sharedServicesSubnetName": {
-      "type": "string",
-      "value": "[parameters('sharedServicesSubnetName')]"
-    },
-    "sharedServicesSubnetResourceId": {
-      "type": "string",
-      "value": "[resourceId(parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName'), 'Microsoft.Network/Virtualnetworks/subnets', format('{0}/{1}', parameters('sharedServicesVirtualNetworkName'), parameters('sharedServicesSubnetName')))]"
-    },
-    "sharedServicesSubnetAddressPrefix": {
-      "type": "string",
-      "value": "[parameters('sharedServicesSubnetAddressPrefix')]"
-    },
-    "sharedServicesNetworkSecurityGroupName": {
-      "type": "string",
-      "value": "[parameters('sharedServicesNetworkSecurityGroupName')]"
-    },
-    "sharedServicesNetworkSecurityGroupResourceId": {
-      "type": "string",
-      "value": "[resourceId(parameters('sharedServicesSubscriptionId'), parameters('sharedServicesResourceGroupName'), 'Microsoft.Network/networkSecurityGroups', parameters('sharedServicesNetworkSecurityGroupName'))]"
     }
   }
 }

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "10390826664819648825"
+      "templateHash": "13572668780282663954"
     }
   },
   "parameters": {
@@ -5801,6 +5801,10 @@
     }
   ],
   "outputs": {
+    "firewallPrivateIPAddress": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
+    },
     "hub": {
       "type": "object",
       "value": {
@@ -5813,9 +5817,16 @@
         "subnetResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetResourceId.value]",
         "subnetAddressPrefix": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.subnetAddressPrefix.value]",
         "networkSecurityGroupName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupName.value]",
-        "networkSecurityGroupResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]",
-        "firewallPrivateIPAddress": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
+        "networkSecurityGroupResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]"
       }
+    },
+    "logAnalyticsWorkspaceName": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
+    },
+    "logAnalyticsWorkspaceResourceId": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
     },
     "spokes": {
       "type": "array",
@@ -5829,23 +5840,12 @@
           "virtualNetworkName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]",
           "virtualNetworkResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value]",
           "subnetName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.subnetName.value]",
+          "subnetResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.subnetResourceId.value]",
           "subnetAddressPrefix": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.subnetAddressPrefix.value]",
           "networkSecurityGroupName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupName.value]",
           "networkSecurityGroupResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('nowUtc'))), '2020-06-01').outputs.networkSecurityGroupResourceId.value]"
         }
       }
-    },
-    "logAnalyticsWorkspaceName": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-    },
-    "logAnalyticsWorkspaceResourceId": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.id.value]"
-    },
-    "firewallPrivateIPAddress": {
-      "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.firewallPrivateIPAddress.value]"
     }
   }
 }

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "15239738373058366803"
+      "templateHash": "16140145053270604410"
     }
   },
   "parameters": {
@@ -3366,16 +3366,13 @@
       "apiVersion": "2020-06-01",
       "name": "[format('deploy-vnet-peerings-hub-{0}', parameters('nowUtc'))]",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
-      "location": "[deployment().location]",
+      "resourceGroup": "[parameters('hubResourceGroupName')]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
         },
         "mode": "Incremental",
         "parameters": {
-          "hubResourceGroupName": {
-            "value": "[parameters('hubResourceGroupName')]"
-          },
           "hubVirtualNetworkName": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), parameters('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value]"
           },
@@ -3384,25 +3381,22 @@
               {
                 "name": "value",
                 "count": "[length(variables('spokes'))]",
-                "input": "[createObject('type', variables('spokes')[copyIndex('value')].type, 'name', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscription, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].type, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkName.value, 'virtualNetworkResourceId', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscription, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].type, parameters('nowUtc'))), '2020-06-01').outputs.virtualNetworkResourceId.value)]"
+                "input": "[createObject('type', variables('spokes')[copyIndex('value')].type, 'virtualNetworkName', variables('spokes')[copyIndex('value')].virtualNetworkName, 'virtualNetworkResourceId', resourceId(variables('spokes')[copyIndex('value')].subscriptionId, variables('spokes')[copyIndex('value')].resourceGroupName, 'Microsoft.Network/virtualNetworks@2021-02-01', variables('spokes')[copyIndex('value')].virtualNetworkName))]"
               }
             ]
           }
         },
         "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "4265705882628417745"
+              "templateHash": "5598014082902284098"
             }
           },
           "parameters": {
-            "hubResourceGroupName": {
-              "type": "string"
-            },
             "hubVirtualNetworkName": {
               "type": "string"
             },
@@ -3420,7 +3414,6 @@
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-06-01",
               "name": "[format('hubTo{0}VirtualNetworkPeering', parameters('spokeNetworks')[copyIndex()].type)]",
-              "resourceGroup": "[parameters('hubResourceGroupName')]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"

--- a/src/bicep/modules/hubNetworkPeerings.bicep
+++ b/src/bicep/modules/hubNetworkPeerings.bicep
@@ -2,36 +2,13 @@ targetScope = 'subscription'
 
 param hubResourceGroupName string
 param hubVirtualNetworkName string
-param identityVirtualNetworkName string
-param identityVirtualNetworkResourceId string
-param operationsVirtualNetworkName string
-param operationsVirtualNetworkResourceId string
-param sharedServicesVirtualNetworkName string
-param sharedServicesVirtualNetworkResourceId string
+param spokeNetworks array
 
-module hubToIdentityVirtualNetworkPeering './virtualNetworkPeering.bicep' = {
+module hubToSpokePeering './virtualNetworkPeering.bicep' = [ for spoke in spokeNetworks: {
   scope: resourceGroup(hubResourceGroupName)
-  name: 'hubToIdentityVirtualNetworkPeering'
+  name: 'hubTo${spoke.type}VirtualNetworkPeering'
   params: {
-    name: '${hubVirtualNetworkName}/to-${identityVirtualNetworkName}'
-    remoteVirtualNetworkResourceId: identityVirtualNetworkResourceId
+    name: '${hubVirtualNetworkName}/to-${spoke.virtualNetworkName}'
+    remoteVirtualNetworkResourceId: spoke.virtualNetworkResourceId
   }
-}
-
-module hubToOperationsVirtualNetworkPeering './virtualNetworkPeering.bicep' = {
-  scope: resourceGroup(hubResourceGroupName)
-  name: 'hubToOperationsVirtualNetworkPeering'
-  params: {
-    name: '${hubVirtualNetworkName}/to-${operationsVirtualNetworkName}'
-    remoteVirtualNetworkResourceId: operationsVirtualNetworkResourceId
-  }
-}
-
-module hubToSharedServicesVirtualNetworkPeering './virtualNetworkPeering.bicep' = {
-  scope: resourceGroup(hubResourceGroupName)
-  name: 'hubToSharedServicesVirtualNetworkPeering'
-  params: {
-    name: '${hubVirtualNetworkName}/to-${sharedServicesVirtualNetworkName}'
-    remoteVirtualNetworkResourceId: sharedServicesVirtualNetworkResourceId
-  }
-}
+}]

--- a/src/bicep/modules/hubNetworkPeerings.bicep
+++ b/src/bicep/modules/hubNetworkPeerings.bicep
@@ -1,12 +1,8 @@
-targetScope = 'subscription'
-
-param hubResourceGroupName string
 param hubVirtualNetworkName string
-param spokeNetworks array
+param spokes array
 
-module hubToSpokePeering './virtualNetworkPeering.bicep' = [ for spoke in spokeNetworks: {
-  scope: resourceGroup(hubResourceGroupName)
-  name: 'hubTo${spoke.type}VirtualNetworkPeering'
+module hubToSpokePeering './virtualNetworkPeering.bicep' = [ for spoke in spokes: {
+  name: 'hub-to-${spoke.type}-vnet-peering'
   params: {
     name: '${hubVirtualNetworkName}/to-${spoke.virtualNetworkName}'
     remoteVirtualNetworkResourceId: spoke.virtualNetworkResourceId

--- a/src/bicep/modules/logAnalyticsWorkspace.bicep
+++ b/src/bicep/modules/logAnalyticsWorkspace.bicep
@@ -106,7 +106,6 @@ resource lock 'Microsoft.Authorization/locks@2016-09-01' = if (enableDeleteLock)
   }
 }
 
-
 output id string = logAnalyticsWorkspace.id
 output name string = logAnalyticsWorkspace.name
-
+output resourceGroupName string = resourceGroup().name

--- a/src/bicep/modules/policyAssignment.bicep
+++ b/src/bicep/modules/policyAssignment.bicep
@@ -4,7 +4,7 @@
   'CMMC'
 ])
 @description('[NIST/IL5/CMMC] Built-in policy assignments to assign, default is NIST. IL5 is only availalbe for GOV cloud and will switch to NIST if tried in AzureCloud.')
-param builtInAssignment string
+param builtInAssignment string = 'NIST'
 param logAnalyticsWorkspaceName string
 param logAnalyticsWorkspaceResourceGroupName string
 param operationsSubscriptionId string
@@ -21,7 +21,7 @@ var policyDefinitionID = {
   NIST: {
     id: '/providers/Microsoft.Authorization/policySetDefinitions/cf25b9c1-bd23-4eb6-bd2c-f4f3ac644a5f'
     parameters: json(replace(loadTextContent('policies/NIST-policyAssignmentParameters.json'),'<LAWORKSPACE>', logAnalyticsWorkspace.id))
-  }  
+  }
   IL5: {
     id: '/providers/Microsoft.Authorization/policySetDefinitions/f9a961fa-3241-4b20-adc4-bbf8ad9d7197'
     parameters: json(replace(loadTextContent('policies/IL5-policyAssignmentParameters.json'),'<LAWORKSPACE>', logAnalyticsWorkspace.id))
@@ -29,7 +29,7 @@ var policyDefinitionID = {
   CMMC: {
     id: '/providers/Microsoft.Authorization/policySetDefinitions/b5629c75-5c77-4422-87b9-2509e680f8de'
     parameters: json(replace(loadTextContent('policies/CMMC-policyAssignmentParameters.json'),'<LAWORKSPACE>', logAnalyticsWorkspace.properties.customerId))
-  }  
+  }
 }
 
 var modifiedAssignment = ( environment().name =~ 'AzureCloud' && builtInAssignment =~ 'IL5' ? 'NIST' : builtInAssignment )
@@ -39,7 +39,7 @@ var agentVmAssignmentName = 'Deploy VM Agents ${resourceGroup().name}'
 var contributorRoleDefinitionId = resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
 var lawsReaderRoleDefinitionId = resourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')
 
-// assign policy to resource group 
+// assign policy to resource group
 resource assignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = {
   name: assignmentName
   location: resourceGroup().location

--- a/src/bicep/modules/policyAssignment.bicep
+++ b/src/bicep/modules/policyAssignment.bicep
@@ -1,4 +1,10 @@
-param builtInAssignment string = ''
+@allowed([
+  'NIST'
+  'IL5' // AzureUsGovernment only, trying to deploy IL5 in AzureCloud will switch to NIST
+  'CMMC'
+])
+@description('[NIST/IL5/CMMC] Built-in policy assignments to assign, default is NIST. IL5 is only availalbe for GOV cloud and will switch to NIST if tried in AzureCloud.')
+param builtInAssignment string
 param logAnalyticsWorkspaceName string
 param logAnalyticsWorkspaceResourceGroupName string
 param operationsSubscriptionId string
@@ -6,7 +12,6 @@ param operationsSubscriptionId string
 @description('Starts a policy remediation for the VM Agent policies in hub RG. Set to false by default since this is time consuming in deployment.')
 param deployRemediation bool = false
 
-// Creating a symbolic name for an existing resource
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
   name: logAnalyticsWorkspaceName
   scope: resourceGroup(operationsSubscriptionId, logAnalyticsWorkspaceResourceGroupName)
@@ -35,8 +40,7 @@ var contributorRoleDefinitionId = resourceId('Microsoft.Authorization/roleDefini
 var lawsReaderRoleDefinitionId = resourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')
 
 // assign policy to resource group 
-
-resource assignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (!empty(modifiedAssignment)){
+resource assignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = {
   name: assignmentName
   location: resourceGroup().location
   properties: {
@@ -81,8 +85,7 @@ resource vmAgentAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01
 }
 
 // assign the policies assigned idenitity as contributor to each resource group for deploy if not exist and modify policiy remediation
-
-resource policyRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = if (!empty(modifiedAssignment)){
+resource policyRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
   name: guid(contributorRoleDefinitionId,assignmentName)
   scope: resourceGroup()
   properties: {
@@ -115,17 +118,17 @@ resource vmPolicyRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-04
 module roleAssignment '../modules/roleAssignment.bicep' = {
   name: 'Assign-Laws-Role-Policy-${resourceGroup().name}'
   scope: resourceGroup(operationsSubscriptionId, logAnalyticsWorkspaceResourceGroupName)
-    params: {
-      targetResourceId: logAnalyticsWorkspace.id
-      roleDefinitionId: lawsReaderRoleDefinitionId
-      principalId: vmAgentAssignment.identity.principalId
-    }
+  params: {
+    targetResourceId: logAnalyticsWorkspace.id
+    roleDefinitionId: lawsReaderRoleDefinitionId
+    principalId: vmAgentAssignment.identity.principalId
   }
+}
 
-  resource vmPolicyRemediation 'Microsoft.PolicyInsights/remediations@2019-07-01' = if(deployRemediation) {
-    name: 'VM-Agent-Policy-Remediation'
-    properties: {
-      policyAssignmentId: vmAgentAssignment.id
-      resourceDiscoveryMode: 'ReEvaluateCompliance'
-    }
+resource vmPolicyRemediation 'Microsoft.PolicyInsights/remediations@2019-07-01' = if(deployRemediation) {
+  name: 'VM-Agent-Policy-Remediation'
+  properties: {
+    policyAssignmentId: vmAgentAssignment.id
+    resourceDiscoveryMode: 'ReEvaluateCompliance'
   }
+}

--- a/src/bicep/modules/resourceGroup.bicep
+++ b/src/bicep/modules/resourceGroup.bicep
@@ -12,3 +12,4 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2019-05-01' = {
 
 output id string = resourceGroup.id
 output name string = resourceGroup.name
+output location string = resourceGroup.location

--- a/src/bicep/modules/spokeNetworkPeering.bicep
+++ b/src/bicep/modules/spokeNetworkPeering.bicep
@@ -1,5 +1,6 @@
 targetScope = 'subscription'
 
+param spokeType string
 param spokeResourceGroupName string
 param spokeVirtualNetworkName string
 
@@ -7,8 +8,8 @@ param hubVirtualNetworkName string
 param hubVirtualNetworkResourceId string
 
 module spokeNetworkPeering './virtualNetworkPeering.bicep' = {
+  name: '${spokeType}-to-hub-vnet-peering'
   scope: resourceGroup(spokeResourceGroupName)
-  name: 'spokeNetworkPeering'
   params: {
     name: '${spokeVirtualNetworkName}/to-${hubVirtualNetworkName}'
     remoteVirtualNetworkResourceId: hubVirtualNetworkResourceId


### PR DESCRIPTION
# Description

This change creates spokes and their dependencies in the same way to reduce the likelihood of introducing changes that causes spokes to differ.

First, it creates a `mlz.bicep` array called `spokes` that is composed of user-defined and defaulted parameters:

https://github.com/Azure/missionlz/blob/d95dc7a43a32260fe6532fab1b313c2f7cff764e/src/bicep/mlz.bicep#L557-L561

Then, it uses [Bicep's loop syntax](https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/loops) to create modules for those items in the `spokes` array:

https://github.com/Azure/missionlz/blob/d95dc7a43a32260fe6532fab1b313c2f7cff764e/src/bicep/mlz.bicep#L17-L25

This change also adds documentation on how to retrieve deployed resources programmatically:

https://github.com/Azure/missionlz/blob/d95dc7a43a32260fe6532fab1b313c2f7cff764e/src/bicep/README.md#reference-deployment-output

## Issue reference

The issue this PR will close: #493

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
