### PR TITLE
Fix IaaS DNS forwarders deployment with default extensions uri + more documentation

### DIFF
--- a/src/bicep/examples/iaas-dns-forwarders/README.md
+++ b/src/bicep/examples/iaas-dns-forwarders/README.md
@@ -23,7 +23,13 @@ The two Windows DNS Servers are configured to act as DNS servers for all Virtual
 1. A Mission LZ deployment (a deployment of mlz.bicep)
 2. The outputs from a deployment of mlz.bicep (./src/bicep/examples/deploymentVariables.json).  
 
-See below for information on how to create the appropriate deployment variables file for use with this template.
+### Generate MLZ Variable File (deploymentVariables.json)
+
+For instructions on generating 'deploymentVariables.json' using both Azure PowerShell and Azure CLI, please see the [README at the root of the examples folder](..\README.md).
+
+Place the resulting 'deploymentVariables.json' file within the ./src/bicep/examples folder.
+
+## Deployment
 
 ### Template Parameters
 
@@ -37,12 +43,6 @@ extensionsFilesContainerSas    | storage account account SAS token used to host 
 dnsServerForwardersIpAddresses | default DNS server forwarders (for instance: DISA's). Defaults to Azure DNS.
 conditionalDnsServerForwarders | array of conditional forwarders to create, including Azure Private DNS zones and Active Directory-related zones. Defaults to Azure US Government's private endpoint DNS zones.
 
-### Generate MLZ Variable File (deploymentVariables.json)
-
-For instructions on generating 'deploymentVariables.json' using both Azure PowerShell and Azure CLI, please see the [README at the root of the examples folder](..\README.md).
-
-Place the resulting 'deploymentVariables.json' file within the ./src/bicep/examples folder.
-
 ### Deploying IaaS DNS Forwarders
 
 Connect to the appropriate Azure Environment and set appropriate context, see getting started with Azure PowerShell for help if needed.  The commands below assume you are deploying in Azure Government and show the entire process from deploying MLZ and then adding DNS forwarders post-deployment.
@@ -54,17 +54,61 @@ New-AzSubscriptionDeployment -Name contoso -TemplateFile .\mlz.bicep -resourcePr
 cd .\examples
 (Get-AzSubscriptionDeployment -Name contoso).outputs | ConvertTo-Json | Out-File -FilePath .\deploymentVariables.json
 cd .\keyVault
+$vmAdminPassword = Read-Host -Prompt "Please provide a password for the VMs local administrator account, with a length of at least 12 characters" -AsSecureString
 New-AzResourceGroupDeployment -DeploymentName IaaSDNSForwarders `
                               -TemplateFile .\forwarderVm.bicep
                               -ResourceGroupName 'contoso-rg-hub-mlz'
                               -vmNamePrefix 'contoso-dnsfwd'
+                              -vmAdminPassword $vmAdminPassword
                               -nicPrivateIPAddresses "10.9.0.4", "10.9.0.5"
                               -dnsServerForwardersIpAddresses "2.2.2.2"                 
 ```
 
+### conditionalDnsServerForwarders parameter
+
+The `conditionalDnsServerForwarders` parameter defaults to the [Azure US Government Private Endpoint DNS zones](https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-dns#government) listed in the [forwarderVm.bicep template](forwarderVm.bicep).
+
+If you are using another cloud, wish to use a subsets of the [Private Endpoint DNS zones](https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-dns) and/or add conditional forwarders for your own internal ActiveDirectory DNS domains, you will need to provide this parameter.
+
+The example below specifies conditionalDnsServerForwarders for the Azure Storage Blob and Azure Key Vault services only, in the Azure Public Cloud, as well as a conditional DNS forwarder for an internal Active Directory zone (as depicted in the example diagram).
+
+```PowerShell
+$conditionalDnsServerForwarders = "[
+{   
+    'Name': 'privatelink.vaultcore.azure.net',
+    'Forwarders': ['168.63.129.16']
+},
+{   
+    'Name': 'privatelink.blob.core.windows.net',
+    'Forwarders': ['168.63.129.16']
+},
+{   
+    'Name': 'contoso.pri',
+    'Forwarders': ['10.9.1.4','10.9.1.5']
+}]" | ConvertFrom-JSON
+New-AzResourceGroupDeployment -DeploymentName IaaSDNSForwarders `
+                              -TemplateFile .\forwarderVm.bicep
+                              -ResourceGroupName 'contoso-rg-hub-mlz'
+                              -vmNamePrefix 'contoso-dnsfwd'
+                              -vmAdminPassword $vmAdminPassword
+                              -nicPrivateIPAddresses "10.9.0.4", "10.9.0.5"
+                              -dnsServerForwardersIpAddresses "2.2.2.2" 
+                              -conditionalDnsServerForwarders $conditionalDnsServerForwarders               
+```
+
+### How does it work
+
+The [forwarderVm.bicep template](forwarderVm.bicep) goes through the following steps to deploy the solution:
+
+1. Deploy Availability Set.
+2. Deploy Network Interfaces.
+3. Deploys Virtual Machines (using the [MLZ VM Module](https://github.com/FabienGilbert/mlz/blob/main/src/bicep/modules/windows-virtual-machine.bicep)).
+4. Deploys the PowerShell DSC VM Extension, to install the Windows DNS Server feature and configure the default server forwarders (provided in the `dnsServerForwardersIpAddresses` parameter).
+5. Deploy the Custom Script VM Extension, to create the Conditional DNS Forwarders (provided in the `conditionalDnsServerForwarders` parameter).
+
 ### Setting all Virtual Networks to use the Forwarders as DNS servers
 
-The PowerShell script below configures the (existing) Virtual Networks to use the DNS Forwarders as DNS servers.
+Once the DNS Forwarders are deployed, you will want to set all of your Virtual Networks to use the forwarders as DNS servers. The PowerShell script below configures all of the existing Virtual Networks to use the DNS Forwarders as DNS servers.
 
 ```PowerShell
 $dnsForwarders = "10.9.0.4", "10.9.0.5"

--- a/src/bicep/examples/iaas-dns-forwarders/forwarderVm.bicep
+++ b/src/bicep/examples/iaas-dns-forwarders/forwarderVm.bicep
@@ -48,8 +48,8 @@ param vmStorageAccountType string = 'StandardSSD_LRS'
   'Static'
   'Dynamic'
 ])
