### PR TITLE
Remove Parentheses from tier count expression to enable single tier deployment. 

### DIFF
--- a/.azure-devops/nightlybuild/templates/az-deployment.yml
+++ b/.azure-devops/nightlybuild/templates/az-deployment.yml
@@ -40,7 +40,7 @@ steps:
         az deployment sub show \
           --name ${{ parameters.DeploymentName }} \
           --query properties.outputs \
-          > $(Build.SourcesDirectory)/src/bicep/examples/deploymentVariables.json
+          > $(Build.SourcesDirectory)/src/bicep/add-ons/deploymentVariables.json
 
   - task: AzureCLI@2
     displayName: "T3 Bicep Deployment"

--- a/src/terraform/mlz/main.tf
+++ b/src/terraform/mlz/main.tf
@@ -240,7 +240,7 @@ resource "azurerm_monitor_diagnostic_setting" "hub-central" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "tier0-central" {
-  count              = (var.tier0_subid != "") ? ((var.tier0_subid != var.hub_subid) ? 1 : 0) : 0
+  count              = (var.tier0_subid != "") ? (var.tier0_subid != var.hub_subid ? 1 : 0) : 0
   provider           = azurerm.tier0
   name               = "tier0-central-diagnostics"
   target_resource_id = "/subscriptions/${var.tier0_subid}"
@@ -262,7 +262,7 @@ resource "azurerm_monitor_diagnostic_setting" "tier0-central" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "tier1-central" {
-  count              = (var.tier1_subid != "") ? ((var.tier1_subid != var.hub_subid) ? 1 : 0) : 0
+  count              = (var.tier1_subid != "") ? (var.tier1_subid != var.hub_subid ? 1 : 0) : 0
   provider           = azurerm.tier1
   name               = "tier1-central-diagnostics"
   target_resource_id = "/subscriptions/${var.tier1_subid}"
@@ -284,7 +284,7 @@ resource "azurerm_monitor_diagnostic_setting" "tier1-central" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "tier2-central" {
-  count              = (var.tier2_subid != "") ? ((var.tier2_subid != var.hub_subid) ? 1 : 0) : 0
+  count              = (var.tier2_subid != "") ? (var.tier2_subid != var.hub_subid ? 1 : 0) : 0
   provider           = azurerm.tier2
   name               = "tier2-central-diagnostics"
   target_resource_id = "/subscriptions/${var.tier2_subid}"

--- a/src/terraform/tier3/main.tf
+++ b/src/terraform/tier3/main.tf
@@ -113,6 +113,7 @@ locals {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "tier3-central" {
+  count              = var.tier3_subid != var.hub_subid ? 1 : 0
   provider           = azurerm.tier3
   name               = "tier3-central-diagnostics"
   target_resource_id = "/subscriptions/${var.tier3_subid}"


### PR DESCRIPTION
# Description

There appears to be a problem with parentheses in count expressions, if they are present in a single expression they return the wrong evaluation in the expression.   This removes those parens so that the expression can process correctly. 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [X] All acceptance criteria in the backlog item are met
* [X] The documentation is updated to cover any new or changed features
* [X] Manual tests have passed
* [X] Relevant issues are linked to this PR
