### PR TITLE
Fix for Terraform issue in which the tier 2 subscription parameter is ignored

### DIFF
--- a/src/terraform/mlz/main.tf
+++ b/src/terraform/mlz/main.tf
@@ -96,7 +96,7 @@ provider "azurerm" {
   alias           = "tier2"
   environment     = var.environment
   metadata_host   = var.metadata_host
-  subscription_id = coalesce(var.hub_subid, var.tier2_subid)
+  subscription_id = coalesce(var.tier2_subid, var.hub_subid)
 
   features {
     log_analytics_workspace {


### PR DESCRIPTION
# Description

Fixed a bug in which the `coalesce` statement to determine which subscription to deploy tier 2 into has the wrong parameter order.

## Issue reference

The issue this PR will close: #637 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [ ] ~~The documentation is updated to cover any new or changed features~~
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
