### PR TITLE
Enforce a mandatory resourcePrefix parameter

### DIFF
--- a/.azure-devops/nightlybuild/mlz-bicep-azurecloud-pipelines.yml
+++ b/.azure-devops/nightlybuild/mlz-bicep-azurecloud-pipelines.yml
@@ -25,10 +25,12 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
+        datetime=$(date +%s) # gets the current date time as a epoch
         az deployment sub create \
           --name $(bDeploymentName) \
           --location $(Location) \
-          --template-file $(TemplateFile)
+          --template-file $(TemplateFile) \
+          --parameters resourcePrefix=$datetime
 
   - task: AzureCLI@2
     displayName: "Extract Values and Hydrate Variables for T3 Deployment"

--- a/.azure-devops/nightlybuild/mlz-bicep-azurecloud-pipelines.yml
+++ b/.azure-devops/nightlybuild/mlz-bicep-azurecloud-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
-        datetime=$(date +%s) # gets the current date time as a epoch
+        datetime=$(date +%s) # gets the current date time as an epoch
         az deployment sub create \
           --name $(bDeploymentName) \
           --location $(Location) \

--- a/.azure-devops/nightlybuild/mlz-bicep-azuregov-pipelines.yml
+++ b/.azure-devops/nightlybuild/mlz-bicep-azuregov-pipelines.yml
@@ -25,11 +25,11 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
-        datetime=$(date +%s) # gets the current date time as a epoch
+        datetime=$(date +%s) # gets the current date time as an epoch
         az deployment sub create \
           --name $(bDeploymentName) \
           --location $(GLocation) \
-          --template-file $(TemplateFile)
+          --template-file $(TemplateFile) \
           --parameters resourcePrefix=$datetime
 
   - task: AzureCLI@2

--- a/.azure-devops/nightlybuild/mlz-bicep-azuregov-pipelines.yml
+++ b/.azure-devops/nightlybuild/mlz-bicep-azuregov-pipelines.yml
@@ -25,10 +25,12 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
+        datetime=$(date +%s) # gets the current date time as a epoch
         az deployment sub create \
           --name $(bDeploymentName) \
           --location $(GLocation) \
           --template-file $(TemplateFile)
+          --parameters resourcePrefix=$datetime
 
   - task: AzureCLI@2
     displayName: "Extract Values and Hydrate Variables for T3 Deployment"

--- a/.azure-devops/prbuild/mlz-pr-bicep-azurecloud-pipelines.yml
+++ b/.azure-devops/prbuild/mlz-pr-bicep-azurecloud-pipelines.yml
@@ -26,7 +26,9 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
+        datetime=$(date +%s) # gets the current date time as a epoch
         az deployment sub what-if \
           --name $(bDeploymentName) \
           --location $(Location) \
           --template-file $(TemplateFile)
+          --parameters resourcePrefix=$datetime

--- a/.azure-devops/prbuild/mlz-pr-bicep-azurecloud-pipelines.yml
+++ b/.azure-devops/prbuild/mlz-pr-bicep-azurecloud-pipelines.yml
@@ -26,9 +26,9 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
-        datetime=$(date +%s) # gets the current date time as a epoch
+        datetime=$(date +%s) # gets the current date time as an epoch
         az deployment sub what-if \
           --name $(bDeploymentName) \
           --location $(Location) \
-          --template-file $(TemplateFile)
+          --template-file $(TemplateFile) \
           --parameters resourcePrefix=$datetime

--- a/.azure-devops/prbuild/mlz-pr-bicep-azuregov-pipelines.yml
+++ b/.azure-devops/prbuild/mlz-pr-bicep-azuregov-pipelines.yml
@@ -26,7 +26,9 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
+        datetime=$(date +%s) # gets the current date time as a epoch
         az deployment sub what-if \
           --name $(bDeploymentName) \
           --location $(GLocation) \
-          --template-file $(TemplateFile)
+          --template-file $(TemplateFile) \
+          --parameters resourcePrefix=$datetime

