### PR TITLE
Move AMPLS to Operations Tier

### DIFF
--- a/src/bicep/core/hub-network.bicep
+++ b/src/bicep/core/hub-network.bicep
@@ -9,7 +9,6 @@ param tags object = {}
 param logStorageAccountName string
 param logStorageSkuName string
 
-param logAnalyticsWorkspaceName string
 param logAnalyticsWorkspaceResourceId string
 
 param virtualNetworkName string
@@ -70,11 +69,6 @@ param firewallManagementPublicIPAddressAvailabilityZones array
 
 param publicIPAddressDiagnosticsLogs array
 param publicIPAddressDiagnosticsMetrics array
-
-param supportedClouds array = [
-  'AzureCloud'
-  'AzureUSGovernment'
-]
 
 module logStorage '../modules/storage-account.bicep' = {
   name: 'logStorage'
@@ -236,21 +230,6 @@ module firewall '../modules/firewall.bicep' = {
     logs: firewallDiagnosticsLogs
     metrics: firewallDiagnosticsMetrics
   }
-}
-
-module azureMonitorPrivateLink '../modules/private-link.bicep' = if ( contains(supportedClouds, environment().name) ){
-  name: 'azure-monitor-private-link'
-  params: {
-    logAnalyticsWorkspaceName: logAnalyticsWorkspaceName
-    logAnalyticsWorkspaceResourceId: logAnalyticsWorkspaceResourceId
-    privateEndpointSubnetName: subnetName
-    privateEndpointVnetName: virtualNetwork.outputs.name
-    location: location
-    tags: tags
-  }
-  dependsOn: [
-    subnet
-  ]
 }
 
 output virtualNetworkName string = virtualNetwork.outputs.name

--- a/src/bicep/core/spoke-network.bicep
+++ b/src/bicep/core/spoke-network.bicep
@@ -34,6 +34,8 @@ param routeTableRouteAddressPrefix string = '0.0.0.0/0'
 param routeTableRouteNextHopIpAddress string = firewallPrivateIPAddress
 param routeTableRouteNextHopType string = 'VirtualAppliance'
 
+param subnetPrivateEndpointNetworkPolicies string
+
 module logStorage '../modules/storage-account.bicep' = {
   name: 'logStorage'
   params: {
@@ -95,7 +97,8 @@ module virtualNetwork '../modules/virtual-network.bicep' = {
           routeTable: {
             id: routeTable.outputs.id
           }
-          serviceEndpoints: subnetServiceEndpoints
+          serviceEndpoints: subnetServiceEndpoints            
+          privateEndpointNetworkPolicies: subnetPrivateEndpointNetworkPolicies
         }
       }
     ]