-@description('[Static/Dynamic] The private IP Address allocation method for the Virtual Machine. It defaults to "Dynamic".')
-param nicPrivateIPAddressAllocationMethod string = 'Dynamic'
+@description('[Static/Dynamic] The private IP Address allocation method for the Virtual Machine. It defaults to "Static".')
+param nicPrivateIPAddressAllocationMethod string = 'Static'
 
 @description('Array of static private IP addresses for the VM Network Interface Cards')
 param nicPrivateIPAddresses array = []
@@ -200,7 +200,7 @@ param conditionalDnsServerForwarders array = [
 
 var vmAvSetName = '${vmNamePrefix}-avset-01'
 var NetworkInterfaceIpConfigurationName = 'ipConfiguration1'
-var sasToken = ((extensionsFilesContainerSas != '') ? '?${extensionsFilesContainerSas}' : null)
+var sasToken = ((extensionsFilesContainerSas != '') ? '?${extensionsFilesContainerSas}' : '')
 
 resource vmAvSet 'Microsoft.Compute/availabilitySets@2022-03-01' = {
   name: vmAvSetName


### PR DESCRIPTION
# Description

Fixed deployment with `extensionsFilesContainerUri` defaulting to public Repo and added more documentation

## Issue reference

The issue this PR will close: #752 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [X] All acceptance criteria in the backlog item are met
* [X] The documentation is updated to cover any new or changed features
* [X] Manual tests have passed
* [X] Relevant issues are linked to this PR