--- a/.azure-devops/prbuild/mlz-pr-bicep-azuregov-pipelines.yml
+++ b/.azure-devops/prbuild/mlz-pr-bicep-azuregov-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
-        datetime=$(date +%s) # gets the current date time as a epoch
+        datetime=$(date +%s) # gets the current date time as an epoch
         az deployment sub what-if \
           --name $(bDeploymentName) \
           --location $(GLocation) \

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ az deployment sub create \
   --template-file ./missionlz/src/bicep/mlz.bicep
 ```
 
+You'll be prompted for the one required argument `resourcePrefix` (a unique alphanumeric string 3-10 characters in length), which is used to to generate names for your resource groups and resources:
+
+```plaintext
+> Please provide string value for 'resourcePrefix' (? for help): (your unique alphanumeric string 3-10 characters in length)
+```
+
 ## Scope
 
 Mission LZ has the following scope:

--- a/src/bicep/README.md
+++ b/src/bicep/README.md
@@ -11,24 +11,33 @@ You can deploy with the Azure Portal, the Azure CLI, or with both in a Azure Com
 
 > NOTE: The AZ CLI will automatically install the Bicep tools when a command is run that needs them, or you can manually install them following the [instructions here.](https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/install#azure-cli)
 
-Are you deploying into a cloud other than `AzureCloud` like say `AzureUsGovernment`?
+#### Decide on a Resource Prefix
 
-- See [Deploying to Other Clouds](#Deploying-to-Other-Clouds).
+Resource Groups and resource names are derived from the mandatory parameter `resourcePrefix`.
 
-Want to add Azure Policies to this deployment?
+Pick a unqiue resource prefix that is 3-10 alphanumeric characters in length without whitespaces.
 
-- See [Adding Azure Policy](#Adding-Azure-Policy) to add policies like DoD IL5, NIST 800-53, CMMC Level 3, or how to apply your own.
+#### Pick your deployment options
 
-Want to remotely access the network without exposing it via Public IP Addresses?
+- Are you deploying into a cloud other than `AzureCloud` like say `AzureUsGovernment`?
 
-- See [Adding Remote Access via Bastion Host](#Adding-Remote-Access-via-Bastion-Host) to add virtual machines inside the network that you can access from an authenticated session in the Azure Portal with Azure Bastion.
+  - See [Deploying to Other Clouds](#Deploying-to-Other-Clouds).
 
-By default, this template deploys **[Azure Firewall Premium](https://docs.microsoft.com/en-us/azure/firewall/premium-features)**.
+- Want to add Azure Policies to this deployment?
 
-**Not all regions support Azure Firewall Premium.** Check here to [see if the region you're deploying to supports Azure Firewall Premium](https://docs.microsoft.com/en-us/azure/firewall/premium-features#supported-regions). If this doesn't fit your needs:
+  - See [Adding Azure Policy](#Adding-Azure-Policy) to add policies like DoD IL5, NIST 800-53, CMMC Level 3, or how to apply your own.
 
-- See [Setting the Firewall SKU](#Setting-the-Firewall-SKU) for steps on how to use the Standard SKU instead.
-- See [Setting the Firewall Location](#Setting-the-Firewall-Location) for steps on how to deploy into a different region.
+- Want to remotely access the network without exposing it via Public IP Addresses?
+
+  - See [Adding Remote Access via Bastion Host](#Adding-Remote-Access-via-Bastion-Host) to add virtual machines inside the network that you can access from an authenticated session in the Azure Portal with Azure Bastion.
+
+- By default, this template deploys **[Azure Firewall Premium](https://docs.microsoft.com/en-us/azure/firewall/premium-features)**.
+
+  - **Not all regions support Azure Firewall Premium.** Check here to [see if the region you're deploying to supports Azure Firewall Premium](https://docs.microsoft.com/en-us/azure/firewall/premium-features#supported-regions). If this doesn't fit your needs:
+  - See [Setting the Firewall SKU](#Setting-the-Firewall-SKU) for steps on how to use the Standard SKU instead.
+  - See [Setting the Firewall Location](#Setting-the-Firewall-Location) for steps on how to deploy into a different region.
+
+#### Know where to find your deployment output
 
 After a deployment is complete, you can refer to the provisioned resources programmaticaly with the Azure CLI.
 
@@ -47,6 +56,12 @@ az deployment sub create \
   --name myMlzDeployment \
   --location eastus \
   --template-file ./mlz.bicep
+```
+
+You'll be prompted for the one required argument `resourcePrefix` (a unique alphanumeric string 3-10 characters in length), which is used to to generate names for your resource groups and resources:
+
+```plaintext
+> Please provide string value for 'resourcePrefix' (? for help): mymlz01
 ```
 
 #### Multiple subscription deployment

--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -302,9 +302,9 @@ module remoteAccess './modules/remoteAccess.bicep' = if(deployRemoteAccess) {
 // parameters
 
 @minLength(3)
-@maxLength(24)
-@description('A name (3-24 alphanumeric characters in length without whitespace) used to prefix resources and generate uniqueness for resources with globally unique naming requirements like Storage Accounts and Log Analytics Workspaces')
-param resourcePrefix string = 'mlz-${uniqueId}'
+@maxLength(10)
+@description('A name (3-10 alphanumeric characters without whitespace) used to prefix resources and generate uniqueness for resources with globally unique naming requirements like Storage Accounts and Log Analytics Workspaces')
+param resourcePrefix string
 param hubSubscriptionId string = subscription().subscriptionId
 param identitySubscriptionId string = hubSubscriptionId
 param operationsSubscriptionId string = hubSubscriptionId
@@ -526,7 +526,7 @@ var defaultTags = {
 }
 var calculatedTags = union(tags,defaultTags)
 
-param uniqueId string = uniqueString(deployment().name)
+param uniqueId string = uniqueString(resourcePrefix, nowUtc)
 param nowUtc string = utcNow()
 
 var spokes = [

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,17 +5,16 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "8860935919538003927"
+      "templateHash": "15227849893402646033"
     }
   },
   "parameters": {
     "resourcePrefix": {
       "type": "string",
-      "defaultValue": "[format('mlz-{0}', parameters('uniqueId'))]",
       "metadata": {
-        "description": "A name (3-24 alphanumeric characters in length without whitespace) used to prefix resources and generate uniqueness for resources with globally unique naming requirements like Storage Accounts and Log Analytics Workspaces"
+        "description": "A name (3-10 alphanumeric characters without whitespace) used to prefix resources and generate uniqueness for resources with globally unique naming requirements like Storage Accounts and Log Analytics Workspaces"
       },
-      "maxLength": 24,
+      "maxLength": 10,
       "minLength": 3
     },
     "hubSubscriptionId": {
@@ -624,7 +623,7 @@
     },
     "uniqueId": {
       "type": "string",
-      "defaultValue": "[uniqueString(deployment().name)]"
+      "defaultValue": "[uniqueString(parameters('resourcePrefix'), parameters('nowUtc'))]"
     },
     "nowUtc": {
       "type": "string",


### PR DESCRIPTION
# Description

This change:

- makes `resourcePrefix` a mandatory parameter 
- removes `deployment().name` as a seed for resource names and uniqueness
- uses `resourcePrefix` for resource names
- uses `resourcePrefix` + `utcNow()` to generates uniqueness
- updates Azure DevOps pipelines to ensure a `resourcePrefix` parameter is supplied to deployment commands
- updates documentation to inform users that this parameter is now mandatory and used for naming

## Issue reference

The issue this PR will close: #552 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
