### PR TITLE
Enable intrusion detection (IDPS) by default

### DIFF
--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -77,6 +77,7 @@ module hubNetwork './modules/hubNetwork.bicep' = {
     firewallSkuTier: firewallSkuTier
     firewallPolicyName: firewallPolicyName
     firewallThreatIntelMode: firewallThreatIntelMode
+    firewallIntrustionDetectionMode: firewallIntrustionDetectionMode
     firewallDiagnosticsLogs: firewallDiagnosticsLogs
     firewallDiagnosticsMetrics: firewallDiagnosticsMetrics
     firewallClientIpConfigurationName: firewallClientIpConfigurationName
@@ -349,7 +350,21 @@ param firewallName string = 'firewall'
 param firewallManagementSubnetAddressPrefix string = '10.0.100.64/26'
 param firewallClientSubnetAddressPrefix string = '10.0.100.0/26'
 param firewallPolicyName string = 'firewall-policy'
+
+@allowed([
+  'Alert'
+  'Deny'
+  'Off'
+])
 param firewallThreatIntelMode string = 'Alert'
+
+@allowed([
+  'Alert'
+  'Deny'
+  'Off'
+])
+param firewallIntrustionDetectionMode string = 'Alert'
+
 param firewallDiagnosticsLogs array = [
   {
     category: 'AzureFirewallApplicationRule'

--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -77,7 +77,7 @@ module hubNetwork './modules/hubNetwork.bicep' = {
     firewallSkuTier: firewallSkuTier
     firewallPolicyName: firewallPolicyName
     firewallThreatIntelMode: firewallThreatIntelMode
-    firewallIntrustionDetectionMode: firewallIntrustionDetectionMode
+    firewallIntrusionDetectionMode: firewallIntrusionDetectionMode
     firewallDiagnosticsLogs: firewallDiagnosticsLogs
     firewallDiagnosticsMetrics: firewallDiagnosticsMetrics
     firewallClientIpConfigurationName: firewallClientIpConfigurationName
@@ -363,7 +363,7 @@ param firewallThreatIntelMode string = 'Alert'
   'Deny'
   'Off'
 ])
-param firewallIntrustionDetectionMode string = 'Alert'
+param firewallIntrusionDetectionMode string = 'Alert'
 
 param firewallDiagnosticsLogs array = [
   {

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "8860935919538003927"
+      "templateHash": "17440136114433413151"
     }
   },
   "parameters": {
@@ -133,7 +133,21 @@
     },
     "firewallThreatIntelMode": {
       "type": "string",
-      "defaultValue": "Alert"
+      "defaultValue": "Alert",
+      "allowedValues": [
+        "Alert",
+        "Deny",
+        "Off"
+      ]
+    },
+    "firewallIntrustionDetectionMode": {
+      "type": "string",
+      "defaultValue": "Alert",
+      "allowedValues": [
+        "Alert",
+        "Deny",
+        "Off"
+      ]
     },
     "firewallDiagnosticsLogs": {
       "type": "array",
@@ -1135,6 +1149,9 @@
           "firewallThreatIntelMode": {
             "value": "[parameters('firewallThreatIntelMode')]"
           },
+          "firewallIntrustionDetectionMode": {
+            "value": "[parameters('firewallIntrustionDetectionMode')]"
+          },
           "firewallDiagnosticsLogs": {
             "value": "[parameters('firewallDiagnosticsLogs')]"
           },
@@ -1203,7 +1220,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "13599565970900573060"
+              "templateHash": "15778033927435118479"
             }
           },
           "parameters": {
@@ -1286,7 +1303,20 @@
               "type": "string"
             },
             "firewallThreatIntelMode": {
-              "type": "string"
+              "type": "string",
+              "allowedValues": [
+                "Alert",
+                "Deny",
+                "Off"
+              ]
+            },
+            "firewallIntrustionDetectionMode": {
+              "type": "string",
+              "allowedValues": [
+                "Alert",
+                "Deny",
+                "Off"
+              ]
             },
             "firewallDiagnosticsLogs": {
               "type": "array"
@@ -2102,6 +2132,9 @@
                   "threatIntelMode": {
                     "value": "[parameters('firewallThreatIntelMode')]"
                   },
+                  "intrustionDetectionMode": {
+                    "value": "[parameters('firewallIntrustionDetectionMode')]"
+                  },
                   "clientIpConfigurationName": {
                     "value": "[parameters('firewallClientIpConfigurationName')]"
                   },
@@ -2140,7 +2173,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "16515753424142002553"
+                      "templateHash": "18358175967941846549"
                     }
                   },
                   "parameters": {
@@ -2159,7 +2192,20 @@
                       "type": "string"
                     },
                     "threatIntelMode": {
-                      "type": "string"
+                      "type": "string",
+                      "allowedValues": [
+                        "Alert",
+                        "Deny",
+                        "Off"
+                      ]
+                    },
+                    "intrustionDetectionMode": {
+                      "type": "string",
+                      "allowedValues": [
+                        "Alert",
+                        "Deny",
+                        "Off"
+                      ]
                     },
                     "clientIpConfigurationName": {
                       "type": "string"
@@ -2205,6 +2251,9 @@
                       "tags": "[parameters('tags')]",
                       "properties": {
                         "threatIntelMode": "[parameters('threatIntelMode')]",
+                        "intrusionDetection": {
+                          "mode": "[parameters('intrustionDetectionMode')]"
+                        },
                         "sku": {
                           "tier": "[parameters('skuTier')]"
                         }

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "17440136114433413151"
+      "templateHash": "12403164256946992612"
     }
   },
   "parameters": {
@@ -140,7 +140,7 @@
         "Off"
       ]
     },