--- a/src/bicep/modules/private-dns.bicep
+++ b/src/bicep/modules/private-dns.bicep
@@ -1,0 +1,132 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT License.
+*/
+
+@description('The name of the virtual network the private dns zones will be connected to')
+param vnetName string
+
+@description('The name of the the resource group where the virtual network exists')
+param vnetResourceGroup string = resourceGroup().name
+
+@description('The subscription id of the subscription the virtual network exists in')
+param vnetSubscriptionId string = subscription().subscriptionId
+
+@description('The tags that will be associated to the resources')
+param tags object
+
+var privateDnsZones_privatelink_monitor_azure_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.monitor.azure.com' : 'privatelink.monitor.azure.us' ) 
+var privateDnsZones_privatelink_ods_opinsights_azure_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.ods.opinsights.azure.com' : 'privatelink.ods.opinsights.azure.us' )
+var privateDnsZones_privatelink_oms_opinsights_azure_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.oms.opinsights.azure.com' : 'privatelink.oms.opinsights.azure.us' )
+var privateDnsZones_privatelink_blob_core_cloudapi_net_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.blob.${environment().suffixes.storage}' : 'privatelink.blob.core.usgovcloudapi.net' )
+var privateDnsZones_privatelink_agentsvc_azure_automation_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.agentsvc.azure-automation.net' : 'privatelink.agentsvc.azure-automation.us' )
+
+resource privatelink_monitor_azure_com 'Microsoft.Network/privateDnsZones@2018-09-01' = {
+  name: privateDnsZones_privatelink_monitor_azure_name
+  location: 'global'
+  tags: tags
+}
+
+resource privatelink_oms_opinsights_azure_com 'Microsoft.Network/privateDnsZones@2018-09-01' = {
+  name: privateDnsZones_privatelink_oms_opinsights_azure_name
+  location: 'global'
+  tags: tags
+}
+
+resource privatelink_ods_opinsights_azure_com 'Microsoft.Network/privateDnsZones@2018-09-01' = {
+  name: privateDnsZones_privatelink_ods_opinsights_azure_name
+  location: 'global'
+  tags: tags
+}
+
+resource privatelink_agentsvc_azure_automation_net 'Microsoft.Network/privateDnsZones@2018-09-01' = {
+  name: privateDnsZones_privatelink_agentsvc_azure_automation_name
+  location: 'global'
+  tags: tags
+}
+
+resource privatelink_blob_core_cloudapi_net 'Microsoft.Network/privateDnsZones@2018-09-01' = {
+  name: privateDnsZones_privatelink_blob_core_cloudapi_net_name
+  location: 'global'
+  tags: tags
+}
+
+resource privatelink_monitor_azure_com_privatelink_monitor_azure_com_link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
+  name: '${privateDnsZones_privatelink_monitor_azure_name}/${privateDnsZones_privatelink_monitor_azure_name}-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: resourceId(vnetSubscriptionId, vnetResourceGroup, 'Microsoft.Network/virtualNetworks', vnetName )
+    }
+  }
+  dependsOn: [
+    privatelink_monitor_azure_com
+  ]
+}
+
+resource privatelink_oms_opinsights_azure_com_privatelink_oms_opinsights_azure_com_link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
+  name: '${privateDnsZones_privatelink_oms_opinsights_azure_name}/${privateDnsZones_privatelink_oms_opinsights_azure_name}-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: resourceId(vnetSubscriptionId, vnetResourceGroup, 'Microsoft.Network/virtualNetworks', vnetName )
+    }
+  }
+  dependsOn: [
+    privatelink_oms_opinsights_azure_com
+    privatelink_monitor_azure_com_privatelink_monitor_azure_com_link
+  ]
+}
+
+resource privatelink_ods_opinsights_azure_com_privatelink_ods_opinsights_azure_com_link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
+  name: '${privateDnsZones_privatelink_ods_opinsights_azure_name}/${privateDnsZones_privatelink_ods_opinsights_azure_name}-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: resourceId(vnetSubscriptionId, vnetResourceGroup, 'Microsoft.Network/virtualNetworks', vnetName )
+    }
+  }
+  dependsOn: [
+    privatelink_ods_opinsights_azure_com
+    privatelink_oms_opinsights_azure_com_privatelink_oms_opinsights_azure_com_link
+  ]
+}
+
+resource privatelink_agentsvc_azure_automation_net_privatelink_agentsvc_azure_automation_net_link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
+  name: '${privateDnsZones_privatelink_agentsvc_azure_automation_name}/${privateDnsZones_privatelink_agentsvc_azure_automation_name}-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: resourceId(vnetSubscriptionId, vnetResourceGroup, 'Microsoft.Network/virtualNetworks', vnetName )
+    }
+  }
+  dependsOn: [
+    privatelink_agentsvc_azure_automation_net
+    privatelink_ods_opinsights_azure_com_privatelink_ods_opinsights_azure_com_link
+  ]
+}
+
+resource privateDnsZones_privatelink_blob_core_cloudapi_net_privateDnsZones_privatelink_blob_core_cloudapi_net_link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
+  name: '${privateDnsZones_privatelink_blob_core_cloudapi_net_name}/${privateDnsZones_privatelink_blob_core_cloudapi_net_name}-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: resourceId(vnetSubscriptionId, vnetResourceGroup, 'Microsoft.Network/virtualNetworks', vnetName )
+    }
+  }
+  dependsOn: [
+    privatelink_blob_core_cloudapi_net
+    privatelink_agentsvc_azure_automation_net_privatelink_agentsvc_azure_automation_net_link
+  ]
+}
+
+output monitorPrivateDnsZoneId string = privatelink_monitor_azure_com.id
+output omsPrivateDnsZoneId string = privatelink_oms_opinsights_azure_com.id
+output odsPrivateDnsZoneId string = privatelink_ods_opinsights_azure_com.id
+output agentsvcPrivateDnsZoneId string = privatelink_agentsvc_azure_automation_net.id
+output storagePrivateDnsZoneId string = privatelink_blob_core_cloudapi_net.id

