### PR TITLE
DfC #653 Fixed. Added Infrastructure Encryption on Storage. Added Private Link Service Network Policies

### DIFF
--- a/src/bicep/add-ons/tier3/tier3.bicep
+++ b/src/bicep/add-ons/tier3/tier3.bicep
@@ -176,6 +176,7 @@ module spokeNetwork '../../core/spoke-network.bicep' = {
     subnetAddressPrefix: subnetAddressPrefix
     subnetServiceEndpoints: subnetServiceEndpoints
     subnetPrivateEndpointNetworkPolicies: 'Enabled'
+    subnetPrivateLinkServiceNetworkPolicies: 'Enabled'
   }
 }
 

--- a/src/bicep/core/spoke-network.bicep
+++ b/src/bicep/core/spoke-network.bicep
@@ -35,6 +35,7 @@ param routeTableRouteNextHopIpAddress string = firewallPrivateIPAddress
 param routeTableRouteNextHopType string = 'VirtualAppliance'
 
 param subnetPrivateEndpointNetworkPolicies string
+param subnetPrivateLinkServiceNetworkPolicies string
 
 module logStorage '../modules/storage-account.bicep' = {
   name: 'logStorage'
@@ -99,6 +100,7 @@ module virtualNetwork '../modules/virtual-network.bicep' = {
           }
           serviceEndpoints: subnetServiceEndpoints            
           privateEndpointNetworkPolicies: subnetPrivateEndpointNetworkPolicies
+          privateLinkServiceNetworkPolicies: subnetPrivateLinkServiceNetworkPolicies
         }
       }
     ]

--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -669,6 +669,7 @@ var spokes = [
     subnetAddressPrefix: identitySubnetAddressPrefix
     subnetServiceEndpoints: identitySubnetServiceEndpoints
     subnetPrivateEndpointNetworkPolicies: 'Enabled'
+    subnetPrivateLinkServiceNetworkPolicies: 'Enabled'
   }
   {
     name: operationsName
@@ -687,6 +688,7 @@ var spokes = [
     subnetAddressPrefix: operationsSubnetAddressPrefix
     subnetServiceEndpoints: operationsSubnetServiceEndpoints
     subnetPrivateEndpointNetworkPolicies: 'Disabled'
+    subnetPrivateLinkServiceNetworkPolicies: 'Disabled'
   }
   {
     name: sharedServicesName
@@ -705,6 +707,7 @@ var spokes = [
     subnetAddressPrefix: sharedServicesSubnetAddressPrefix
     subnetServiceEndpoints: sharedServicesSubnetServiceEndpoints
     subnetPrivateEndpointNetworkPolicies: 'Enabled'
+    subnetPrivateLinkServiceNetworkPolicies: 'Enabled'
   }
 ]
 
@@ -853,6 +856,7 @@ module spokeNetworks './core/spoke-network.bicep' = [for spoke in spokes: {
     subnetServiceEndpoints: spoke.subnetServiceEndpoints
 
     subnetPrivateEndpointNetworkPolicies: spoke.subnetPrivateEndpointNetworkPolicies
+    subnetPrivateLinkServiceNetworkPolicies: spoke.subnetPrivateLinkServiceNetworkPolicies
   }
 }]
 

