### PR TITLE
modified private link naming variables

### DIFF
--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "14984160042336406283"
+      "templateHash": "11074406747608602454"
     }
   },
   "parameters": {

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "11544710405663054226"
+      "templateHash": "14984160042336406283"
     }
   },
   "parameters": {
@@ -1227,7 +1227,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "2822522237557490106"
+              "templateHash": "13599565970900573060"
             }
           },
           "parameters": {
@@ -2432,7 +2432,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "18251381868621303940"
+                      "templateHash": "7428452441585761239"
                     }
                   },
                   "parameters": {
@@ -2490,10 +2490,10 @@
                   },
                   "functions": [],
                   "variables": {
-                    "privateLinkConnectionName": "[substring(format('plconn{0}{1}', parameters('logAnalyticsWorkspaceName'), parameters('uniqueData')), 0, 16)]",
-                    "privateLinkEndpointName": "[substring(format('pl{0}{1}', parameters('logAnalyticsWorkspaceName'), parameters('uniqueData')), 0, 16)]",
-                    "privateLinkScopeName": "[substring(format('plscope{0}{1}', parameters('logAnalyticsWorkspaceName'), parameters('uniqueData')), 0, 16)]",
-                    "privateLinkScopeResourceName": "[substring(format('plscres{0}{1}', parameters('logAnalyticsWorkspaceName'), parameters('uniqueData')), 0, 16)]",
+                    "privateLinkConnectionName": "[take(format('plconn{0}{1}', parameters('logAnalyticsWorkspaceName'), parameters('uniqueData')), 80)]",
+                    "privateLinkEndpointName": "[take(format('pl{0}{1}', parameters('logAnalyticsWorkspaceName'), parameters('uniqueData')), 80)]",
+                    "privateLinkScopeName": "[take(format('plscope{0}{1}', parameters('logAnalyticsWorkspaceName'), parameters('uniqueData')), 80)]",
+                    "privateLinkScopeResourceName": "[take(format('plscres{0}{1}', parameters('logAnalyticsWorkspaceName'), parameters('uniqueData')), 80)]",
                     "privateDnsZones_privatelink_monitor_azure_name": "[if(equals(toLower(environment().name), toLower('AzureCloud')), 'privatelink.monitor.azure.com', 'privatelink.monitor.azure.us')]",
                     "privateDnsZones_privatelink_ods_opinsights_azure_name": "[if(equals(toLower(environment().name), toLower('AzureCloud')), 'privatelink.ods.opinsights.azure.com', 'privatelink.ods.opinsights.azure.us')]",
                     "privateDnsZones_privatelink_oms_opinsights_azure_name": "[if(equals(toLower(environment().name), toLower('AzureCloud')), 'privatelink.oms.opinsights.azure.com', 'privatelink.oms.opinsights.azure.us')]",

--- a/src/bicep/modules/privateLink.bicep
+++ b/src/bicep/modules/privateLink.bicep
@@ -22,10 +22,10 @@ param vnetResourceGroup string = resourceGroup().name
 @description('The subscription id of the subscription the virtual network exists in')
 param vnetSubscriptionId string = subscription().subscriptionId
 
-var privateLinkConnectionName  = substring('plconn${logAnalyticsWorkspaceName }${uniqueData}', 0, 16)
-var privateLinkEndpointName = substring('pl${logAnalyticsWorkspaceName }${uniqueData}', 0, 16)
-var privateLinkScopeName = substring('plscope${logAnalyticsWorkspaceName }${uniqueData}', 0, 16)
-var privateLinkScopeResourceName = substring('plscres${logAnalyticsWorkspaceName }${uniqueData}', 0, 16)
+var privateLinkConnectionName  = take('plconn${logAnalyticsWorkspaceName }${uniqueData}', 80)
+var privateLinkEndpointName = take('pl${logAnalyticsWorkspaceName }${uniqueData}', 80)
+var privateLinkScopeName = take('plscope${logAnalyticsWorkspaceName }${uniqueData}', 80)
+var privateLinkScopeResourceName = take('plscres${logAnalyticsWorkspaceName }${uniqueData}', 80)
 
 resource globalPrivateLinkScope 'microsoft.insights/privateLinkScopes@2019-10-17-preview' = {
   name: privateLinkScopeName

--- a/src/bicep/modules/privateLink.bicep
+++ b/src/bicep/modules/privateLink.bicep
@@ -22,10 +22,10 @@ param vnetResourceGroup string = resourceGroup().name
 @description('The subscription id of the subscription the virtual network exists in')
 param vnetSubscriptionId string = subscription().subscriptionId
 
-var privateLinkConnectionName  = take('plconn${logAnalyticsWorkspaceName }${uniqueData}', 80)
-var privateLinkEndpointName = take('pl${logAnalyticsWorkspaceName }${uniqueData}', 80)
-var privateLinkScopeName = take('plscope${logAnalyticsWorkspaceName }${uniqueData}', 80)
-var privateLinkScopeResourceName = take('plscres${logAnalyticsWorkspaceName }${uniqueData}', 80)
+var privateLinkConnectionName  = take('plconn${logAnalyticsWorkspaceName}${uniqueData}', 80)
+var privateLinkEndpointName = take('pl${logAnalyticsWorkspaceName}${uniqueData}', 80)
+var privateLinkScopeName = take('plscope${logAnalyticsWorkspaceName}${uniqueData}', 80)
+var privateLinkScopeResourceName = take('plscres${logAnalyticsWorkspaceName}${uniqueData}', 80)
 
 resource globalPrivateLinkScope 'microsoft.insights/privateLinkScopes@2019-10-17-preview' = {
   name: privateLinkScopeName

--- a/src/bicep/modules/privateLink.bicep
+++ b/src/bicep/modules/privateLink.bicep
@@ -93,7 +93,7 @@ resource dnsZonePrivateLinkEndpoint 'Microsoft.Network/privateEndpoints/privateD
       {
         name: 'agentsvc'
         properties: {
-          privateDnsZoneId: privatelink_agentsvc_azure_automation_net .id
+          privateDnsZoneId: privatelink_agentsvc_azure_automation_net.id
         }
       }
       {


### PR DESCRIPTION
# Description

During testing it was discovered that longer than normal prefix naming could cause private link scoping (which was set to 16 characters) to truncate the LAWS name down to ending with a hyphen which in turn broke creating the private link scope.

## Issue reference

The issue this PR will close: #527 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
