### PR TITLE
Add default tags to Bicep examples

### DIFF
--- a/src/bicep/examples/appServicePlan/modules/appServicePlan.bicep
+++ b/src/bicep/examples/appServicePlan/modules/appServicePlan.bicep
@@ -3,6 +3,7 @@ param location string
 param capacity int = 2
 param kind string
 param sku string
+param tags object = {}
 
 var reserved = kind == 'linux' ? true : false
 
@@ -17,6 +18,7 @@ resource svcPlanName_resource 'Microsoft.Web/serverfarms@2020-12-01' = {
   properties: {
     reserved: reserved
   }
+  tags: tags
 }
 
 output svcPlanName string = svcPlanName_resource.name

--- a/src/bicep/examples/containerRegistry/contRegistry.bicep
+++ b/src/bicep/examples/containerRegistry/contRegistry.bicep
@@ -11,12 +11,20 @@ param contRegistryName string = replace('${mlzDeploymentVariables.mlzResourcePre
 @description('The name of the resource group in which the container registry will be deployed. If unchanged or not specified, the MLZ shared services resource group is used.')
 param targetResourceGroup string = '${mlzDeploymentVariables.spokes.Value[2].resourceGroupName}'
 
+@description('A string dictionary of tags to add to deployed resources. See https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources?tabs=json#arm-templates for valid settings.')
+param tags object = {}
+var defaultTags = {
+  'DeploymentType': 'MissionLandingZoneARM'
+}
+var calculatedTags = union(tags, defaultTags)
+
 var targetSubscriptionId_Var = targetResourceGroup == '${mlzDeploymentVariables.spokes.Value[2].resourceGroupName}' ? '${mlzDeploymentVariables.spokes.Value[2].subscriptionId}' : subscription().subscriptionId
 var location = deployment().location
 
 resource targetACRResourceGroup 'Microsoft.Resources/resourceGroups@2020-10-01' = {
   name: targetResourceGroup
   location: location
+  tags: calculatedTags
 }
 
 module containerRegistry 'modules/containerRegistry.bicep' = {
@@ -24,8 +32,10 @@ module containerRegistry 'modules/containerRegistry.bicep' = {
   name: contRegistryName
   params: {
     registryName: contRegistryName
+    tags: calculatedTags
   }
 }
 
 output azureContainerRegistryName string = contRegistryName
 output azureContainerRegistryResourceGroup string = targetACRResourceGroup.name
+output tags object = calculatedTags

--- a/src/bicep/examples/containerRegistry/modules/containerRegistry.bicep
+++ b/src/bicep/examples/containerRegistry/modules/containerRegistry.bicep
@@ -4,6 +4,7 @@ param registryName string
 param location string = resourceGroup().location
 param registrySku string = 'premium'
 param publicNetworkAccess string = 'enabled'
+param tags object = {}
 
 resource registryName_resource 'Microsoft.ContainerRegistry/registries@2020-11-01-preview' = {
   name: registryName
@@ -11,6 +12,7 @@ resource registryName_resource 'Microsoft.ContainerRegistry/registries@2020-11-0
   sku: {
     name: registrySku
   }
+  tags: tags
   properties: {
     publicNetworkAccess: publicNetworkAccess
     adminUserEnabled: true

--- a/src/bicep/examples/inheritTags/README.md
+++ b/src/bicep/examples/inheritTags/README.md
@@ -1,6 +1,6 @@
 # Inheriting Tags
 
-This example adds a virtual machine adds ia policy to a given resource group that forces a specific tag to be inherited by all of its child components.  This example is useful for those trying to create a charging model or provide tracking for resource consumption based on resources in a specific resource group or scope.  You can use this to apply a custom tag of your choosing.
+This example adds a policy to a given resource group that forces a specific tag to be inherited by all of its child components.  This example is useful for those trying to create a charging model or provide tracking for resource consumption based on resources in a specific resource group or scope.  You can use this to apply a custom tag of your choosing.
 
 ## What this example does
 

--- a/src/bicep/examples/keyVault/azureKeyVault.bicep
+++ b/src/bicep/examples/keyVault/azureKeyVault.bicep
@@ -11,9 +11,15 @@ param keyVaultName string = '${mlzDeploymentVariables.mlzResourcePrefix.Value}-a
 @description('The name of the resource group in which the key vault will be deployed. If unchanged or not specified, the MLZ shared services resource group is used.')
 param targetResourceGroup string = '${mlzDeploymentVariables.spokes.Value[2].resourceGroupName}'
 
+@description('A string dictionary of tags to add to deployed resources. See https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources?tabs=json#arm-templates for valid settings.')
+param tags object = {}
+var defaultTags = {
+  'DeploymentType': 'MissionLandingZoneARM'
+}
+var calculatedTags = union(tags, defaultTags)
+
 var targetSubscriptionId_Var = targetResourceGroup == '${mlzDeploymentVariables.spokes.Value[2].resourceGroupName}' ? '${mlzDeploymentVariables.spokes.Value[2].subscriptionId}' : subscription().subscriptionId
 var location = deployment().location
-
 
 resource targetASPResourceGroup 'Microsoft.Resources/resourceGroups@2020-10-01' = {
   name: targetResourceGroup
@@ -26,8 +32,10 @@ module deployAzureKeyVault 'modules/keyVault.bicep' = {
   params: {
     keyVaultName: keyVaultName
     tenantID: subscription().tenantId
+    tags: calculatedTags
   }
 }
 
 output azureKeyVaultName string = keyVaultName
 output resourceGroupName string = targetResourceGroup
+output tags object = calculatedTags

--- a/src/bicep/examples/keyVault/modules/keyVault.bicep
+++ b/src/bicep/examples/keyVault/modules/keyVault.bicep
@@ -1,10 +1,12 @@
 param keyVaultName string
 param location string = resourceGroup().location
 param tenantID string
+param tags object = {}
 
 resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' = {
   name: keyVaultName
   location: location
+  tags: tags
   properties: {
     sku: {
       family: 'A'

--- a/src/bicep/examples/newWorkload/newWorkload.bicep
+++ b/src/bicep/examples/newWorkload/newWorkload.bicep
@@ -58,7 +58,7 @@ module resourceGroup '../../modules/resourceGroup.bicep' = {
   params: {
     name: resourceGroupName
     location: location
-    tags: tags
+    tags: calculatedTags
   }
 }
 

--- a/src/bicep/examples/remoteAccess/main.bicep
+++ b/src/bicep/examples/remoteAccess/main.bicep
@@ -53,6 +53,13 @@ param windowsVmStorageAccountType string = 'StandardSSD_LRS'
 
 param nowUtc string = utcNow()
 
+@description('A string dictionary of tags to add to deployed resources. See https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources?tabs=json#arm-templates for valid settings.')
+param tags object = {}
+var defaultTags = {
+  'DeploymentType': 'MissionLandingZoneARM'
+}
+var calculatedTags = union(tags, defaultTags)
+
 module remoteAccess '../../modules/remoteAccess.bicep' = {
   name: 'deploy-remoteAccess-Example-${nowUtc}'
   params: {
@@ -102,5 +109,7 @@ module remoteAccess '../../modules/remoteAccess.bicep' = {
     windowsVmStorageAccountType: windowsVmStorageAccountType
 
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceResourceId
+
+    tags: calculatedTags
   }
 }

--- a/src/bicep/examples/remoteAccess/main.json
+++ b/src/bicep/examples/remoteAccess/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1008.15138",
-      "templateHash": "1824009288413854506"
+      "version": "0.4.1124.51302",
+      "templateHash": "17246634398667903634"
     }
   },
   "parameters": {
@@ -168,13 +168,25 @@
     "nowUtc": {
       "type": "string",
       "defaultValue": "[utcNow()]"
+    },
+    "tags": {
+      "type": "object",
+      "defaultValue": {},
+      "metadata": {
+        "description": "A string dictionary of tags to add to deployed resources. See https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources?tabs=json#arm-templates for valid settings."
+      }
     }
   },
-  "functions": [],
+  "variables": {
+    "defaultTags": {
+      "DeploymentType": "MissionLandingZoneARM"
+    },
+    "calculatedTags": "[union(parameters('tags'), variables('defaultTags'))]"
+  },
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2020-10-01",
       "name": "[format('deploy-remoteAccess-Example-{0}', parameters('nowUtc'))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -298,6 +310,9 @@
           },
           "logAnalyticsWorkspaceId": {
             "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
+          },
+          "tags": {
+            "value": "[variables('calculatedTags')]"
           }
         },
         "template": {
@@ -306,8 +321,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "5159353539145495381"
+              "version": "0.4.1124.51302",
+              "templateHash": "1358220533990268216"
             }
           },
           "parameters": {
@@ -439,11 +454,10 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "remoteAccess-bastionHost",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -488,8 +502,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "8312671392588769494"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "2380768471469099549"
                     }
                   },
                   "parameters": {
@@ -525,7 +539,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "subnetName": "AzureBastionSubnet"
                   },
@@ -584,7 +597,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "remoteAccess-linuxNetworkInterface",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -620,8 +633,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "15767041695622422511"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "8101744643505090252"
                     }
                   },
                   "parameters": {
@@ -648,7 +661,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Network/networkInterfaces",
@@ -689,7 +701,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "remoteAccess-linuxVirtualMachine",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -737,7 +749,7 @@
                     "value": "[parameters('linuxVmAdminPasswordOrKey')]"
                   },
                   "networkInterfaceName": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'remoteAccess-linuxNetworkInterface'), '2020-06-01').outputs.name.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'remoteAccess-linuxNetworkInterface'), '2020-10-01').outputs.name.value]"
                   },
                   "logAnalyticsWorkspaceId": {
                     "value": "[parameters('logAnalyticsWorkspaceId')]"
@@ -749,8 +761,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "1923864005701002999"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "16581269896210557617"
                     }
                   },
                   "parameters": {
@@ -806,7 +818,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "linuxConfiguration": {
                       "disablePasswordAuthentication": true,
@@ -948,7 +959,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "remoteAccess-windowsNetworkInterface",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -984,8 +995,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "15767041695622422511"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "8101744643505090252"
                     }
                   },
                   "parameters": {
@@ -1012,7 +1023,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Network/networkInterfaces",
@@ -1053,7 +1063,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "remoteAccess-windowsVirtualMachine",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -1098,7 +1108,7 @@
                     "value": "[parameters('windowsVmStorageAccountType')]"
                   },
                   "networkInterfaceName": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'remoteAccess-windowsNetworkInterface'), '2020-06-01').outputs.name.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'remoteAccess-windowsNetworkInterface'), '2020-10-01').outputs.name.value]"
                   },
                   "logAnalyticsWorkspaceId": {
                     "value": "[parameters('logAnalyticsWorkspaceId')]"
@@ -1110,8 +1120,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "18222194463697657474"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "5877468865897065265"
                     }
                   },
                   "parameters": {
@@ -1160,7 +1170,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Compute/virtualMachines",

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1124.51302",
-      "templateHash": "16835281694778509752"
+      "templateHash": "10156023147744075921"
     }
   },
   "parameters": {
@@ -914,7 +914,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1124.51302",
-              "templateHash": "2358208423733104980"
+              "templateHash": "14950222555728755781"
             }
           },
           "parameters": {
@@ -950,6 +950,10 @@
             "location": {
               "type": "string",
               "value": "[reference(subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('name')), '2019-05-01', 'full').location]"
+            },
+            "tags": {
+              "type": "object",
+              "value": "[reference(subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('name')), '2019-05-01', 'full').tags]"
             }
           }
         }
