### PR TITLE
Remove `Microsoft.Compute.CredentialsCombo` from portal user interface

### DIFF
--- a/src/bicep/form/mlz.portal.json
+++ b/src/bicep/form/mlz.portal.json
@@ -917,8 +917,7 @@
                   },
                   "options": {
                     "hideConfirmation": false
-                  },
-                  "osPlatform": "Linux"
+                  }
                 }
               ]
             }

--- a/src/bicep/form/mlz.portal.json
+++ b/src/bicep/form/mlz.portal.json
@@ -863,16 +863,15 @@
                   },
                   "type": "Microsoft.Common.PasswordBox",
                   "defaultValue": "",
-                  "toolTip": {
-                    "password": "Specify an administrator password for the Windows virtual machine used to remote into the network."
-                  },
+                  "toolTip": "Specify an administrator password for the Windows virtual machine used to remote into the network.",
                   "constraints": {
-                    "required": true
+                    "required": true,
+                    "regex": "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,72}$",
+                    "validationMessage": "The password must be alphanumeric, contain at least 12 characters, and have at least 1 letter, 1 number and one special character."
                   },
                   "options": {
                     "hideConfirmation": false
-                  },
-                  "osPlatform": "Windows"
+                  }
                 }
               ]
             },
@@ -886,7 +885,7 @@
                   "name": "linuxVmDescriptionTextblock",
                   "type": "Microsoft.Common.TextBlock",
                   "options": {
-                    "text": "Provide an administrator username and password (or SSH public key) for the Linux virtual machine."
+                    "text": "Provide an administrator username and password for the Linux virtual machine."
                   }
                 },
                 {
@@ -907,22 +906,17 @@
                   "name": "linuxVmAdminPasswordOrKey",
                   "type": "Microsoft.Common.PasswordBox",
                   "label": {
-                    "authenticationType": "Authentication type",
                     "password": "Password",
-                    "confirmPassword": "Confirm password",
-                    "sshPublicKey": "SSH public key"
+                    "confirmPassword": "Confirm password"
                   },
-                  "toolTip": {
-                    "authenticationType": "Select an authentication type",
-                    "password": "Specify an administrator password for the Linux virtual machine used to remote into the network.",
-                    "sshPublicKey": "Paste in an SSH Public Key for the Linux virtual machine used to remote into the network."
-                  },
+                  "toolTip": "Specify an administrator password for the Linux virtual machine used to remote into the network.",
                   "constraints": {
-                    "required": true
+                    "required": true,
+                    "regex": "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,72}$",
+                    "validationMessage": "The password must be alphanumeric, contain at least 12 characters, and have at least 1 letter, 1 number and one special character."
                   },
                   "options": {
-                    "hideConfirmation": false,
-                    "hidePassword": false
+                    "hideConfirmation": false
                   },
                   "osPlatform": "Linux"
                 }

--- a/src/bicep/form/mlz.portal.json
+++ b/src/bicep/form/mlz.portal.json
@@ -861,7 +861,7 @@
                     "password": "Password",
                     "confirmPassword": "Confirm password"
                   },
-                  "type": "Microsoft.Common.PasswordBox",
+                  "type": "Microsoft.Compute.CredentialsCombo-Windows",
                   "defaultValue": "",
                   "toolTip": {
                     "password": "Specify an administrator password for the Windows virtual machine used to remote into the network."
@@ -905,7 +905,7 @@
                 },
                 {
                   "name": "linuxVmAdminPasswordOrKey",
-                  "type": "Microsoft.Common.PasswordBox",
+                  "type": "Microsoft.Compute.CredentialsCombo-Linux",
                   "label": {
                     "authenticationType": "Authentication type",
                     "password": "Password",

--- a/src/bicep/form/mlz.portal.json
+++ b/src/bicep/form/mlz.portal.json
@@ -861,7 +861,7 @@
                     "password": "Password",
                     "confirmPassword": "Confirm password"
                   },
-                  "type": "Microsoft.Compute.CredentialsCombo-Windows",
+                  "type": "Microsoft.Common.PasswordBox",
                   "defaultValue": "",
                   "toolTip": {
                     "password": "Specify an administrator password for the Windows virtual machine used to remote into the network."
@@ -905,7 +905,7 @@
                 },
                 {
                   "name": "linuxVmAdminPasswordOrKey",
-                  "type": "Microsoft.Compute.CredentialsCombo-Linux",
+                  "type": "Microsoft.Common.PasswordBox",
                   "label": {
                     "authenticationType": "Authentication type",
                     "password": "Password",

--- a/src/bicep/form/mlz.portal.json
+++ b/src/bicep/form/mlz.portal.json
@@ -861,7 +861,7 @@
                     "password": "Password",
                     "confirmPassword": "Confirm password"
                   },
-                  "type": "Microsoft.Compute.CredentialsCombo",
+                  "type": "Microsoft.Common.PasswordBox",
                   "defaultValue": "",
                   "toolTip": {
                     "password": "Specify an administrator password for the Windows virtual machine used to remote into the network."
@@ -905,7 +905,7 @@
                 },
                 {
                   "name": "linuxVmAdminPasswordOrKey",
-                  "type": "Microsoft.Compute.CredentialsCombo",
+                  "type": "Microsoft.Common.PasswordBox",
                   "label": {
                     "authenticationType": "Authentication type",
                     "password": "Password",

--- a/src/bicep/form/mlz.portal.json
+++ b/src/bicep/form/mlz.portal.json
@@ -861,7 +861,7 @@
                     "password": "Password",
                     "confirmPassword": "Confirm password"
                   },
-                  "type": "Microsoft.Compute.CredentialsCombo-Windows",
+                  "type": "Microsoft.Common.PasswordBox",
                   "defaultValue": "",
                   "toolTip": {
                     "password": "Specify an administrator password for the Windows virtual machine used to remote into the network."
@@ -905,7 +905,7 @@
                 },
                 {
                   "name": "linuxVmAdminPasswordOrKey",
-                  "type": "Microsoft.Compute.CredentialsCombo-Linux",
+                  "type": "Microsoft.Common.PasswordBox",
                   "label": {
                     "authenticationType": "Authentication type",
                     "password": "Password",
@@ -986,7 +986,7 @@
         "windowsVmAdminUsername": "[steps('remoteAccess').windowsVmSection.windowsVmAdminUsername]",
         "windowsVmAdminPassword": "[steps('remoteAccess').windowsVmSection.windowsVmAdminPassword.password]",
         "linuxVmAdminUsername": "[steps('remoteAccess').linuxVmSection.linuxVmAdminUsername]",
-        "linuxVmAuthenticationType": "[steps('remoteAccess').linuxVmSection.linuxVmAdminPasswordOrKey.authenticationType]",
+        "linuxVmAuthenticationType": "password",
         "linuxVmAdminPasswordOrKey": "[if(equals(steps('remoteAccess').linuxVmSection.linuxVmAdminPasswordOrKey.authenticationType, 'password'), steps('remoteAccess').linuxVmSection.linuxVmAdminPasswordOrKey.password, steps('remoteAccess').linuxVmSection.linuxVmAdminPasswordOrKey.sshPublicKey)]"
       }
     }


### PR DESCRIPTION
# Description

Changed from `Microsoft.Compute.CredentialsCombo` to `Microsoft.Common.PasswordBox` because the Azure Portal no longer supports the `CredentialsCombo` control.

> NOTE: For now the ability to enter an SSH key has been removed because `PasswordBox` does not support that feature. We will update with an additional PR to add it back.

## Issue reference

The issue this PR will close: #615 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
