### PR TITLE
Remove default NSG rules for 22 and 3389 from Bicep deployment

### DIFF
--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -324,36 +324,7 @@ param hubSubnetAddressPrefix string = '10.0.100.128/27'
 param hubVirtualNetworkDiagnosticsLogs array = []
 param hubVirtualNetworkDiagnosticsMetrics array = []
 param hubNetworkSecurityGroupName string = 'hub-nsg'
-param hubNetworkSecurityGroupRules array = [
-  {
-    name: 'allow_ssh'
-    properties: {
-      description: 'Allow SSH access from anywhere'
-      access: 'Allow'
-      priority: 100
-      protocol: 'Tcp'
-      direction: 'Inbound'
-      sourcePortRange: '*'
-      sourceAddressPrefix: '*'
-      destinationPortRange: '22'
-      destinationAddressPrefix: '*'
-    }
-  }
-  {
-    name: 'allow_rdp'
-    properties: {
-      description: 'Allow RDP access from anywhere'
-      access: 'Allow'
-      priority: 200
-      protocol: 'Tcp'
-      direction: 'Inbound'
-      sourcePortRange: '*'
-      sourceAddressPrefix: '*'
-      destinationPortRange: '3389'
-      destinationAddressPrefix: '*'
-    }
-  }
-]
+param hubNetworkSecurityGroupRules array = []
 param hubNetworkSecurityGroupDiagnosticsLogs array = [
   {
     category: 'NetworkSecurityGroupEvent'

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "11074406747608602454"
+      "templateHash": "12229757666558456520"
     }
   },
   "parameters": {
@@ -80,36 +80,7 @@
     },
     "hubNetworkSecurityGroupRules": {
       "type": "array",
-      "defaultValue": [
-        {
-          "name": "allow_ssh",
-          "properties": {
-            "description": "Allow SSH access from anywhere",
-            "access": "Allow",
-            "priority": 100,
-            "protocol": "Tcp",
-            "direction": "Inbound",
-            "sourcePortRange": "*",
-            "sourceAddressPrefix": "*",
-            "destinationPortRange": "22",
-            "destinationAddressPrefix": "*"
-          }
-        },
-        {
-          "name": "allow_rdp",
-          "properties": {
-            "description": "Allow RDP access from anywhere",
-            "access": "Allow",
-            "priority": 200,
-            "protocol": "Tcp",
-            "direction": "Inbound",
-            "sourcePortRange": "*",
-            "sourceAddressPrefix": "*",
-            "destinationPortRange": "3389",
-            "destinationAddressPrefix": "*"
-          }
-        }
-      ]
+      "defaultValue": []
     },
     "hubNetworkSecurityGroupDiagnosticsLogs": {
       "type": "array",


### PR DESCRIPTION
# Description

Removed the default values of Hub NSG rules

## Issue reference

The issue this PR will close: #443 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
