### PR TITLE
Fixing Bicep deploy-time warnings

### DIFF
--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -277,28 +277,28 @@ param operationsVirtualNetworkDiagnosticsMetrics array = []
 @description('An array of Network Security Group rules to apply to the Operations Virtual Network. See https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networksecuritygroups/securityrules?tabs=bicep#securityrulepropertiesformat for valid settings.')
 param operationsNetworkSecurityGroupRules array = [
   {
-  name: 'Allow-Traffic-From-Spokes'
-  properties: {
-    access: 'Allow'
-    description: 'Allow traffic from spokes'
-    destinationAddressPrefix: operationsVirtualNetworkAddressPrefix
-    destinationPortRanges: [
-      '22'
-      '80'
-      '443'
-      '3389'
-    ]
-    direction: 'Inbound'
-    priority: 200
-    protocol: '*'
-    sourceAddressPrefixes: [
-      identityVirtualNetworkAddressPrefix
-      sharedServicesVirtualNetworkAddressPrefix
-    ]
-    sourcePortRange: '*'
+    name: 'Allow-Traffic-From-Spokes'
+    properties: {
+      access: 'Allow'
+      description: 'Allow traffic from spokes'
+      destinationAddressPrefix: operationsVirtualNetworkAddressPrefix
+      destinationPortRanges: [
+        '22'
+        '80'
+        '443'
+        '3389'
+      ]
+      direction: 'Inbound'
+      priority: 200
+      protocol: '*'
+      sourceAddressPrefixes: [
+        identityVirtualNetworkAddressPrefix
+        sharedServicesVirtualNetworkAddressPrefix
+      ]
+      sourcePortRange: '*'
+    }
+    type: 'string'
   }
-  type: 'string'
-}
 ]
 
 @description('An array of Network Security Group diagnostic logs to apply to the Operations Virtual Network. See https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-nsg-manage-log#log-categories for valid settings.')
@@ -711,9 +711,9 @@ var spokes = [
 // TAGS
 
 var defaultTags = {
-  'resourcePrefix': resourcePrefix
-  'resourceSuffix': resourceSuffix
-  'DeploymentType': 'MissionLandingZoneARM'
+  resourcePrefix: resourcePrefix
+  resourceSuffix: resourceSuffix
+  DeploymentType: 'MissionLandingZoneARM'
 }
 
 var calculatedTags = union(tags, defaultTags)
@@ -937,7 +937,7 @@ module hubSubscriptionActivityLogging './modules/central-logging.bicep' = {
   ]
 }
 
