### PR TITLE
Breestryker/polichecklatest

### DIFF
--- a/.azure-devops/cred-poli-scan.yml
+++ b/.azure-devops/cred-poli-scan.yml
@@ -16,7 +16,7 @@ pool:
 jobs:
 - job: ADOPoliCredScanCheck
   steps:
-  - task: PoliCheck@1
+  - task: PoliCheck@2
     inputs:
       inputType: 'Basic'
       targetType: 'F'
@@ -24,7 +24,7 @@ jobs:
       result: 'PoliCheck.xml'
   - publish: D:\a\1\_sdt\logs\PoliCheck\PoliCheck.xml
     artifact: PoliCheck.xml
-  - task: CredScan@2
+  - task: CredScan@3
     inputs:
       toolMajorVersion: 'V2'
       scanFolder: '$(System.DefaultWorkingDirectory)'

--- a/.azure-devops/cred-poli-scan.yml
+++ b/.azure-devops/cred-poli-scan.yml
@@ -22,7 +22,7 @@ jobs:
       targetType: 'F'
       targetArgument: '$(System.DefaultWorkingDirectory)'
       result: 'PoliCheck.xml'
-  - publish: D:\a\1\_sdt\logs\PoliCheck\PoliCheck.xml
+  - publish: D:\a\1\.gdn\.r\policheck\001\policheck.xml
     artifact: PoliCheck.xml
   - task: CredScan@3
     inputs:


### PR DESCRIPTION
# Description

Pinned to latest major versions.  Changed artifact output as it changed between versions.

There doesn't appear to be a decorator to pin to latest, and you are required to at least specify the major version.
Based on https://docs.microsoft.com/en-us/azure/devops/pipelines/process/tasks?view=azure-devops&tabs=yaml#task-versions

This is still being hosted out of the original devops area as policheck and credential scanner are not available tasks in our new pipeline store yet.  I will move them over asap. 

## Issue reference

The issue this PR will close: #547 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [X] All acceptance criteria in the backlog item are met
* [X] The documentation is updated to cover any new or changed features
* [X] Manual tests have passed
* [X] Relevant issues are linked to this PR
