### PR TITLE
Generate uniqueData for Private Link resources in an idempotent manner

### DIFF
--- a/src/bicep/modules/private-link.bicep
+++ b/src/bicep/modules/private-link.bicep
@@ -4,10 +4,10 @@ Licensed under the MIT License.
 */
 
 @description('The name of the resource the private endpoint is being created for')
-param logAnalyticsWorkspaceName  string
+param logAnalyticsWorkspaceName string
 
 @description('The resource id of the resoure the private endpoint is being created for')
-param logAnalyticsWorkspaceResourceId  string
+param logAnalyticsWorkspaceResourceId string
 
 @description('The name of the subnet in the virtual network where the private endpoint will be placed')
 param privateEndpointSubnetName string
@@ -19,7 +19,7 @@ param privateEndpointVnetName string
 param tags object
 
 @description('Data used to append to resources to ensure uniqueness')
-param uniqueData string = substring(newGuid(), 0, 8)
+param uniqueData string = substring(uniqueString(subscription().subscriptionId, deployment().name), 0, 8)
 
 @description('The name of the the resource group where the virtual network exists')
 param vnetResourceGroup string = resourceGroup().name
@@ -45,7 +45,7 @@ param agentsvcPrivateDnsZoneId string
 @description('Azure Blob Storage Private DNS Zone resource id')
 param storagePrivateDnsZoneId string
 
-var privateLinkConnectionName  = take('plconn${logAnalyticsWorkspaceName}${uniqueData}', 80)
+var privateLinkConnectionName = take('plconn${logAnalyticsWorkspaceName}${uniqueData}', 80)
 var privateLinkEndpointName = take('pl${logAnalyticsWorkspaceName}${uniqueData}', 80)
 var privateLinkScopeName = take('plscope${logAnalyticsWorkspaceName}${uniqueData}', 80)
 var privateLinkScopeResourceName = take('plscres${logAnalyticsWorkspaceName}${uniqueData}', 80)
@@ -56,17 +56,17 @@ resource globalPrivateLinkScope 'microsoft.insights/privateLinkScopes@2019-10-17
   properties: {}
 }
 
-resource logAnalyticsWorkspacePrivateLinkScope  'microsoft.insights/privateLinkScopes/scopedResources@2019-10-17-preview' = {
+resource logAnalyticsWorkspacePrivateLinkScope 'microsoft.insights/privateLinkScopes/scopedResources@2019-10-17-preview' = {
   name: '${privateLinkScopeName}/${privateLinkScopeResourceName}'
   properties: {
     linkedResourceId: logAnalyticsWorkspaceResourceId
   }
   dependsOn: [
-    globalPrivateLinkScope 
+    globalPrivateLinkScope
   ]
 }
 
-resource subnetPrivateEndpoint  'Microsoft.Network/privateEndpoints@2020-07-01' = {
+resource subnetPrivateEndpoint 'Microsoft.Network/privateEndpoints@2020-07-01' = {
   name: privateLinkEndpointName
   location: location
   tags: tags
@@ -76,7 +76,7 @@ resource subnetPrivateEndpoint  'Microsoft.Network/privateEndpoints@2020-07-01' 
     }
     privateLinkServiceConnections: [
       {
-        name: privateLinkConnectionName 
+        name: privateLinkConnectionName
         properties: {
           privateLinkServiceId: globalPrivateLinkScope.id
           groupIds: [
@@ -87,7 +87,7 @@ resource subnetPrivateEndpoint  'Microsoft.Network/privateEndpoints@2020-07-01' 
     ]
   }
   dependsOn: [
-    logAnalyticsWorkspacePrivateLinkScope 
+    logAnalyticsWorkspacePrivateLinkScope
   ]
 }
 
@@ -128,6 +128,6 @@ resource dnsZonePrivateLinkEndpoint 'Microsoft.Network/privateEndpoints/privateD
     ]
   }
   dependsOn: [
-    subnetPrivateEndpoint 
+    subnetPrivateEndpoint
   ]
 }


### PR DESCRIPTION
# Description

The current method for generating `uniqueData` for use in naming resources prevents idempotent deployment because an attempt to create a new AMPLS resource results in a conflict with the previous one. This additionally leads to multiple private endpoints getting created, which could eventually exhaust IP space in the subnet over time if deployed enough times.

I propose that if this is generated using the `uniqueString` Bicep function instead, the random string will be generated in a repeatable manner, provided future deployments are both to the same subscription, and with the same deployment name. Manual testing in an Azure Gov subscription seems good as far as I can tell.

Relevant change is to L22. The remainder are corrections to whitespace by the Bicep plugin in VS Code.

## Issue reference

The issue this PR will close: #700

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [ ] All acceptance criteria in the backlog item are met
* [ ] The documentation is updated to cover any new or changed features
* [ ] Manual tests have passed
* [ ] Relevant issues are linked to this PR