--- a/src/bicep/modules/private-link.bicep
+++ b/src/bicep/modules/private-link.bicep
@@ -30,6 +30,21 @@ param vnetSubscriptionId string = subscription().subscriptionId
 @description('The location of this resource')
 param location string = resourceGroup().location
 
+@description('Azure Monitor Private DNS Zone resource id')
+param monitorPrivateDnsZoneId string
+
+@description('OMS Private DNS Zone resource id')
+param omsPrivateDnsZoneId string
+
+@description('ODS Private DNS Zone resource id')
+param odsPrivateDnsZoneId string
+
+@description('Agentsvc Private DNS Zone resource id')
+param agentsvcPrivateDnsZoneId string
+
+@description('Azure Blob Storage Private DNS Zone resource id')
+param storagePrivateDnsZoneId string
+
 var privateLinkConnectionName  = take('plconn${logAnalyticsWorkspaceName}${uniqueData}', 80)
 var privateLinkEndpointName = take('pl${logAnalyticsWorkspaceName}${uniqueData}', 80)
 var privateLinkScopeName = take('plscope${logAnalyticsWorkspaceName}${uniqueData}', 80)
@@ -83,140 +98,36 @@ resource dnsZonePrivateLinkEndpoint 'Microsoft.Network/privateEndpoints/privateD
       {
         name: 'monitor'
         properties: {
-          privateDnsZoneId: privatelink_monitor_azure_com.id
+          privateDnsZoneId: monitorPrivateDnsZoneId
         }
       }
       {
         name: 'oms'
         properties: {
-          privateDnsZoneId: privatelink_oms_opinsights_azure_com.id
+          privateDnsZoneId: omsPrivateDnsZoneId
         }
       }
       {
         name: 'ods'
         properties: {
-          privateDnsZoneId: privatelink_ods_opinsights_azure_com.id
+          privateDnsZoneId: odsPrivateDnsZoneId
         }
       }
       {
         name: 'agentsvc'
         properties: {
-          privateDnsZoneId: privatelink_agentsvc_azure_automation_net.id
+          privateDnsZoneId: agentsvcPrivateDnsZoneId
         }
       }
       {
         name: 'storage'
         properties: {
-          privateDnsZoneId: privatelink_blob_core_cloudapi_net.id
+          privateDnsZoneId: storagePrivateDnsZoneId
         }
       }
     ]
   }
   dependsOn: [
     subnetPrivateEndpoint 
-  ]
-}
-var privateDnsZones_privatelink_monitor_azure_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.monitor.azure.com' : 'privatelink.monitor.azure.us' ) 
-var privateDnsZones_privatelink_ods_opinsights_azure_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.ods.opinsights.azure.com' : 'privatelink.ods.opinsights.azure.us' )
-var privateDnsZones_privatelink_oms_opinsights_azure_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.oms.opinsights.azure.com' : 'privatelink.oms.opinsights.azure.us' )
-var privateDnsZones_privatelink_blob_core_cloudapi_net_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.blob.${environment().suffixes.storage}' : 'privatelink.blob.core.usgovcloudapi.net' )
-var privateDnsZones_privatelink_agentsvc_azure_automation_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.agentsvc.azure-automation.net' : 'privatelink.agentsvc.azure-automation.us' )
-
-resource privatelink_monitor_azure_com 'Microsoft.Network/privateDnsZones@2018-09-01' = {
-  name: privateDnsZones_privatelink_monitor_azure_name
-  location: 'global'
-}
-
-resource privatelink_oms_opinsights_azure_com 'Microsoft.Network/privateDnsZones@2018-09-01' = {
-  name: privateDnsZones_privatelink_oms_opinsights_azure_name
-  location: 'global'
-}
-
-resource privatelink_ods_opinsights_azure_com 'Microsoft.Network/privateDnsZones@2018-09-01' = {
-  name: privateDnsZones_privatelink_ods_opinsights_azure_name
-  location: 'global'
-}
-
-resource privatelink_agentsvc_azure_automation_net 'Microsoft.Network/privateDnsZones@2018-09-01' = {
-  name: privateDnsZones_privatelink_agentsvc_azure_automation_name
-  location: 'global'
-}
-
-resource privatelink_blob_core_cloudapi_net 'Microsoft.Network/privateDnsZones@2018-09-01' = {
-  name: privateDnsZones_privatelink_blob_core_cloudapi_net_name
-  location: 'global'
-}
-
-resource privatelink_monitor_azure_com_privatelink_monitor_azure_com_link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
-  name: '${privateDnsZones_privatelink_monitor_azure_name}/${privateDnsZones_privatelink_monitor_azure_name}-link'
-  location: 'global'
-  properties: {
-    registrationEnabled: false
-    virtualNetwork: {
-      id: resourceId(vnetSubscriptionId, vnetResourceGroup, 'Microsoft.Network/virtualNetworks', privateEndpointVnetName )
-    }
-  }
-  dependsOn: [
-    privatelink_monitor_azure_com
-  ]
-}
-
-resource privatelink_oms_opinsights_azure_com_privatelink_oms_opinsights_azure_com_link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
-  name: '${privateDnsZones_privatelink_oms_opinsights_azure_name}/${privateDnsZones_privatelink_oms_opinsights_azure_name}-link'
-  location: 'global'
-  properties: {
-    registrationEnabled: false
-    virtualNetwork: {
-      id: resourceId(vnetSubscriptionId, vnetResourceGroup, 'Microsoft.Network/virtualNetworks', privateEndpointVnetName )
-    }
-  }
-  dependsOn: [
-    privatelink_oms_opinsights_azure_com
-    privatelink_monitor_azure_com_privatelink_monitor_azure_com_link
-  ]
-}
-
-resource privatelink_ods_opinsights_azure_com_privatelink_ods_opinsights_azure_com_link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
-  name: '${privateDnsZones_privatelink_ods_opinsights_azure_name}/${privateDnsZones_privatelink_ods_opinsights_azure_name}-link'
-  location: 'global'
-  properties: {
-    registrationEnabled: false
-    virtualNetwork: {
-      id: resourceId(vnetSubscriptionId, vnetResourceGroup, 'Microsoft.Network/virtualNetworks', privateEndpointVnetName )
-    }
-  }
-  dependsOn: [
-    privatelink_ods_opinsights_azure_com
-    privatelink_oms_opinsights_azure_com_privatelink_oms_opinsights_azure_com_link
-  ]
-}
-
-resource privatelink_agentsvc_azure_automation_net_privatelink_agentsvc_azure_automation_net_link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
-  name: '${privateDnsZones_privatelink_agentsvc_azure_automation_name}/${privateDnsZones_privatelink_agentsvc_azure_automation_name}-link'
-  location: 'global'
-  properties: {
-    registrationEnabled: false
-    virtualNetwork: {
-      id: resourceId(vnetSubscriptionId, vnetResourceGroup, 'Microsoft.Network/virtualNetworks', privateEndpointVnetName )
-    }
-  }
-  dependsOn: [
-    privatelink_agentsvc_azure_automation_net
-    privatelink_ods_opinsights_azure_com_privatelink_ods_opinsights_azure_com_link
-  ]
-}
-
-resource privateDnsZones_privatelink_blob_core_cloudapi_net_privateDnsZones_privatelink_blob_core_cloudapi_net_link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
-  name: '${privateDnsZones_privatelink_blob_core_cloudapi_net_name}/${privateDnsZones_privatelink_blob_core_cloudapi_net_name}-link'
-  location: 'global'
-  properties: {
-    registrationEnabled: false
-    virtualNetwork: {
-      id: resourceId(vnetSubscriptionId, vnetResourceGroup, 'Microsoft.Network/virtualNetworks', privateEndpointVnetName )
-    }
-  }
-  dependsOn: [
-    privatelink_blob_core_cloudapi_net
-    privatelink_agentsvc_azure_automation_net_privatelink_agentsvc_azure_automation_net_link
   ]
 }


### PR DESCRIPTION
# Description

Moved the AMPLS and its Private Endpoint to the Operations tier, so that it sits together with the Log Analytics Workspace. This includes the following changes:

1. Moved the Private DNS zones creation out of the private-link module and into its own module, so that the zones still get created in the Hub.
2. Added a parameter for the VNET Subnet `PrivateEndpointNetworkPolicies` setting in the spoke module, so that the Operations VNET subnet get created with that setting disabled.
3. Moved the Private DNS zones and the AMPLS creation out of the hub module and into the main template, so that they can be deployed to different tiers.

## Issue reference

The issue this PR will close: #738

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [X] All acceptance criteria in the backlog item are met
* [X] The documentation is updated to cover any new or changed features
* [X] Manual tests have passed
* [X] Relevant issues are linked to this PR