--- a/src/bicep/modules/defender.bicep
+++ b/src/bicep/modules/defender.bicep
@@ -6,14 +6,16 @@ Licensed under the MIT License.
 targetScope = 'subscription'
 
 param bundle array = (environment().name == 'AzureCloud') ? [
+  'Api'
   'AppServices'
   'Arm'
-  'ContainerRegistry'
+  'CloudPosture'
+  //'ContainerRegistry' (deprecated)
   'Containers'
   'CosmosDbs'
-  'Dns'
+  //'Dns' (deprecated)
   'KeyVaults'
-  'KubernetesService'
+  //'KubernetesService' (deprecated)
   'OpenSourceRelationalDatabases'
   'SqlServers'
   'SqlServerVirtualMachines'
@@ -21,10 +23,10 @@ param bundle array = (environment().name == 'AzureCloud') ? [
   'VirtualMachines'
 ] : (environment().name == 'AzureUSGovernment') ? [
   'Arm'
-  'ContainerRegistry'
+  //'ContainerRegistry' (deprecated)
   'Containers'
-  'Dns'
-  'KubernetesService'
+  //'Dns' (deprecated)
+  //'KubernetesService' (deprecated)
   'OpenSourceRelationalDatabases'
   'SqlServers'
   'SqlServerVirtualMachines'
@@ -46,8 +48,8 @@ param emailSecurityContact string
 param policySetDescription string = 'The Microsoft Cloud Security Benchmark initiative represents the policies and controls implementing security recommendations defined in Microsoft Cloud Security Benchmark v2, see https://aka.ms/azsecbm. This also serves as the Microsoft Defender for Cloud default policy initiative. You can directly assign this initiative, or manage its policies and compliance results within Microsoft Defender.'
 
 // defender
-
-resource defenderPricing 'Microsoft.Security/pricings@2018-06-01' = [for name in bundle: {
+@batchSize(1)
+resource defenderPricing 'Microsoft.Security/pricings@2023-01-01' = [for name in bundle: {
   name: name
   properties: {
     pricingTier: 'Standard'
@@ -56,14 +58,14 @@ resource defenderPricing 'Microsoft.Security/pricings@2018-06-01' = [for name in
 
 // auto provisioing
 
-resource autoProvision 'Microsoft.Security/autoProvisioningSettings@2017-08-01-preview' = {
+resource autoProvision 'Microsoft.Security/autoProvisioningSettings@2019-01-01' = {
   name: 'default'
   properties: {
     autoProvision: autoProvisioning
   }
 }
 
-resource securityWorkspaceSettings 'Microsoft.Security/workspaceSettings@2017-08-01-preview' = {
+resource securityWorkspaceSettings 'Microsoft.Security/workspaceSettings@2019-01-01' = {
   name: 'default'
   properties: {
     workspaceId: logAnalyticsWorkspaceId
@@ -71,7 +73,7 @@ resource securityWorkspaceSettings 'Microsoft.Security/workspaceSettings@2017-08
   }
 }
 
-resource securityNotifications 'Microsoft.Security/securityContacts@2017-08-01-preview' = if (!empty(emailSecurityContact)) {
+resource securityNotifications 'Microsoft.Security/securityContacts@2020-01-01-preview' = if (!empty(emailSecurityContact)) {
   name: 'securityNotifications'
   properties: {
     alertsToAdmins: 'On'
@@ -80,7 +82,7 @@ resource securityNotifications 'Microsoft.Security/securityContacts@2017-08-01-p
   }
 }
 
-resource securityPoliciesDefault 'Microsoft.Authorization/policyAssignments@2020-09-01' = {
+resource securityPoliciesDefault 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
   name: 'Microsoft Cloud Security Benchmark'
   scope: subscription()
   properties: {

--- a/src/bicep/modules/private-dns.bicep
+++ b/src/bicep/modules/private-dns.bicep
@@ -20,6 +20,7 @@ var privateDnsZones_privatelink_ods_opinsights_azure_name = ( environment().name
 var privateDnsZones_privatelink_oms_opinsights_azure_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.oms.opinsights.azure.com' : 'privatelink.oms.opinsights.azure.us' )
 var privateDnsZones_privatelink_blob_core_cloudapi_net_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.blob.${environment().suffixes.storage}' : 'privatelink.blob.core.usgovcloudapi.net' )
 var privateDnsZones_privatelink_agentsvc_azure_automation_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.agentsvc.azure-automation.net' : 'privatelink.agentsvc.azure-automation.us' )
+var privateDnsZones_privatelink_vault_core_azure_name = ( environment().name =~ 'AzureCloud' ? 'privatelink.vaultcore.azure.net' : 'privatelink.vaultcore.usgovcloudapi.net' )
 
 resource privatelink_monitor_azure_com 'Microsoft.Network/privateDnsZones@2018-09-01' = {
   name: privateDnsZones_privatelink_monitor_azure_name
@@ -47,6 +48,12 @@ resource privatelink_agentsvc_azure_automation_net 'Microsoft.Network/privateDns
 
 resource privatelink_blob_core_cloudapi_net 'Microsoft.Network/privateDnsZones@2018-09-01' = {
   name: privateDnsZones_privatelink_blob_core_cloudapi_net_name
+  location: 'global'
+  tags: tags
+}
+
+resource privatelink_vault_core_cloudapi_net 'Microsoft.Network/privateDnsZones@2018-09-01' = {
+  name: privateDnsZones_privatelink_vault_core_azure_name
   location: 'global'
   tags: tags
 }
@@ -125,8 +132,24 @@ resource privateDnsZones_privatelink_blob_core_cloudapi_net_privateDnsZones_priv
   ]
 }
 
+resource privateDnsZones_privatelink_vault_core_cloudapi_net_privateDnsZones_privatelink_vault_core_cloudapi_net_link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
+  name: '${privateDnsZones_privatelink_vault_core_azure_name}/${privateDnsZones_privatelink_vault_core_azure_name}-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: resourceId(vnetSubscriptionId, vnetResourceGroup, 'Microsoft.Network/virtualNetworks', vnetName )
+    }
+  }
+  dependsOn: [
+    privatelink_vault_core_cloudapi_net
+    privateDnsZones_privatelink_blob_core_cloudapi_net_privateDnsZones_privatelink_blob_core_cloudapi_net_link
+  ]
+}
+
 output monitorPrivateDnsZoneId string = privatelink_monitor_azure_com.id
 output omsPrivateDnsZoneId string = privatelink_oms_opinsights_azure_com.id
 output odsPrivateDnsZoneId string = privatelink_ods_opinsights_azure_com.id
 output agentsvcPrivateDnsZoneId string = privatelink_agentsvc_azure_automation_net.id
 output storagePrivateDnsZoneId string = privatelink_blob_core_cloudapi_net.id
+output vaultPrivateDnsZoneId string = privatelink_vault_core_cloudapi_net.id

--- a/src/bicep/modules/storage-account.bicep
+++ b/src/bicep/modules/storage-account.bicep
@@ -8,7 +8,7 @@ param location string
 param skuName string
 param tags object = {}
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' = {
   name: storageAccountName
   location: location
   kind: 'StorageV2'
@@ -18,6 +18,24 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2019-06-01' = {
   tags: tags
   properties: {
     minimumTlsVersion: 'TLS1_2'
+    encryption: {
+      keySource: 'Microsoft.Storage'
+      requireInfrastructureEncryption: true
+      services: {
+        blob: {
+          enabled: true
+        }
+        file: {
+          enabled: true
+        }
+        queue: {
+          enabled: true
+        }
+        table: {
+          enabled: true
+        }
+      }
+    }
   }
 }
 output id string = storageAccount.id


### PR DESCRIPTION
Added infra encryption to storage
Fixed defender bug under "Discussion #653"
Added KV Private DNS zone

# Description

Defender for Cloud:
When deploying and re-deploying DfC, there are several errors that usually happen which are fixed here.

Storage Accounts:
Storage Accounts can only have infrastructure encryption enabled when created. Added code to enable that upon provisioning

Private Link Service Network Policies:
In order to deploy services like AVD into one of the spokes, there needs to be an option to disable the Private Link Service Network Policies. Added that option and kept the defaults uniform to the Private Endpoint Network Policies.

UNABLE to test in Air-Gapped clouds.

## Issue reference

The issue this PR will close: #653

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [ ] All acceptance criteria in the backlog item are met
* [ ] The documentation is updated to cover any new or changed features
* [ ] Manual tests have passed
* [ ] Relevant issues are linked to this PR

