### PR TITLE
Add instructions for ASC/Defender cleanup

### DIFF
--- a/docs/deployment-guide-bicep.md
+++ b/docs/deployment-guide-bicep.md
@@ -396,10 +396,11 @@ az deployment sub show \
 
 ## Cleanup
 
-The Bicep/ARM deployment of Mission Landing Zone can be deleted with two steps:
+The Bicep/ARM deployment of Mission Landing Zone can be deleted with these steps:
 
 1. Delete all resource groups.
 1. Delete the diagnostic settings deployed at the subscription level.
+1. If Azure Security Center (ASC) was deployed (parameter `deployASC=true` was used) then remove subscription-level policy assignments and downgrade the ASC pricing tiers.
 
 > NOTE: If you deploy and delete Mission Landing Zone in the same subscription multiple times without deleting the subscription-level diagnostic settings, the sixth deployment will fail. Azure has a limit of five diagnostic settings per subscription. The error will be similar to this: `"The limit of 5 diagnostic settings was reached."`
 
@@ -414,6 +415,41 @@ az monitor diagnostic-settings subscription list --query value[] --output table
 # Delete a diagnostic setting
 az monitor diagnostic-settings subscription delete --name <diagnostic setting name>
 ```
+
+To delete the subscription-level policy assignments in the Azure portal:
+
+1. Navigate to the Policy page and select the Assignments tab in the left navigation bar.
+1. At the top, in the Scope box, choose the subscription(s) that contain the policy assignments you want to remove.
+1. In the table click the ellipsis menu ("...") and choose "Delete assignment".
+
+To delete the subscription-level policy assignments using the AZ CLI:
+
+```BASH
+# View the policy assignments for the current subscription
+az policy assignment list -o table --query "[].{Name:name, DisplayName:displayName, Scope:scope}"
+
+# Remove a policy assignment in the current subscription scope.
+az policy assignment delete --name "<name of policy assignment>"
+```
+
+To downgrade the ASC pricing level in the Azure portal:
+
+1. Navigate to the Microsoft Defender for Cloud page, then click the "Environment settings" tab in the left navigation panel.
+1. In the tree/grid select the subscription you want to manage.
+1. Click the large box near the top of the page that says "Enhanced security off".
+1. Click the save button.
+
+To downgrade the ASC pricing level using the AZ CLI:
+
+```BASH
+# List the pricing tiers
+az security pricing list -o table --query "value[].{Name:name, Tier:pricingTier}"
+
+# Change a pricing tier to the default free tier
+az security pricing create --name "<name of tier>" --tier Free
+```
+
+> NOTE: The Azure portal allows changing all pricing tiers with a single setting, but the AZ CLI requires each setting to be managed individually.
 
 ## Development Setup
 


### PR DESCRIPTION
# Description

Adds instructions for cleaning up Azure Security Center/Defender configuration applied when the `deployASC=true` parameter is used to deploy MLZ.

> NOTE: The guidance still refers to "Azure Security Center" in order to be consistent with other docs and code in the repo. Another backlog item will cover changing the name to Azure Defender for Cloud.

## Issue reference

The issue this PR will close: #570 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed (tested script examples in the markdown)
* [x] Relevant issues are linked to this PR
