### PR TITLE
Fix deploymentVariables.json Nightly Build output location

### DIFF
--- a/.azure-devops/nightlybuild/templates/az-deployment.yml
+++ b/.azure-devops/nightlybuild/templates/az-deployment.yml
@@ -40,7 +40,7 @@ steps:
         az deployment sub show \
           --name ${{ parameters.DeploymentName }} \
           --query properties.outputs \
-          > $(Build.SourcesDirectory)/src/bicep/examples/deploymentVariables.json
+          > $(Build.SourcesDirectory)/src/bicep/add-ons/deploymentVariables.json
 
   - task: AzureCLI@2
     displayName: "T3 Bicep Deployment"


### PR DESCRIPTION
# Description

Post re-structure some directory changes were missed.  deploymentVariables.json was being written to the wrong location, this repairs the location to the add-ons/ folder so that the T3 nightly build can pick it up. 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [X] All acceptance criteria in the backlog item are met
* [X] The documentation is updated to cover any new or changed features
* [X] Manual tests have passed