@@ -988,7 +992,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1124.51302",
-              "templateHash": "2358208423733104980"
+              "templateHash": "14950222555728755781"
             }
           },
           "parameters": {
@@ -1024,6 +1028,10 @@
             "location": {
               "type": "string",
               "value": "[reference(subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('name')), '2019-05-01', 'full').location]"
+            },
+            "tags": {
+              "type": "object",
+              "value": "[reference(subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('name')), '2019-05-01', 'full').tags]"
             }
           }
         }
@@ -1387,7 +1395,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1124.51302",
-              "templateHash": "5457795790797504613"
+              "templateHash": "17051388440557968847"
             }
           },
           "parameters": {
@@ -1822,7 +1830,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1124.51302",
-                      "templateHash": "11413611557719242980"
+                      "templateHash": "10163287795309985629"
                     }
                   },
                   "parameters": {
@@ -1899,6 +1907,10 @@
                     "subnets": {
                       "type": "array",
                       "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name'))).subnets]"
+                    },
+                    "addressPrefix": {
+                      "type": "string",
+                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name'))).addressSpace.addressPrefixes[0]]"
                     }
                   }
                 }
@@ -3009,7 +3021,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1124.51302",
-              "templateHash": "15135825859294163398"
+              "templateHash": "8302475958031972588"
             }
           },
           "parameters": {
@@ -3432,7 +3444,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1124.51302",
-                      "templateHash": "11413611557719242980"
+                      "templateHash": "10163287795309985629"
                     }
                   },
                   "parameters": {
@@ -3509,6 +3521,10 @@
                     "subnets": {
                       "type": "array",
                       "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name'))).subnets]"
+                    },
+                    "addressPrefix": {
+                      "type": "string",
+                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name'))).addressSpace.addressPrefixes[0]]"
                     }
                   }
                 }