-    "firewallIntrustionDetectionMode": {
+    "firewallIntrusionDetectionMode": {
       "type": "string",
       "defaultValue": "Alert",
       "allowedValues": [
@@ -1149,8 +1149,8 @@
           "firewallThreatIntelMode": {
             "value": "[parameters('firewallThreatIntelMode')]"
           },
-          "firewallIntrustionDetectionMode": {
-            "value": "[parameters('firewallIntrustionDetectionMode')]"
+          "firewallIntrusionDetectionMode": {
+            "value": "[parameters('firewallIntrusionDetectionMode')]"
           },
           "firewallDiagnosticsLogs": {
             "value": "[parameters('firewallDiagnosticsLogs')]"
@@ -1220,7 +1220,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "15778033927435118479"
+              "templateHash": "5914406162434941149"
             }
           },
           "parameters": {
@@ -1310,7 +1310,7 @@
                 "Off"
               ]
             },
-            "firewallIntrustionDetectionMode": {
+            "firewallIntrusionDetectionMode": {
               "type": "string",
               "allowedValues": [
                 "Alert",
@@ -2132,8 +2132,8 @@
                   "threatIntelMode": {
                     "value": "[parameters('firewallThreatIntelMode')]"
                   },
-                  "intrustionDetectionMode": {
-                    "value": "[parameters('firewallIntrustionDetectionMode')]"
+                  "intrusionDetectionMode": {
+                    "value": "[parameters('firewallIntrusionDetectionMode')]"
                   },
                   "clientIpConfigurationName": {
                     "value": "[parameters('firewallClientIpConfigurationName')]"
@@ -2173,7 +2173,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "18358175967941846549"
+                      "templateHash": "6929052309016745644"
                     }
                   },
                   "parameters": {
@@ -2199,7 +2199,7 @@
                         "Off"
                       ]
                     },
-                    "intrustionDetectionMode": {
+                    "intrusionDetectionMode": {
                       "type": "string",
                       "allowedValues": [
                         "Alert",
@@ -2252,7 +2252,7 @@
                       "properties": {
                         "threatIntelMode": "[parameters('threatIntelMode')]",
                         "intrusionDetection": {
-                          "mode": "[parameters('intrustionDetectionMode')]"
+                          "mode": "[parameters('intrusionDetectionMode')]"
                         },
                         "sku": {
                           "tier": "[parameters('skuTier')]"

--- a/src/bicep/modules/firewall.bicep
+++ b/src/bicep/modules/firewall.bicep
@@ -3,7 +3,20 @@ param location string = resourceGroup().location
 param tags object = {}
 
 param skuTier string
+
+@allowed([
+  'Alert'
+  'Deny'
+  'Off'
+])
 param threatIntelMode string
+
+@allowed([
+  'Alert'
+  'Deny'
+  'Off'
+])
+param intrustionDetectionMode string
 
 param clientIpConfigurationName string
 param clientIpConfigurationSubnetResourceId string
@@ -27,6 +40,9 @@ resource firewallPolicy 'Microsoft.Network/firewallPolicies@2021-02-01' = {
   tags: tags
   properties: {
     threatIntelMode: threatIntelMode
+    intrusionDetection:{
+      mode: intrustionDetectionMode
+    }
     sku: {
       tier: skuTier
     }

--- a/src/bicep/modules/firewall.bicep
+++ b/src/bicep/modules/firewall.bicep
@@ -16,7 +16,7 @@ param threatIntelMode string
   'Deny'
   'Off'
 ])
-param intrustionDetectionMode string
+param intrusionDetectionMode string
 
 param clientIpConfigurationName string
 param clientIpConfigurationSubnetResourceId string
@@ -41,7 +41,7 @@ resource firewallPolicy 'Microsoft.Network/firewallPolicies@2021-02-01' = {
   properties: {
     threatIntelMode: threatIntelMode
     intrusionDetection:{
-      mode: intrustionDetectionMode
+      mode: intrusionDetectionMode
     }
     sku: {
       tier: skuTier

--- a/src/bicep/modules/hubNetwork.bicep
+++ b/src/bicep/modules/hubNetwork.bicep
@@ -42,7 +42,7 @@ param firewallThreatIntelMode string
   'Deny'
   'Off'
 ])
-param firewallIntrustionDetectionMode string
+param firewallIntrusionDetectionMode string
 param firewallDiagnosticsLogs array
 param firewallDiagnosticsMetrics array
 param firewallClientIpConfigurationName string
@@ -214,7 +214,7 @@ module firewall './firewall.bicep' = {
 
     firewallPolicyName: firewallPolicyName
     threatIntelMode: firewallThreatIntelMode
-    intrustionDetectionMode: firewallIntrustionDetectionMode
+    intrusionDetectionMode: firewallIntrusionDetectionMode
     clientIpConfigurationName: firewallClientIpConfigurationName
     clientIpConfigurationSubnetResourceId: '${virtualNetwork.outputs.id}/subnets/${firewallClientSubnetName}'
     clientIpConfigurationPublicIPAddressResourceId: firewallClientPublicIPAddress.outputs.id

--- a/src/bicep/modules/hubNetwork.bicep
+++ b/src/bicep/modules/hubNetwork.bicep
@@ -29,7 +29,20 @@ param routeTableRouteNextHopType string = 'VirtualAppliance'
 param firewallName string
 param firewallSkuTier string
 param firewallPolicyName string
+
+@allowed([
+  'Alert'
+  'Deny'
+  'Off'
+])
 param firewallThreatIntelMode string
+
+@allowed([
+  'Alert'
+  'Deny'
+  'Off'
+])
+param firewallIntrustionDetectionMode string
 param firewallDiagnosticsLogs array
 param firewallDiagnosticsMetrics array
 param firewallClientIpConfigurationName string
@@ -201,7 +214,7 @@ module firewall './firewall.bicep' = {
 
     firewallPolicyName: firewallPolicyName
     threatIntelMode: firewallThreatIntelMode
-
+    intrustionDetectionMode: firewallIntrustionDetectionMode
     clientIpConfigurationName: firewallClientIpConfigurationName
     clientIpConfigurationSubnetResourceId: '${virtualNetwork.outputs.id}/subnets/${firewallClientSubnetName}'
     clientIpConfigurationPublicIPAddressResourceId: firewallClientPublicIPAddress.outputs.id


### PR DESCRIPTION
# Description

Enables IDPS by default and provides a parameter for setting the IDPS value. 

Also added validation to the `threadIntelMode` parameter. Both parameters use the same list of allowed values: Alert, Deny, Off.

## Issue reference

The issue this PR will close: #539 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* ~~[] The documentation is updated to cover any new or changed features~~
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
