### PR TITLE
Update GitHub connection for generating releases

### DIFF
--- a/.azure-devops/release/create-release.yml
+++ b/.azure-devops/release/create-release.yml
@@ -61,7 +61,7 @@ steps:
 - task: GitHubRelease@0
   displayName: 'Generate GitHub Release'
   inputs:
-    gitHubConnection: 'glennmusa'
+    gitHubConnection: 'missionlz-release'
     repositoryName: '$(Build.Repository.Name)'
     action: 'create'
     target: '$(Build.SourceVersion)'


### PR DESCRIPTION
# Description

The previous connection `Azure` uses an `InstallationToken`  authentication scheme that is incompatible with the GitHub Release ADO task.

This change uses a newly generated OAuth token specifically for MLZ Release uses.

## Issue reference

The issue this PR will close: #688

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