-module azureMonitorPrivateLink './modules/private-link.bicep' = if ( contains(supportedClouds, environment().name) ){
+module azureMonitorPrivateLink './modules/private-link.bicep' = if (contains(supportedClouds, environment().name)) {
   name: 'azure-monitor-private-link'
   scope: resourceGroup(operationsSubscriptionId, operationsResourceGroupName)
   params: {

--- a/src/bicep/modules/defender.bicep
+++ b/src/bicep/modules/defender.bicep
@@ -5,32 +5,32 @@ Licensed under the MIT License.
 
 targetScope = 'subscription'
 
-param bundle array = (environment().name == 'AzureCloud') ? [  
-	'AppServices'
-	'Arm'
-	'ContainerRegistry'
-	'Containers'
-	'CosmosDbs'
-	'Dns'
-	'KeyVaults'
-	'KubernetesService'
-	'OpenSourceRelationalDatabases'
-	'SqlServers'
-	'SqlServerVirtualMachines'
-	'StorageAccounts'
-	'VirtualMachines'
-  ] : (environment().name == 'AzureUSGovernment') ? [
-	'Arm'
-	'ContainerRegistry'
-	'Containers'
-	'Dns'
-	'KubernetesService'
-	'OpenSourceRelationalDatabases'
-	'SqlServers'
-	'SqlServerVirtualMachines'
-	'StorageAccounts'
-	'VirtualMachines'
-  ] : []
+param bundle array = (environment().name == 'AzureCloud') ? [
+  'AppServices'
+  'Arm'
+  'ContainerRegistry'
+  'Containers'
+  'CosmosDbs'
+  'Dns'
+  'KeyVaults'
+  'KubernetesService'
+  'OpenSourceRelationalDatabases'
+  'SqlServers'
+  'SqlServerVirtualMachines'
+  'StorageAccounts'
+  'VirtualMachines'
+] : (environment().name == 'AzureUSGovernment') ? [
+  'Arm'
+  'ContainerRegistry'
+  'Containers'
+  'Dns'
+  'KubernetesService'
+  'OpenSourceRelationalDatabases'
+  'SqlServers'
+  'SqlServerVirtualMachines'
+  'StorageAccounts'
+  'VirtualMachines'
+] : []
 
 @description('Turn automatic deployment by Defender of the MMA (OMS VM extension) on or off')
 param enableAutoProvisioning bool = true
@@ -44,7 +44,6 @@ param emailSecurityContact string
 
 @description('Policy Initiative description field')
 param policySetDescription string = 'The Azure Security Benchmark initiative represents the policies and controls implementing security recommendations defined in Azure Security Benchmark v2, see https://aka.ms/azsecbm. This also serves as the Microsoft Defender for Cloud default policy initiative. You can directly assign this initiative, or manage its policies and compliance results within Microsoft Defender.'
-
 
 // defender
 
@@ -64,7 +63,7 @@ resource autoProvision 'Microsoft.Security/autoProvisioningSettings@2017-08-01-p
   }
 }
 
-resource securityWorkspaceSettings  'Microsoft.Security/workspaceSettings@2017-08-01-preview' = {
+resource securityWorkspaceSettings 'Microsoft.Security/workspaceSettings@2017-08-01-preview' = {
   name: 'default'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
@@ -89,6 +88,6 @@ resource securityPoliciesDefault 'Microsoft.Authorization/policyAssignments@2020
     description: policySetDescription
     enforcementMode: 'DoNotEnforce'
     parameters: {}
-    policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8'
+    policyDefinitionId: tenantResourceId('Microsoft.Authorization/policySetDefinitions', '1f3afdf9-d0c9-4c3d-847f-89da613e70a8')
   }
 }

--- a/src/bicep/modules/log-analytics-diagnostic-logging.bicep
+++ b/src/bicep/modules/log-analytics-diagnostic-logging.bicep
@@ -11,7 +11,6 @@ param supportedClouds array = [
   'AzureUSGovernment'
 ]
 
-
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
   name: logAnalyticsWorkspaceName
 }
@@ -20,15 +19,9 @@ resource stg 'Microsoft.Storage/storageAccounts@2021-02-01' existing = {
   name: diagnosticStorageAccountName
 }
 
-resource securityContacts 'Microsoft.Security/securityContacts@2017-08-01-preview' existing = {
-  name: 'securityNotifications'
-  scope: subscription()
-}
-
-
 //// Setting log analytics to collect its own diagnostics to itself and to storage
-resource logAnalyticsDiagnostics 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = if ( contains(supportedClouds, environment().name)) {
-  name: 'enable-log-analytics-diagnostics'  
+resource logAnalyticsDiagnostics 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = if (contains(supportedClouds, environment().name)) {
+  name: 'enable-log-analytics-diagnostics'
   scope: logAnalyticsWorkspace
   properties: {
     workspaceId: logAnalyticsWorkspace.id


### PR DESCRIPTION
# Description

Syntax changes to address deploy-time warnings.

`use-resource-id-functions` - fixed by referencing the built-in policy defs using tenantResourceId() as described here: https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions-resource#tenantresourceid

`prefer-unquoted-property-names` - removed single quotes from keys in the `defaultTags` variable in `mlz.bicep`

`no-unused-existing-resources` - fixed by removing unused `securityContacts` resource from `log-analytics-diagnostic-logging.bicep`

`use-stable-resource-identifiers` - This warning was fixed as a result of prior work done in PR #748

Remaining changes are VSCode formatting artifacts, which I can revert if necessary/desired.

## Issue reference

The issue this PR will close: #743

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
