### PR TITLE
Check cloud before collecting audit logs

### DIFF
--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -215,7 +215,6 @@ module logAnalyticsDiagnosticLogging './modules/logAnalyticsDiagnosticLogging.bi
   params: {
     diagnosticStorageAccountName: operationsLogStorageAccountName
     logAnalyticsWorkspaceName: logAnalyticsWorkspace.outputs.name
-    enableDiagnostics: true
   }
   dependsOn: [
     hubNetwork

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "12775752022763865170"
+      "templateHash": "11544710405663054226"
     }
   },
   "parameters": {
@@ -4358,9 +4358,6 @@
           },
           "logAnalyticsWorkspaceName": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), parameters('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('nowUtc'))), '2020-06-01').outputs.name.value]"
-          },
-          "enableDiagnostics": {
-            "value": true
           }
         },
         "template": {
@@ -4370,7 +4367,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "15160395873360351727"
+              "templateHash": "11315996337583372529"
             }
           },
           "parameters": {
@@ -4380,15 +4377,18 @@
             "logAnalyticsWorkspaceName": {
               "type": "string"
             },
-            "enableDiagnostics": {
-              "type": "bool",
-              "defaultValue": true
+            "supportedClouds": {
+              "type": "array",
+              "defaultValue": [
+                "AzureCloud",
+                "AzureUSGovernment"
+              ]
             }
           },
           "functions": [],
           "resources": [
             {
-              "condition": "[parameters('enableDiagnostics')]",
+              "condition": "[contains(parameters('supportedClouds'), environment().name)]",
               "type": "Microsoft.Insights/diagnosticSettings",
               "apiVersion": "2017-05-01-preview",
               "scope": "[format('Microsoft.OperationalInsights/workspaces/{0}', parameters('logAnalyticsWorkspaceName'))]",

--- a/src/bicep/modules/logAnalyticsDiagnosticLogging.bicep
+++ b/src/bicep/modules/logAnalyticsDiagnosticLogging.bicep
@@ -1,6 +1,11 @@
 param diagnosticStorageAccountName string
 param logAnalyticsWorkspaceName string
-param enableDiagnostics bool = true
+
+param supportedClouds array = [
+  'AzureCloud'
+  'AzureUSGovernment'
+]
+
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
   name: logAnalyticsWorkspaceName
@@ -17,7 +22,7 @@ resource securityContacts 'Microsoft.Security/securityContacts@2017-08-01-previe
 
 
 //// Setting log analytics to collect its own diagnostics to itself and to storage
-resource logAnalyticsDiagnostics 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = if (enableDiagnostics) {
+resource logAnalyticsDiagnostics 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = if ( contains(supportedClouds, environment().name)) {
   name: 'enable-log-analytics-diagnostics'  
   scope: logAnalyticsWorkspace
   properties: {


### PR DESCRIPTION
# Description

Deploying to clouds other than pub and gov may cause issues adding diagnostic settings to the workspace (essentially monitoring the workspace itself) since the Audit logs are not supported in all clouds. The PR added the environment check and removed the boolean parameter for deploying this diagnostic setting.

## Issue reference

The issue this PR will close: #519 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