@@ -3528,6 +3544,10 @@
             "virtualNetworkResourceId": {
               "type": "string",
               "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2020-10-01').outputs.id.value]"
+            },
+            "virtualNetworkAddressPrefix": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2020-10-01').outputs.addressPrefix.value]"
             },
             "subnetName": {
               "type": "string",

--- a/src/bicep/modules/resourceGroup.bicep
+++ b/src/bicep/modules/resourceGroup.bicep
@@ -13,3 +13,4 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2019-05-01' = {
 output id string = resourceGroup.id
 output name string = resourceGroup.name
 output location string = resourceGroup.location
+output tags object = resourceGroup.tags

--- a/src/bicep/modules/spokeNetwork.bicep
+++ b/src/bicep/modules/spokeNetwork.bicep
@@ -105,6 +105,7 @@ module virtualNetwork './virtualNetwork.bicep' = {
 
 output virtualNetworkName string = virtualNetwork.outputs.name
 output virtualNetworkResourceId string = virtualNetwork.outputs.id
+output virtualNetworkAddressPrefix string = virtualNetwork.outputs.addressPrefix
 output subnetName string = virtualNetwork.outputs.subnets[0].name
 output subnetAddressPrefix string = virtualNetwork.outputs.subnets[0].properties.addressPrefix
 output subnetResourceId string = virtualNetwork.outputs.subnets[0].id

--- a/src/bicep/modules/virtualNetwork.bicep
+++ b/src/bicep/modules/virtualNetwork.bicep
@@ -39,3 +39,4 @@ resource diagnostics 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' 
 output name string = virtualNetwork.name
 output id string = virtualNetwork.id
 output subnets array = virtualNetwork.properties.subnets
+output addressPrefix string = virtualNetwork.properties.addressSpace.addressPrefixes[0]


### PR DESCRIPTION
# Description

Updated Bicep examples to add the same tags as the base MLZ Bicep deployment. Users can supply an optional parameter to add tags, and the example will union those tags with the standard MLZ tags. 

I considered adding a new module for calculating the tags, like this:

```Bicep
targetScope = 'subscription'

param tags object = {}
var defaultTags = {
  'DeploymentType': 'MissionLandingZoneARM'
}
var calculatedTags = union(tags, defaultTags)

output tags object = calculatedTags
```

Which would be called from another template like this: 

```Bicep
param tags object = {}
module calculatedTags '../../modules/calculateTags.bicep' = {
  name: 'calculatedTags'
  params: {
    tags: tags
  }
}
```

The advantage would be that it's a single place to manage the default tags. However, I didn't use it because the amount of code required to call the module was not much less than the code to do the calculation within each template. I'm open to changing my mind if others have a different opinion. 👍 

## Issue reference

The issue this PR will close: #580

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
