### PR TITLE
Change examples to add-ons

### DIFF
--- a/.azure-devops/nightlybuild/templates/az-deployment.yml
+++ b/.azure-devops/nightlybuild/templates/az-deployment.yml
@@ -54,5 +54,5 @@ steps:
            --subscription ${{ parameters.WorkloadSubId }} \
            --location ${{ parameters.Location }} \
            --name ${{ parameters.WorkloadName }} \
-           --template-file $(Build.SourcesDirectory)/src/bicep/examples/tier3/tier3.bicep \
+           --template-file $(Build.SourcesDirectory)/src/bicep/add-ons/tier3/tier3.bicep \
            --parameters resourcePrefix=$datetime


### PR DESCRIPTION
# Description

Due to changes made in the restructure, a path was missed in the nightly build pipeline causing breakage.   This PR changes the directory from 'examples' to 'add-ons'

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [X] All acceptance criteria in the backlog item are met
* [X] The documentation is updated to cover any new or changed features
* [X] Manual tests have passed
