### PR TITLE
Fixed dependency for remote access

### DIFF
--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -1143,6 +1143,7 @@ module remoteAccess './core/remote-access.bicep' = if (deployRemoteAccess) {
   }
   dependsOn: [
     azureMonitorPrivateLink
+    hubNetworkDNS
   ]
 }
 

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -4,27 +4,27 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.10.61.36676",
-      "templateHash": "11325591247187477175"
+      "version": "0.24.24.22086",
+      "templateHash": "17486567247363088362"
     }
   },
   "parameters": {
     "resourcePrefix": {
       "type": "string",
+      "minLength": 3,
+      "maxLength": 10,
       "metadata": {
         "description": "A prefix, 3-10 alphanumeric characters without whitespace, used to prefix resources and generate uniqueness for resources with globally unique naming requirements like Storage Accounts and Log Analytics Workspaces"
-      },
-      "maxLength": 10,
-      "minLength": 3
+      }
     },
     "resourceSuffix": {
       "type": "string",
       "defaultValue": "mlz",
+      "minLength": 3,
+      "maxLength": 6,
       "metadata": {
         "description": "A suffix, 3 to 6 characters in length, to append to resource names (e.g. \"dev\", \"test\", \"prod\", \"mlz\"). It defaults to \"mlz\"."
-      },
-      "maxLength": 6,
-      "minLength": 3
+      }
     },
     "hubSubscriptionId": {
       "type": "string",
@@ -158,37 +158,37 @@
     "firewallSkuTier": {
       "type": "string",
       "defaultValue": "Premium",
-      "metadata": {
-        "description": "[Standard/Premium] The SKU for Azure Firewall. It defaults to \"Premium\"."
-      },
       "allowedValues": [
         "Standard",
         "Premium"
-      ]
+      ],
+      "metadata": {
+        "description": "[Standard/Premium] The SKU for Azure Firewall. It defaults to \"Premium\"."
+      }
     },
     "firewallThreatIntelMode": {
       "type": "string",
       "defaultValue": "Alert",
-      "metadata": {
-        "description": "[Alert/Deny/Off] The Azure Firewall Threat Intelligence Rule triggered logging behavior. Valid values are \"Alert\", \"Deny\", or \"Off\". The default value is \"Alert\"."
-      },
       "allowedValues": [
         "Alert",
         "Deny",
         "Off"
-      ]
+      ],
+      "metadata": {
+        "description": "[Alert/Deny/Off] The Azure Firewall Threat Intelligence Rule triggered logging behavior. Valid values are \"Alert\", \"Deny\", or \"Off\". The default value is \"Alert\"."
+      }
     },
     "firewallIntrusionDetectionMode": {
       "type": "string",
       "defaultValue": "Alert",
-      "metadata": {
-        "description": "[Alert/Deny/Off] The Azure Firewall Intrusion Detection mode. Valid values are \"Alert\", \"Deny\", or \"Off\". The default value is \"Alert\"."
-      },
       "allowedValues": [
         "Alert",
         "Deny",
         "Off"
-      ]
+      ],
+      "metadata": {
+        "description": "[Alert/Deny/Off] The Azure Firewall Intrusion Detection mode. Valid values are \"Alert\", \"Deny\", or \"Off\". The default value is \"Alert\"."
+      }
     },
     "enableProxy": {
       "type": "bool",
@@ -621,9 +621,6 @@
     "logAnalyticsWorkspaceSkuName": {
       "type": "string",
       "defaultValue": "PerGB2018",
-      "metadata": {
-        "description": "[Free/Standard/Premium/PerNode/PerGB2018/Standalone] The SKU for the Log Analytics Workspace. It defaults to \"PerGB2018\". See https://docs.microsoft.com/en-us/azure/azure-monitor/logs/resource-manager-workspace for valid settings."
-      },
       "allowedValues": [
         "Free",
         "Standard",
@@ -631,7 +628,10 @@
         "PerNode",
         "PerGB2018",
         "Standalone"
-      ]
+      ],
+      "metadata": {
+        "description": "[Free/Standard/Premium/PerNode/PerGB2018/Standalone] The SKU for the Log Analytics Workspace. It defaults to \"PerGB2018\". See https://docs.microsoft.com/en-us/azure/azure-monitor/logs/resource-manager-workspace for valid settings."
+      }
     },
     "logStorageSkuName": {
       "type": "string",
@@ -671,16 +671,16 @@
     "linuxVmAuthenticationType": {
       "type": "string",
       "defaultValue": "password",
-      "metadata": {
-        "description": "[sshPublicKey/password] The authentication type for the Linux Virtual Machine to Azure Bastion remote into. It defaults to \"password\"."
-      },
       "allowedValues": [
         "sshPublicKey",
         "password"
-      ]
+      ],
+      "metadata": {
+        "description": "[sshPublicKey/password] The authentication type for the Linux Virtual Machine to Azure Bastion remote into. It defaults to \"password\"."
+      }
     },
     "linuxVmAdminPasswordOrKey": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "[if(parameters('deployRemoteAccess'), '', newGuid())]",
       "minLength": 12,
       "metadata": {
@@ -739,13 +739,13 @@
     "linuxNetworkInterfacePrivateIPAddressAllocationMethod": {
       "type": "string",
       "defaultValue": "Dynamic",
-      "metadata": {
-        "description": "[Static/Dynamic] The public IP Address allocation method for the Linux virtual machine. It defaults to \"Dynamic\"."
-      },
       "allowedValues": [
         "Static",
         "Dynamic"
-      ]
+      ],
+      "metadata": {
+        "description": "[Static/Dynamic] The public IP Address allocation method for the Linux virtual machine. It defaults to \"Dynamic\"."
+      }
     },
     "windowsVmAdminUsername": {
       "type": "string",
@@ -755,7 +755,7 @@
       }
     },
     "windowsVmAdminPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "[if(parameters('deployRemoteAccess'), '', newGuid())]",
       "minLength": 12,
       "metadata": {
@@ -814,13 +814,13 @@
     "windowsNetworkInterfacePrivateIPAddressAllocationMethod": {
       "type": "string",
       "defaultValue": "Dynamic",
-      "metadata": {
-        "description": "[Static/Dynamic] The public IP Address allocation method for the Windows virtual machine. It defaults to \"Dynamic\"."
-      },
       "allowedValues": [
         "Static",
         "Dynamic"
-      ]
+      ],
+      "metadata": {
+        "description": "[Static/Dynamic] The public IP Address allocation method for the Windows virtual machine. It defaults to \"Dynamic\"."
+      }
     },
     "deployPolicy": {
       "type": "bool",
@@ -832,15 +832,15 @@
     "policy": {
       "type": "string",
       "defaultValue": "NISTRev4",
-      "metadata": {
-        "description": "[NISTRev4/NISTRev5/IL5/CMMC] Built-in policy assignments to assign, it defaults to \"NISTRev4\". IL5 is only available for AzureUsGovernment and will switch to NISTRev4 if tried in AzureCloud."
-      },
       "allowedValues": [
         "NISTRev4",
         "NISTRev5",
         "IL5",
         "CMMC"
-      ]
+      ],
+      "metadata": {
+        "description": "[NISTRev4/NISTRev5/IL5/CMMC] Built-in policy assignments to assign, it defaults to \"NISTRev4\". IL5 is only available for AzureUsGovernment and will switch to NISTRev4 if tried in AzureCloud."
+      }
     },
     "deployDefender": {
       "type": "bool",
@@ -852,13 +852,13 @@
     "defenderSkuTier": {
       "type": "string",
       "defaultValue": "Standard",
-      "metadata": {
-        "description": "[Standard/Free] The SKU for Defender. It defaults to \"Standard\"."
-      },
       "allowedValues": [
         "Standard",
         "Free"
-      ]
+      ],
+      "metadata": {
+        "description": "[Standard/Free] The SKU for Defender. It defaults to \"Standard\"."
+      }
     },
     "emailSecurityContact": {
       "type": "string",
@@ -1010,7 +1010,7 @@
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('deploy-rg-hub-{0}', parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
       "location": "[deployment().location]",
@@ -1036,8 +1036,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "18346155787391352255"
+              "version": "0.24.24.22086",
+              "templateHash": "7140967460139920692"
             }
           },
           "parameters": {
@@ -1088,7 +1088,7 @@
         "count": "[length(variables('spokes'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('deploy-rg-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "location": "[deployment().location]",
@@ -1114,8 +1114,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "18346155787391352255"
+              "version": "0.24.24.22086",
+              "templateHash": "7140967460139920692"
             }
           },
           "parameters": {
@@ -1162,7 +1162,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('deploy-laws-{0}', parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[parameters('operationsSubscriptionId')]",
       "resourceGroup": "[variables('operationsResourceGroupName')]",
@@ -1200,8 +1200,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "4363803513381780626"
+              "version": "0.24.24.22086",
+              "templateHash": "9947295372567029530"
             }
           },
           "parameters": {
@@ -1316,11 +1316,11 @@
               }
             },
             {
-              "condition": "[variables('solutions')[copyIndex()].deploy]",
               "copy": {
                 "name": "logAnalyticsSolutions",
                 "count": "[length(variables('solutions'))]"
               },
+              "condition": "[variables('solutions')[copyIndex()].deploy]",
               "type": "Microsoft.OperationsManagement/solutions",
               "apiVersion": "2015-11-01-preview",
               "name": "[format('{0}({1})', variables('solutions')[copyIndex()].name, parameters('name'))]",
@@ -1374,7 +1374,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
       "resourceGroup": "[variables('hubResourceGroupName')]",
@@ -1397,7 +1397,7 @@
             "value": "[parameters('logStorageSkuName')]"
           },
           "logAnalyticsWorkspaceResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.id.value]"
           },
           "virtualNetworkName": {
             "value": "[variables('hubVirtualNetworkName')]"
@@ -1523,8 +1523,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "1557820237271279412"
+              "version": "0.24.24.22086",
+              "templateHash": "5868168706337396749"
             }
           },
           "parameters": {
@@ -1703,10 +1703,10 @@
               "properties": {
                 "addressPrefix": "[parameters('subnetAddressPrefix')]",
                 "networkSecurityGroup": {
-                  "id": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup')).outputs.id.value]"
+                  "id": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2022-09-01').outputs.id.value]"
                 },
                 "routeTable": {
-                  "id": "[reference(resourceId('Microsoft.Resources/deployments', 'routeTable')).outputs.id.value]"
+                  "id": "[reference(resourceId('Microsoft.Resources/deployments', 'routeTable'), '2022-09-01').outputs.id.value]"
                 },
                 "serviceEndpoints": "[parameters('subnetServiceEndpoints')]",
                 "privateEndpointNetworkPolicies": "Disabled",
@@ -1721,7 +1721,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "logStorage",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -1748,8 +1748,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "4435843471246172620"
+                      "version": "0.24.24.22086",
+                      "templateHash": "11432560412215968310"
                     }
                   },
                   "parameters": {
@@ -1812,7 +1812,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "networkSecurityGroup",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -1836,7 +1836,7 @@
                     "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
                   },
                   "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2022-09-01').outputs.id.value]"
                   },
                   "logs": {
                     "value": "[parameters('networkSecurityGroupDiagnosticsLogs')]"
@@ -1851,8 +1851,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "7894763285242421186"
+                      "version": "0.24.24.22086",
+                      "templateHash": "11977507194028278079"
                     }
                   },
                   "parameters": {
@@ -1927,7 +1927,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "virtualNetwork",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -1972,7 +1972,7 @@
                     "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
                   },
                   "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2022-09-01').outputs.id.value]"
                   },
                   "logs": {
                     "value": "[parameters('virtualNetworkDiagnosticsLogs')]"
@@ -1987,8 +1987,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "16443263514490560792"
+                      "version": "0.24.24.22086",
+                      "templateHash": "3610049520534333304"
                     }
                   },
                   "parameters": {
@@ -2069,11 +2069,11 @@
                     },
                     "subnets": {
                       "type": "array",
-                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name'))).subnets]"
+                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name')), '2021-02-01').subnets]"
                     },
                     "addressPrefix": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name'))).addressSpace.addressPrefixes[0]]"
+                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name')), '2021-02-01').addressSpace.addressPrefixes[0]]"
                     }
                   }
                 }
@@ -2084,7 +2084,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "routeTable",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2108,7 +2108,7 @@
                     "value": "[parameters('routeTableRouteAddressPrefix')]"
                   },
                   "routeNextHopIpAddress": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewall')).outputs.privateIPAddress.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewall'), '2022-09-01').outputs.privateIPAddress.value]"
                   },
                   "routeNextHopType": {
                     "value": "[parameters('routeTableRouteNextHopType')]"
@@ -2120,8 +2120,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "8332169477119932515"
+                      "version": "0.24.24.22086",
+                      "templateHash": "13858235086546968061"
                     }
                   },
                   "parameters": {
@@ -2187,7 +2187,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "firewallClientPublicIPAddress",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2217,7 +2217,7 @@
                     "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
                   },
                   "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2022-09-01').outputs.id.value]"
                   },
                   "logs": {
                     "value": "[parameters('publicIPAddressDiagnosticsLogs')]"
@@ -2232,8 +2232,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "18439825222758045392"
+                      "version": "0.24.24.22086",
+                      "templateHash": "643596479218724976"
                     }
                   },
                   "parameters": {
@@ -2314,7 +2314,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "firewallManagementPublicIPAddress",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2344,7 +2344,7 @@
                     "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
                   },
                   "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2022-09-01').outputs.id.value]"
                   },
                   "logs": {
                     "value": "[parameters('publicIPAddressDiagnosticsLogs')]"
@@ -2359,8 +2359,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "18439825222758045392"
+                      "version": "0.24.24.22086",
+                      "templateHash": "643596479218724976"
                     }
                   },
                   "parameters": {
@@ -2441,7 +2441,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "firewall",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2474,10 +2474,10 @@
                     "value": "[parameters('firewallClientIpConfigurationName')]"
                   },
                   "clientIpConfigurationSubnetResourceId": {
-                    "value": "[format('{0}/subnets/{1}', reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.id.value, parameters('firewallClientSubnetName'))]"
+                    "value": "[format('{0}/subnets/{1}', reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.id.value, parameters('firewallClientSubnetName'))]"
                   },
                   "clientIpConfigurationPublicIPAddressResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewallClientPublicIPAddress')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewallClientPublicIPAddress'), '2022-09-01').outputs.id.value]"
                   },
                   "firewallSupernetIPAddress": {
                     "value": "[parameters('firewallSupernetIPAddress')]"
@@ -2492,16 +2492,16 @@
                     "value": "[parameters('firewallManagementIpConfigurationName')]"
                   },
                   "managementIpConfigurationSubnetResourceId": {
-                    "value": "[format('{0}/subnets/{1}', reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.id.value, parameters('firewallManagementSubnetName'))]"
+                    "value": "[format('{0}/subnets/{1}', reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.id.value, parameters('firewallManagementSubnetName'))]"
                   },
                   "managementIpConfigurationPublicIPAddressResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewallManagementPublicIPAddress')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewallManagementPublicIPAddress'), '2022-09-01').outputs.id.value]"
                   },
                   "logAnalyticsWorkspaceResourceId": {
                     "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
                   },
                   "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2022-09-01').outputs.id.value]"
                   },
                   "logs": {
                     "value": "[parameters('firewallDiagnosticsLogs')]"
@@ -2516,8 +2516,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "3970955170518833761"
+                      "version": "0.24.24.22086",
+                      "templateHash": "8776599634048001479"
                     }
                   },
                   "parameters": {
@@ -2803,7 +2803,7 @@
                   "outputs": {
                     "privateIPAddress": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Network/azureFirewalls', parameters('name'))).ipConfigurations[0].properties.privateIPAddress]"
+                      "value": "[reference(resourceId('Microsoft.Network/azureFirewalls', parameters('name')), '2021-02-01').ipConfigurations[0].properties.privateIPAddress]"
                     }
                   }
                 }
@@ -2819,11 +2819,11 @@
           "outputs": {
             "virtualNetworkName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.name.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.name.value]"
             },
             "virtualNetworkResourceId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.id.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.id.value]"
             },
             "subnetName": {
               "type": "string",
@@ -2831,7 +2831,7 @@
             },
             "subnetAddressPrefix": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName')), '/')[0], split(format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName')), '/')[1])).addressPrefix]"
+              "value": "[reference(resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName')), '/')[0], split(format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName')), '/')[1]), '2021-02-01').addressPrefix]"
             },
             "subnetResourceId": {
               "type": "string",
@@ -2839,15 +2839,15 @@
             },
             "networkSecurityGroupName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup')).outputs.name.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2022-09-01').outputs.name.value]"
             },
             "networkSecurityGroupResourceId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup')).outputs.id.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2022-09-01').outputs.id.value]"
             },
             "firewallPrivateIPAddress": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewall')).outputs.privateIPAddress.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewall'), '2022-09-01').outputs.privateIPAddress.value]"
             }
           }
         }
@@ -2858,7 +2858,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('deploy-vnet-hub-DNS-{0}', parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
       "resourceGroup": "[variables('hubResourceGroupName')]",
@@ -2881,7 +2881,7 @@
             "value": "[parameters('logStorageSkuName')]"
           },
           "logAnalyticsWorkspaceResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.id.value]"
           },
           "virtualNetworkName": {
             "value": "[variables('hubVirtualNetworkName')]"
@@ -2990,7 +2990,7 @@
           },
           "vNetDnsServers": {
             "value": [
-              "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.firewallPrivateIPAddress.value]"
+              "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.firewallPrivateIPAddress.value]"
             ]
           },
           "publicIPAddressDiagnosticsLogs": {
@@ -3012,8 +3012,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "1557820237271279412"
+              "version": "0.24.24.22086",
+              "templateHash": "5868168706337396749"
             }
           },
           "parameters": {
@@ -3192,10 +3192,10 @@
               "properties": {
                 "addressPrefix": "[parameters('subnetAddressPrefix')]",
                 "networkSecurityGroup": {
-                  "id": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup')).outputs.id.value]"
+                  "id": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2022-09-01').outputs.id.value]"
                 },
                 "routeTable": {
-                  "id": "[reference(resourceId('Microsoft.Resources/deployments', 'routeTable')).outputs.id.value]"
+                  "id": "[reference(resourceId('Microsoft.Resources/deployments', 'routeTable'), '2022-09-01').outputs.id.value]"
                 },
                 "serviceEndpoints": "[parameters('subnetServiceEndpoints')]",
                 "privateEndpointNetworkPolicies": "Disabled",
@@ -3210,7 +3210,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "logStorage",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3237,8 +3237,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "4435843471246172620"
+                      "version": "0.24.24.22086",
+                      "templateHash": "11432560412215968310"
                     }
                   },
                   "parameters": {
@@ -3301,7 +3301,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "networkSecurityGroup",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3325,7 +3325,7 @@
                     "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
                   },
                   "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2022-09-01').outputs.id.value]"
                   },
                   "logs": {
                     "value": "[parameters('networkSecurityGroupDiagnosticsLogs')]"
@@ -3340,8 +3340,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "7894763285242421186"
+                      "version": "0.24.24.22086",
+                      "templateHash": "11977507194028278079"
                     }
                   },
                   "parameters": {
@@ -3416,7 +3416,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "virtualNetwork",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3461,7 +3461,7 @@
                     "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
                   },
                   "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2022-09-01').outputs.id.value]"
                   },
                   "logs": {
                     "value": "[parameters('virtualNetworkDiagnosticsLogs')]"
@@ -3476,8 +3476,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "16443263514490560792"
+                      "version": "0.24.24.22086",
+                      "templateHash": "3610049520534333304"
                     }
                   },
                   "parameters": {
@@ -3558,11 +3558,11 @@
                     },
                     "subnets": {
                       "type": "array",
-                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name'))).subnets]"
+                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name')), '2021-02-01').subnets]"
                     },
                     "addressPrefix": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name'))).addressSpace.addressPrefixes[0]]"
+                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name')), '2021-02-01').addressSpace.addressPrefixes[0]]"
                     }
                   }
                 }
@@ -3573,7 +3573,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "routeTable",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3597,7 +3597,7 @@
                     "value": "[parameters('routeTableRouteAddressPrefix')]"
                   },
                   "routeNextHopIpAddress": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewall')).outputs.privateIPAddress.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewall'), '2022-09-01').outputs.privateIPAddress.value]"
                   },
                   "routeNextHopType": {
                     "value": "[parameters('routeTableRouteNextHopType')]"
@@ -3609,8 +3609,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "8332169477119932515"
+                      "version": "0.24.24.22086",
+                      "templateHash": "13858235086546968061"
                     }
                   },
                   "parameters": {
@@ -3676,7 +3676,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "firewallClientPublicIPAddress",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3706,7 +3706,7 @@
                     "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
                   },
                   "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2022-09-01').outputs.id.value]"
                   },
                   "logs": {
                     "value": "[parameters('publicIPAddressDiagnosticsLogs')]"
@@ -3721,8 +3721,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "18439825222758045392"
+                      "version": "0.24.24.22086",
+                      "templateHash": "643596479218724976"
                     }
                   },
                   "parameters": {
@@ -3803,7 +3803,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "firewallManagementPublicIPAddress",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3833,7 +3833,7 @@
                     "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
                   },
                   "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2022-09-01').outputs.id.value]"
                   },
                   "logs": {
                     "value": "[parameters('publicIPAddressDiagnosticsLogs')]"
@@ -3848,8 +3848,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "18439825222758045392"
+                      "version": "0.24.24.22086",
+                      "templateHash": "643596479218724976"
                     }
                   },
                   "parameters": {
@@ -3930,7 +3930,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "firewall",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3963,10 +3963,10 @@
                     "value": "[parameters('firewallClientIpConfigurationName')]"
                   },
                   "clientIpConfigurationSubnetResourceId": {
-                    "value": "[format('{0}/subnets/{1}', reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.id.value, parameters('firewallClientSubnetName'))]"
+                    "value": "[format('{0}/subnets/{1}', reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.id.value, parameters('firewallClientSubnetName'))]"
                   },
                   "clientIpConfigurationPublicIPAddressResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewallClientPublicIPAddress')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewallClientPublicIPAddress'), '2022-09-01').outputs.id.value]"
                   },
                   "firewallSupernetIPAddress": {
                     "value": "[parameters('firewallSupernetIPAddress')]"
@@ -3981,16 +3981,16 @@
                     "value": "[parameters('firewallManagementIpConfigurationName')]"
                   },
                   "managementIpConfigurationSubnetResourceId": {
-                    "value": "[format('{0}/subnets/{1}', reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.id.value, parameters('firewallManagementSubnetName'))]"
+                    "value": "[format('{0}/subnets/{1}', reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.id.value, parameters('firewallManagementSubnetName'))]"
                   },
                   "managementIpConfigurationPublicIPAddressResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewallManagementPublicIPAddress')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewallManagementPublicIPAddress'), '2022-09-01').outputs.id.value]"
                   },
                   "logAnalyticsWorkspaceResourceId": {
                     "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
                   },
                   "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2022-09-01').outputs.id.value]"
                   },
                   "logs": {
                     "value": "[parameters('firewallDiagnosticsLogs')]"
@@ -4005,8 +4005,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "3970955170518833761"
+                      "version": "0.24.24.22086",
+                      "templateHash": "8776599634048001479"
                     }
                   },
                   "parameters": {
@@ -4292,7 +4292,7 @@
                   "outputs": {
                     "privateIPAddress": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Network/azureFirewalls', parameters('name'))).ipConfigurations[0].properties.privateIPAddress]"
+                      "value": "[reference(resourceId('Microsoft.Network/azureFirewalls', parameters('name')), '2021-02-01').ipConfigurations[0].properties.privateIPAddress]"
                     }
                   }
                 }
@@ -4308,11 +4308,11 @@
           "outputs": {
             "virtualNetworkName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.name.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.name.value]"
             },
             "virtualNetworkResourceId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.id.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.id.value]"
             },
             "subnetName": {
               "type": "string",
@@ -4320,7 +4320,7 @@
             },
             "subnetAddressPrefix": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName')), '/')[0], split(format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName')), '/')[1])).addressPrefix]"
+              "value": "[reference(resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName')), '/')[0], split(format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName')), '/')[1]), '2021-02-01').addressPrefix]"
             },
             "subnetResourceId": {
               "type": "string",
@@ -4328,15 +4328,15 @@
             },
             "networkSecurityGroupName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup')).outputs.name.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2022-09-01').outputs.name.value]"
             },
             "networkSecurityGroupResourceId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup')).outputs.id.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2022-09-01').outputs.id.value]"
             },
             "firewallPrivateIPAddress": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewall')).outputs.privateIPAddress.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'firewall'), '2022-09-01').outputs.privateIPAddress.value]"
             }
           }
         }
@@ -4352,7 +4352,7 @@
         "count": "[length(variables('spokes'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "resourceGroup": "[variables('spokes')[copyIndex()].resourceGroupName]",
@@ -4375,14 +4375,14 @@
             "value": "[parameters('logStorageSkuName')]"
           },
           "logAnalyticsWorkspaceResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.id.value]"
           },
           "firewallPrivateIPAddress": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.firewallPrivateIPAddress.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.firewallPrivateIPAddress.value]"
           },
           "vNetDnsServers": {
             "value": [
-              "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.firewallPrivateIPAddress.value]"
+              "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.firewallPrivateIPAddress.value]"
             ]
           },
           "virtualNetworkName": {
@@ -4431,8 +4431,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "6504783739414137516"
+              "version": "0.24.24.22086",
+              "templateHash": "3636586928348301463"
             }
           },
           "parameters": {
@@ -4522,7 +4522,7 @@
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "logStorage",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -4549,8 +4549,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "4435843471246172620"
+                      "version": "0.24.24.22086",
+                      "templateHash": "11432560412215968310"
                     }
                   },
                   "parameters": {
@@ -4613,7 +4613,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "networkSecurityGroup",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -4637,7 +4637,7 @@
                     "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
                   },
                   "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2022-09-01').outputs.id.value]"
                   },
                   "logs": {
                     "value": "[parameters('networkSecurityGroupDiagnosticsLogs')]"
@@ -4652,8 +4652,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "7894763285242421186"
+                      "version": "0.24.24.22086",
+                      "templateHash": "11977507194028278079"
                     }
                   },
                   "parameters": {
@@ -4728,7 +4728,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "routeTable",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -4764,8 +4764,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "8332169477119932515"
+                      "version": "0.24.24.22086",
+                      "templateHash": "13858235086546968061"
                     }
                   },
                   "parameters": {
@@ -4828,7 +4828,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "virtualNetwork",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -4858,10 +4858,10 @@
                         "properties": {
                           "addressPrefix": "[parameters('subnetAddressPrefix')]",
                           "networkSecurityGroup": {
-                            "id": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup')).outputs.id.value]"
+                            "id": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2022-09-01').outputs.id.value]"
                           },
                           "routeTable": {
-                            "id": "[reference(resourceId('Microsoft.Resources/deployments', 'routeTable')).outputs.id.value]"
+                            "id": "[reference(resourceId('Microsoft.Resources/deployments', 'routeTable'), '2022-09-01').outputs.id.value]"
                           },
                           "serviceEndpoints": "[parameters('subnetServiceEndpoints')]",
                           "privateEndpointNetworkPolicies": "[parameters('subnetPrivateEndpointNetworkPolicies')]",
@@ -4874,7 +4874,7 @@
                     "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
                   },
                   "logStorageAccountResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage')).outputs.id.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logStorage'), '2022-09-01').outputs.id.value]"
                   },
                   "logs": {
                     "value": "[parameters('virtualNetworkDiagnosticsLogs')]"
@@ -4889,8 +4889,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "16443263514490560792"
+                      "version": "0.24.24.22086",
+                      "templateHash": "3610049520534333304"
                     }
                   },
                   "parameters": {
@@ -4971,11 +4971,11 @@
                     },
                     "subnets": {
                       "type": "array",
-                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name'))).subnets]"
+                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name')), '2021-02-01').subnets]"
                     },
                     "addressPrefix": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name'))).addressSpace.addressPrefixes[0]]"
+                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name')), '2021-02-01').addressSpace.addressPrefixes[0]]"
                     }
                   }
                 }
@@ -4990,35 +4990,35 @@
           "outputs": {
             "virtualNetworkName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.name.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.name.value]"
             },
             "virtualNetworkResourceId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.id.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.id.value]"
             },
             "virtualNetworkAddressPrefix": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.addressPrefix.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.addressPrefix.value]"
             },
             "subnetName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.subnets.value[0].name]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.subnets.value[0].name]"
             },
             "subnetAddressPrefix": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.subnets.value[0].properties.addressPrefix]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.subnets.value[0].properties.addressPrefix]"
             },
             "subnetResourceId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork')).outputs.subnets.value[0].id]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'virtualNetwork'), '2022-09-01').outputs.subnets.value[0].id]"
             },
             "networkSecurityGroupName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup')).outputs.name.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2022-09-01').outputs.name.value]"
             },
             "networkSecurityGroupResourceId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup')).outputs.id.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'networkSecurityGroup'), '2022-09-01').outputs.id.value]"
             }
           }
         }
@@ -5030,7 +5030,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('deploy-vnet-peerings-hub-{0}', parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
       "resourceGroup": "[variables('hubResourceGroupName')]",
@@ -5041,14 +5041,14 @@
         "mode": "Incremental",
         "parameters": {
           "hubVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.virtualNetworkName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.virtualNetworkName.value]"
           },
           "spokes": {
             "copy": [
               {
                 "name": "value",
                 "count": "[length(variables('spokes'))]",
-                "input": "[createObject('type', variables('spokes')[copyIndex('value')].name, 'virtualNetworkName', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscriptionId, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].name, parameters('deploymentNameSuffix')))).outputs.virtualNetworkName.value, 'virtualNetworkResourceId', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscriptionId, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].name, parameters('deploymentNameSuffix')))).outputs.virtualNetworkResourceId.value)]"
+                "input": "[createObject('type', variables('spokes')[copyIndex('value')].name, 'virtualNetworkName', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscriptionId, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].name, parameters('deploymentNameSuffix'))), '2022-09-01').outputs.virtualNetworkName.value, 'virtualNetworkResourceId', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex('value')].subscriptionId, variables('spokes')[copyIndex('value')].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex('value')].name, parameters('deploymentNameSuffix'))), '2022-09-01').outputs.virtualNetworkResourceId.value)]"
               }
             ]
           }
@@ -5059,8 +5059,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "15629689242937002521"
+              "version": "0.24.24.22086",
+              "templateHash": "9588462177817329290"
             }
           },
           "parameters": {
@@ -5078,7 +5078,7 @@
                 "count": "[length(parameters('spokes'))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('hub-to-{0}-vnet-peering', parameters('spokes')[copyIndex()].type)]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -5099,8 +5099,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "18419282456813263047"
+                      "version": "0.24.24.22086",
+                      "templateHash": "9853575474833495545"
                     }
                   },
                   "parameters": {
@@ -5141,7 +5141,7 @@
         "count": "[length(variables('spokes'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('deploy-vnet-peerings-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "location": "[deployment().location]",
@@ -5158,13 +5158,13 @@
             "value": "[variables('spokes')[copyIndex()].resourceGroupName]"
           },
           "spokeVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix')))).outputs.virtualNetworkName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))), '2022-09-01').outputs.virtualNetworkName.value]"
           },
           "hubVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.virtualNetworkName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.virtualNetworkName.value]"
           },
           "hubVirtualNetworkResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.virtualNetworkResourceId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.virtualNetworkResourceId.value]"
           }
         },
         "template": {
@@ -5173,8 +5173,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "2611495743947239031"
+              "version": "0.24.24.22086",
+              "templateHash": "1352997920612289656"
             }
           },
           "parameters": {
@@ -5197,7 +5197,7 @@
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('{0}-to-hub-vnet-peering', parameters('spokeName'))]",
               "resourceGroup": "[parameters('spokeResourceGroupName')]",
               "properties": {
@@ -5219,8 +5219,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "18419282456813263047"
+                      "version": "0.24.24.22086",
+                      "templateHash": "9853575474833495545"
                     }
                   },
                   "parameters": {
@@ -5258,7 +5258,7 @@
     {
       "condition": "[parameters('deployPolicy')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('assign-policy-hub-{0}', parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
       "resourceGroup": "[variables('hubResourceGroupName')]",
@@ -5272,10 +5272,10 @@
             "value": "[parameters('policy')]"
           },
           "logAnalyticsWorkspaceName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.name.value]"
           },
           "logAnalyticsWorkspaceResourceGroupName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.resourceGroupName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.resourceGroupName.value]"
           },
           "operationsSubscriptionId": {
             "value": "[parameters('operationsSubscriptionId')]"
@@ -5290,23 +5290,23 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "3765055138598353912"
+              "version": "0.24.24.22086",
+              "templateHash": "16693295535307781768"
             }
           },
           "parameters": {
             "builtInAssignment": {
               "type": "string",
               "defaultValue": "NISTRev4",
-              "metadata": {
-                "description": "[NISTRev4/NISTRev5/IL5/CMMC] Built-in policy assignments to assign, default is NISTRev4. IL5 is only available for AzureUsGovernment and will switch to NISTRev4 if tried in AzureCloud."
-              },
               "allowedValues": [
                 "NISTRev4",
                 "NISTRev5",
                 "IL5",
                 "CMMC"
-              ]
+              ],
+              "metadata": {
+                "description": "[NISTRev4/NISTRev5/IL5/CMMC] Built-in policy assignments to assign, default is NISTRev4. IL5 is only available for AzureUsGovernment and will switch to NISTRev4 if tried in AzureCloud."
+              }
             },
             "logAnalyticsWorkspaceName": {
               "type": "string"
@@ -5333,10 +5333,10 @@
             }
           },
           "variables": {
-            "$fxv#0": "    {\n        \"listOfMembersToExcludeFromWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"admin\"\n        },\n        \"listOfMembersToIncludeInWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"azureuser\"\n        },\n        \"logAnalyticsWorkspaceIdforVMReporting\": \n        {\n        \"value\": \"<LAWORKSPACE>\"\n        },\n        \"IncludeArcMachines\": \n        {\n            \"value\": \"true\"\n        },\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \n        {\n            \"value\": \"1.2\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \n        {\n            \"value\": \"Compliant\"\n        },\n        \"requiredRetentionDays\": \n        {\n            \"value\": \"365\"\n        },\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \n        {\n            \"value\": \"NetworkWatcherRG\"\n        }\n    }",
-            "$fxv#1": "    {\n        \"IncludeArcMachines\": \n        {\n            \"value\": \"true\"\n        },\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \n        {\n            \"value\": \"1.2\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \n        {\n            \"value\": \"Compliant\"\n        },\n        \"requiredRetentionDays\": \n        {\n            \"value\": \"365\"\n        },\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \n        {\n            \"value\": \"NetworkWatcherRG\"\n        }\n    }",
-            "$fxv#2": "{\n    \"IncludeArcMachines\" : { \n        \"value\" : \"false\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\" : { \n        \"value\" : \"Compliant\"\n        },\n        \"MinimumTLSVersionForWindowsServers\" : { \n        \"value\" : \"1.2\"\n        },\n        \"requiredRetentionDays\" : { \n        \"value\" : \"365\"\n        },\n        \"effect-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"audit\"\n        },\n        \"allowedContainerImagesRegex-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"^(.+){0}$\"\n        },\n        \"effect-95edb821-ddaf-4404-9732-666045e056b4\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-440b515e-a580-421e-abeb-b159a61ddcbc\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-233a2a17-77ca-4fb1-9b6b-69223d272a44\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"audit\"\n        },\n        \"cpuLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"memoryLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"effect-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"audit\"\n        },\n        \"runAsUserRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"MustRunAsNonRoot\"\n        },\n        \"runAsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"supplementalGroupsRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"fsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"effect-1c6e92c9-99f0-4e55-9cf2-0c234dc48f99\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-47a1ee2f-2a2a-4576-bf2a-e0e36709c2b8\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-df49d893-a74c-421d-bc95-c663042e5b80\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-1a5b4dca-0b6f-4cf5-907c-56316bc1bf3d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-c26596ff-4d70-4e6a-9a30-c2506bd2f80c\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-511f5417-5d12-434d-ab2e-816901e72a5e\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-82985f06-dc18-4a48-bc1c-b9f4f0098cfe\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-098fc59e-46c7-4d99-9b16-64990e543d75\" : { \n        \"value\" : \"audit\"\n        },\n        \"NetworkWatcherResourceGroupName\" : { \n        \"value\" : \"NetworkWatcherRG\"\n        },\n        \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n        \"value\" : \"enabled\"\n        },\n        \"aadAuthenticationInServiceFabricMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-71ef260a-8f18-47b7-abcb-62d0673d94dc\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-862e97cf-49fc-4a5c-9de4-40d4e2e7c8eb\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d9da03a1-f3c3-412a-9709-947156872263\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-b4ac1030-89c5-4697-8e00-28b5ba6a8811\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-ea0dfaed-95fb-448c-934e-d6e713ce393d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-41425d9f-d1a5-499a-9932-f8ed8453932c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fc4d8e41-e223-45ea-9bf5-eada37891d87\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-86efb160-8de7-451d-bc08-5d475b0aadae\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-4ec52d6d-beb7-40c4-9a9e-fe753254690e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-64d314f6-6062-4780-a861-c23e8951bee5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fd32ebd-e4c3-4e13-a54a-d7422d4d95f6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fa298e57-9444-42ba-bf04-86e8470e32c7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f905d99-2ab7-462c-a6b0-f709acca6c8f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ba769a63-b8cc-4b2d-abf6-ac33c7204be8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0aa61e00-0a01-4a3c-9945-e93cffedf0e6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-47031206-ce96-41f8-861b-6a915f3de284\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-51522a96-0869-4791-82f3-981000c2c67f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-b5ec538c-daa0-4006-8596-35468b9148e8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-56a5ee18-2ae6-4810-86f7-18e39ce5629b\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2e94d99a-8a36-4563-bc77-810d8893b671\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fafeaf6-7927-4059-a50a-8eb2a7a6f2b5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-99e9ccd8-3db9-4592-b0d1-14b1715a4d8a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f68a601-6e6d-4e42-babf-3f643a047ea2\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ca91455f-eace-4f96-be59-e6e2c35b4816\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-702dd420-7fcc-42c5-afe8-4026edd20fe0\" : { \n        \"value\" : \"Audit\"\n        },\n        \"diagnosticsLogsInRedisCacheMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"secureTransferToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d092e0a-7acd-40d2-a975-dca21cae48c4\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"disableUnrestrictedNetworkToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-55615ac9-af46-4a59-874e-391cc3dfb490\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1b8ca024-1d5c-4dec-8995-b1a932b41780\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-53503636-bcc9-4748-9663-5348217f160f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-40cec1dd-a100-4920-b15b-3024fe8901ab\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-a049bf77-880b-470f-ba6d-9f21c530cf83\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ee980b6d-0eca-4501-8d54-f6290fd512c3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1d84d5fb-01f6-4d12-ba4f-4a26081d403d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-37e0d2fe-28a5-43d6-a273-67d37d1f5606\" : { \n        \"value\" : \"Audit\"\n        },\n        \"identityDesignateMoreThanOneOwnerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"diskEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"emailNotificationToSubscriptionOwnerHighSeverityAlertsEnabledEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlDbEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"aadAuthenticationInSqlServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssEndpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssOsVulnerabilitiesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"adaptiveApplicationControlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForPostgreSQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensureJavaVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityDesignateLessThanOwnersMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"securityContactEmailAddressForSubscriptionEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRestrictCORSAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensurePythonVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForMySQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"systemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"nextGenerationFirewallMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"useRbacRulesMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"webAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlServerAuditingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vnetEnableDDoSProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlServerAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"endpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"jitNetworkAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"geoRedundantStorageShouldBeEnabledForStorageAccountsEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"vmssSystemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"longtermGeoRedundantBackupEnabledAzureSQLDatabasesEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"systemConfigurationsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"containerBenchmarkMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"kubernetesServiceVersionUpToDateMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlDbVulnerabilityAssesmentMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"membersToIncludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"membersToExcludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"logAnalyticsWorkspaceIDForVMAgents\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n        },\n        \"PHPLatestVersionForAppServices\" : { \n        \"value\" : \"7.4\"\n        },\n        \"JavaLatestVersionForAppServices\" : { \n        \"value\" : \"11\"\n        },\n        \"WindowsPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.6\"\n        },\n        \"LinuxPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.9\"\n        },\n        \"ensureDotNetFrameworkLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"vulnerabilityAssessmentMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForWebAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"microsoftIaaSAntimalwareExtensionShouldBeDeployedOnWindowsServersEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityCenterStandardPricingTierShouldBeSelectedEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachinesEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensurePHPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityContactPhoneNumberShouldBeProvidedForSubscriptionEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForAPIAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnServerMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachineScaleSetsEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        }\n}",
-            "$fxv#3": "{\n    \"logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n    },\n    \"effect-09024ccc-0c5f-475e-9457-b7c0d9ed487b\" : { \n        \"value\" : \"AuditIfNotExists\"\n    },\n    \"MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f\" :{\n        \"value\": \"\"\n    },\n    \"MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7\": {\n        \"value\": \"\"\n    },\n    \"effect-0961003e-5a0a-4549-abde-af6a37f2724d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b15565f-aa9e-48ba-8619-45960f2c314d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0e60b895-3786-45da-8377-9c6b4b6ac5f9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-17k78e20-9358-41c9-923c-fb736d382a12\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1bc1795e-d44a-4d48-9b3b-6fff0fd5f9ba\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"PHPLatestVersion\" : { \n    \"value\" : \"7.3\"\n    },\n    \"effect-22bee202-a82f-4305-9a2a-6d7f44d4dedb\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-26a828e1-e88f-464e-bbb3-c134a282b9de\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-34c877ad-507e-4c82-993e-3452a6e0ad3c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3c735d8a-a4ba-4a3a-b7cf-db7754cf57f4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-404c3081-a854-4457-ae30-26a93ef643f9\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-47a6b606-51aa-4496-8bb7-64b11cf66adc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-496223c3-ad65-4ecd-878a-bae78737e9ed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"JavaLatestVersion\" : { \n    \"value\" : \"11\"\n    },\n    \"effect-4f11b553-d42e-4e3a-89be-32ca364cad4c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4f4f78b8-e367-4b10-a341-d9a4ad5cf1c7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5c607a2e-c700-4744-8254-d77e7c9eb5e4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5f76cf89-fbf2-47fd-a3f4-b891fa780b60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6b1cbf55-e8b6-442f-ba4c-7246b6381474\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6d555dd1-86f2-4f1c-8ed7-5abae7c6cbab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7008174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"LinuxPythonLatestVersion\" : { \n    \"value\" : \"3.8\"\n    },\n    \"effect-7238174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7261b898-8a84-4db8-9e04-18527132abb3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-74c3584d-afae-46f7-a20a-6f8adba71a16\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-86b3d65f-7626-441e-b690-81a8b71cff60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-88999f4c-376a-45c8-bcb3-4058f713cf39\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8c122334-9d20-4eb8-89ea-ac9a705b74ae\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8cb6aa8b-9e41-4f4e-aa25-089a7ac2581e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9297c21d-2ed6-4474-b48f-163f75654ce3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-991310cd-e9f3-47bc-b7b6-f57b557d07db\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9b597639-28e4-48eb-b506-56b05d366257\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9d0b6ea4-93e2-4578-bf2f-6bb17d22b4bc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9daedab3-fb2d-461e-b861-71790eead4f6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a4af4a39-4135-47fb-b175-47fbdf85311d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"enabled\"\n    },\n    \"effect-a70ca396-0a34-413a-88e1-b956c1e683be\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-aa633080-8b72-40c4-a2d7-d00c03e80bed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb4388-5bf4-4ad7-ba82-2cd2f41ceae9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb7388-5bf4-4ad7-ba99-2cd2f41cebb9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-af6cd1bd-1635-48cb-bde7-5b15693900b9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\" : { \n    \"value\" : \"NetworkWatcherRG\"\n    },\n    \"effect-b7ddfbdc-1260-477d-91fd-98bd9be789a6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c3f317a7-a95c-4547-b7e7-11017ebdf2fe\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-cb510bfd-1cba-4d9f-a230-cb0976f4bb71\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e2c1c086-2d84-4019-bff3-c44ccd95113c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e3576e28-8b17-4677-84c3-db2990658d64\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e8cbc669-f12d-49eb-93e7-9273119e9933\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e9c8d085-d9cc-4b17-9cdc-059f1f01f19e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ebb62a0c-3560-49e1-89ed-27e074e9f8ad\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-efbde977-ba53-4479-b8e9-10b957924fbf\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f0e6e85b-9b9f-4a4b-b67b-f730d42f1b0b\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f6de0be7-9a8a-4b8a-b349-43cf02d22f7c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f8456c1c-aa66-4dfb-861a-25d127b775c9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f9d614c5-c173-4d56-95a7-b4437057d193\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-fb893a29-21bb-418c-a157-e99480ec364c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-feedbf84-6b99-488c-acc2-71c829aa5ffc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-3b980d31-7904-4bb7-8575-5665739a8052\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6e2593d9-add6-4083-9c9b-4b7d2188c899\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b607c5de-e7d9-4eee-9e5c-83f1bcee4fa0\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-013e242c-8828-4970-87b3-ab247555486d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d38fc420-0735-4ef3-ac11-c806f651a570\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a1181c5f-672a-477a-979a-7d58aa086233\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-308fbb08-4ab8-4e67-9b29-592e93fb94fa\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4da35fc9-c9e7-4960-aec9-797fe7d9051d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-523b5cd1-3e23-492f-a539-13118b6d1e3a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7fe3b40f-802b-4cdd-8bd4-fd799c948cc2\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c25d9a16-bc35-4e15-a7e5-9db606bf9ed4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b0f33259-77d7-4c9e-aac6-3aabcfae693c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0820b7b9-23aa-4725-a1ce-ae4558f718e5\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-358c20a6-3f9e-4f0e-97ff-c6ce485e2aac\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5744710e-cc2f-4ee8-8809-3b11e89f4bc9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ac4a19c2-fa67-49b4-8ae5-0b2e78c49457\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c9d007d0-c057-4772-b18c-01e546713bcd\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e372f825-a257-4fb8-9175-797a8a8627d6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d158790f-bfb0-486c-8631-2dc6b4e8e6af\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e802a67a-daf5-4436-9ea6-f6d821dd0c5d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a451c1ef-c6ca-483d-87ed-f49761e3ffb5\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftSql-servers-firewallRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ae89ebca-1c92-4898-ac2c-9f63decb045c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d26f7642-7545-4e18-9b75-8c9bbdee3a9a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1a4e592a-6a6e-44a5-9814-e36264ca96e7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7796937f-307b-4598-941c-67d3a05ebfe7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c5447c04-a4d7-4ba8-a263-c9ee321a6858\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-41388f1c-2db0-4c25-95b2-35d7f5ccbfa9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b02aacc0-b073-424e-8298-42b22829ee0a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-057d6cfe-9c4f-4a6d-bc60-14420ea1f1a9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0ec47710-77ff-4a3d-9181-6aa50af424d0\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-48af4db5-9b8b-401c-8e74-076be876a430\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-82339799-d096-41ae-8538-b108becf0970\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1b7aa243-30e4-4c9e-bca8-d0d3022b634a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ef2a8f2a-b3d9-49cd-a8a8-9a3aaaf647d9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-bb91dfba-c30d-4263-9add-9c2384e659a6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e71308d3-144b-4262-b144-efdc3cc90517\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2bdd0062-9d75-436e-89df-487dd8e4b3c7\" : { \n    \"value\" : \"Disabled\"\n    },\n    \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-6fac406b-40ca-413b-bf8e-0bf964659c25\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-048248b0-55cd-46da-b1ff-39efd52db260\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0d134df8-db83-46fb-ad72-fe0c9428c8dd\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fb2\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n    \"value\" : \"audit\"\n    },\n    \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c43e4a30-77cb-48ab-a4dd-93f175c63b57\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1f314764-cb73-4fc9-b863-8eca98ac36e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-123a3936-f020-408a-ba0c-47873faf1534\" : { \n    \"value\" : \"AuditIfNotExists\"\n    }\n}\n",
+            "$fxv#0": "    {\r\n        \"listOfMembersToExcludeFromWindowsVMAdministratorsGroup\": \r\n        {\r\n        \"value\": \"admin\"\r\n        },\r\n        \"listOfMembersToIncludeInWindowsVMAdministratorsGroup\": \r\n        {\r\n        \"value\": \"azureuser\"\r\n        },\r\n        \"logAnalyticsWorkspaceIdforVMReporting\": \r\n        {\r\n        \"value\": \"<LAWORKSPACE>\"\r\n        },\r\n        \"IncludeArcMachines\": \r\n        {\r\n            \"value\": \"true\"\r\n        },\r\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \r\n        {\r\n            \"value\": \"1.2\"\r\n        },\r\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \r\n        {\r\n            \"value\": \"Compliant\"\r\n        },\r\n        \"requiredRetentionDays\": \r\n        {\r\n            \"value\": \"365\"\r\n        },\r\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \r\n        {\r\n            \"value\": \"NetworkWatcherRG\"\r\n        }\r\n    }",
+            "$fxv#1": "    {\r\n        \"IncludeArcMachines\": \r\n        {\r\n            \"value\": \"true\"\r\n        },\r\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \r\n        {\r\n            \"value\": \"1.2\"\r\n        },\r\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \r\n        {\r\n            \"value\": \"Compliant\"\r\n        },\r\n        \"requiredRetentionDays\": \r\n        {\r\n            \"value\": \"365\"\r\n        },\r\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \r\n        {\r\n            \"value\": \"NetworkWatcherRG\"\r\n        }\r\n    }",
+            "$fxv#2": "{\r\n    \"IncludeArcMachines\" : { \r\n        \"value\" : \"false\"\r\n        },\r\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\" : { \r\n        \"value\" : \"Compliant\"\r\n        },\r\n        \"MinimumTLSVersionForWindowsServers\" : { \r\n        \"value\" : \"1.2\"\r\n        },\r\n        \"requiredRetentionDays\" : { \r\n        \"value\" : \"365\"\r\n        },\r\n        \"effect-febd0533-8e55-448f-b837-bd0e06f16469\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"allowedContainerImagesRegex-febd0533-8e55-448f-b837-bd0e06f16469\" : { \r\n        \"value\" : \"^(.+){0}$\"\r\n        },\r\n        \"effect-95edb821-ddaf-4404-9732-666045e056b4\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-440b515e-a580-421e-abeb-b159a61ddcbc\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-233a2a17-77ca-4fb1-9b6b-69223d272a44\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"cpuLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \r\n        \"value\" : \"0\"\r\n        },\r\n        \"memoryLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \r\n        \"value\" : \"0\"\r\n        },\r\n        \"effect-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"runAsUserRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"MustRunAsNonRoot\"\r\n        },\r\n        \"runAsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"RunAsAny\"\r\n        },\r\n        \"supplementalGroupsRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"RunAsAny\"\r\n        },\r\n        \"fsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"RunAsAny\"\r\n        },\r\n        \"effect-1c6e92c9-99f0-4e55-9cf2-0c234dc48f99\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-47a1ee2f-2a2a-4576-bf2a-e0e36709c2b8\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-df49d893-a74c-421d-bc95-c663042e5b80\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-1a5b4dca-0b6f-4cf5-907c-56316bc1bf3d\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-c26596ff-4d70-4e6a-9a30-c2506bd2f80c\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-511f5417-5d12-434d-ab2e-816901e72a5e\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-82985f06-dc18-4a48-bc1c-b9f4f0098cfe\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-098fc59e-46c7-4d99-9b16-64990e543d75\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"NetworkWatcherResourceGroupName\" : { \r\n        \"value\" : \"NetworkWatcherRG\"\r\n        },\r\n        \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \r\n        \"value\" : \"enabled\"\r\n        },\r\n        \"aadAuthenticationInServiceFabricMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-71ef260a-8f18-47b7-abcb-62d0673d94dc\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-862e97cf-49fc-4a5c-9de4-40d4e2e7c8eb\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-d9da03a1-f3c3-412a-9709-947156872263\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-b4ac1030-89c5-4697-8e00-28b5ba6a8811\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-ea0dfaed-95fb-448c-934e-d6e713ce393d\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-41425d9f-d1a5-499a-9932-f8ed8453932c\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-fc4d8e41-e223-45ea-9bf5-eada37891d87\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-86efb160-8de7-451d-bc08-5d475b0aadae\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-4ec52d6d-beb7-40c4-9a9e-fe753254690e\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-64d314f6-6062-4780-a861-c23e8951bee5\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1fd32ebd-e4c3-4e13-a54a-d7422d4d95f6\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-fa298e57-9444-42ba-bf04-86e8470e32c7\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1f905d99-2ab7-462c-a6b0-f709acca6c8f\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-ba769a63-b8cc-4b2d-abf6-ac33c7204be8\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-0aa61e00-0a01-4a3c-9945-e93cffedf0e6\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-47031206-ce96-41f8-861b-6a915f3de284\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-51522a96-0869-4791-82f3-981000c2c67f\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-b5ec538c-daa0-4006-8596-35468b9148e8\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-56a5ee18-2ae6-4810-86f7-18e39ce5629b\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-2e94d99a-8a36-4563-bc77-810d8893b671\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1fafeaf6-7927-4059-a50a-8eb2a7a6f2b5\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-99e9ccd8-3db9-4592-b0d1-14b1715a4d8a\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1f68a601-6e6d-4e42-babf-3f643a047ea2\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-ca91455f-eace-4f96-be59-e6e2c35b4816\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-702dd420-7fcc-42c5-afe8-4026edd20fe0\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"diagnosticsLogsInRedisCacheMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"secureTransferToStorageAccountMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-7d092e0a-7acd-40d2-a975-dca21cae48c4\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"disableUnrestrictedNetworkToStorageAccountMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-55615ac9-af46-4a59-874e-391cc3dfb490\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1b8ca024-1d5c-4dec-8995-b1a932b41780\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-53503636-bcc9-4748-9663-5348217f160f\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-40cec1dd-a100-4920-b15b-3024fe8901ab\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-a049bf77-880b-470f-ba6d-9f21c530cf83\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-ee980b6d-0eca-4501-8d54-f6290fd512c3\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1d84d5fb-01f6-4d12-ba4f-4a26081d403d\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-37e0d2fe-28a5-43d6-a273-67d37d1f5606\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"identityDesignateMoreThanOneOwnerMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"diskEncryptionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"emailNotificationToSubscriptionOwnerHighSeverityAlertsEnabledEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"functionAppDisableRemoteDebuggingMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"sqlDbEncryptionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vulnerabilityAssessmentOnManagedInstanceMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensurePHPVersionLatestForAPIAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"aadAuthenticationInSqlServerMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vmssEndpointProtectionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vmssOsVulnerabilitiesMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"adaptiveApplicationControlsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForPostgreSQLEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"ensureJavaVersionLatestForWebAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityDesignateLessThanOwnersMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"securityContactEmailAddressForSubscriptionEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"webAppRestrictCORSAccessMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveDeprecatedAccountMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"functionAppEnforceHttpsMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"ensurePythonVersionLatestForWebAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensurePythonVersionLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensurePHPVersionLatestForWebAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensurePythonVersionLatestForAPIAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForMySQLEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"systemUpdatesMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureJavaVersionLatestForAPIAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureHTTPVersionLatestForWebAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"apiAppRequireLatestTlsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityEnableMFAForWritePermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureHTTPVersionLatestForAPIAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureJavaVersionLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"nextGenerationFirewallMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"useRbacRulesMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"webAppEnforceHttpsMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"sqlServerAuditingMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vnetEnableDDoSProtectionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityEnableMFAForOwnerPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"sqlServerAdvancedDataSecurityMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"sqlManagedInstanceAdvancedDataSecurityMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"endpointProtectionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"jitNetworkAccessMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"apiAppEnforceHttpsMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"geoRedundantStorageShouldBeEnabledForStorageAccountsEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"vmssSystemUpdatesMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"webAppDisableRemoteDebuggingMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"longtermGeoRedundantBackupEnabledAzureSQLDatabasesEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"systemConfigurationsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureHTTPVersionLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityEnableMFAForReadPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"containerBenchmarkMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"apiAppDisableRemoteDebuggingMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vulnerabilityAssessmentOnServerMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"webAppRequireLatestTlsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"functionAppRequireLatestTlsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"kubernetesServiceVersionUpToDateMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"sqlDbVulnerabilityAssesmentMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"membersToIncludeInLocalAdministratorsGroup\" : { \r\n        \"value\" : \"\"\r\n        },\r\n        \"membersToExcludeInLocalAdministratorsGroup\" : { \r\n        \"value\" : \"\"\r\n        },\r\n        \"logAnalyticsWorkspaceIDForVMAgents\" : { \r\n        \"value\" : \"<LAWORKSPACE>\"\r\n        },\r\n        \"PHPLatestVersionForAppServices\" : { \r\n        \"value\" : \"7.4\"\r\n        },\r\n        \"JavaLatestVersionForAppServices\" : { \r\n        \"value\" : \"11\"\r\n        },\r\n        \"WindowsPythonLatestVersionForAppServices\" : { \r\n        \"value\" : \"3.6\"\r\n        },\r\n        \"LinuxPythonLatestVersionForAppServices\" : { \r\n        \"value\" : \"3.9\"\r\n        },\r\n        \"ensureDotNetFrameworkLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"vulnerabilityAssessmentMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"ensureDotNetFrameworkLatestForWebAppEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"sqlServerAdvancedDataSecurityEmailsMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"microsoftIaaSAntimalwareExtensionShouldBeDeployedOnWindowsServersEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"securityCenterStandardPricingTierShouldBeSelectedEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachinesEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"ensurePHPVersionLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"securityContactPhoneNumberShouldBeProvidedForSubscriptionEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"threatDetectionTypesOnManagedInstanceMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"ensureDotNetFrameworkLatestForAPIAppEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"threatDetectionTypesOnServerMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachineScaleSetsEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        }\r\n}",
+            "$fxv#3": "{\r\n    \"logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917\" : { \r\n        \"value\" : \"<LAWORKSPACE>\"\r\n    },\r\n    \"effect-09024ccc-0c5f-475e-9457-b7c0d9ed487b\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f\" :{\r\n        \"value\": \"\"\r\n    },\r\n    \"MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7\": {\r\n        \"value\": \"\"\r\n    },\r\n    \"effect-0961003e-5a0a-4549-abde-af6a37f2724d\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0b15565f-aa9e-48ba-8619-45960f2c314d\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0e60b895-3786-45da-8377-9c6b4b6ac5f9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-17k78e20-9358-41c9-923c-fb736d382a12\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-1bc1795e-d44a-4d48-9b3b-6fff0fd5f9ba\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"PHPLatestVersion\" : { \r\n    \"value\" : \"7.3\"\r\n    },\r\n    \"effect-22bee202-a82f-4305-9a2a-6d7f44d4dedb\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-26a828e1-e88f-464e-bbb3-c134a282b9de\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-34c877ad-507e-4c82-993e-3452a6e0ad3c\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-3c735d8a-a4ba-4a3a-b7cf-db7754cf57f4\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-404c3081-a854-4457-ae30-26a93ef643f9\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-47a6b606-51aa-4496-8bb7-64b11cf66adc\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-496223c3-ad65-4ecd-878a-bae78737e9ed\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"JavaLatestVersion\" : { \r\n    \"value\" : \"11\"\r\n    },\r\n    \"effect-4f11b553-d42e-4e3a-89be-32ca364cad4c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-4f4f78b8-e367-4b10-a341-d9a4ad5cf1c7\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-5c607a2e-c700-4744-8254-d77e7c9eb5e4\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-5f76cf89-fbf2-47fd-a3f4-b891fa780b60\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-6b1cbf55-e8b6-442f-ba4c-7246b6381474\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-6d555dd1-86f2-4f1c-8ed7-5abae7c6cbab\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-7008174a-fd10-4ef0-817e-fc820a951d73\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"LinuxPythonLatestVersion\" : { \r\n    \"value\" : \"3.8\"\r\n    },\r\n    \"effect-7238174a-fd10-4ef0-817e-fc820a951d73\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-7261b898-8a84-4db8-9e04-18527132abb3\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-74c3584d-afae-46f7-a20a-6f8adba71a16\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-86b3d65f-7626-441e-b690-81a8b71cff60\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-88999f4c-376a-45c8-bcb3-4058f713cf39\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-8c122334-9d20-4eb8-89ea-ac9a705b74ae\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-8cb6aa8b-9e41-4f4e-aa25-089a7ac2581e\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-9297c21d-2ed6-4474-b48f-163f75654ce3\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-991310cd-e9f3-47bc-b7b6-f57b557d07db\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-9b597639-28e4-48eb-b506-56b05d366257\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-9d0b6ea4-93e2-4578-bf2f-6bb17d22b4bc\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-9daedab3-fb2d-461e-b861-71790eead4f6\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-a4af4a39-4135-47fb-b175-47fbdf85311d\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \r\n    \"value\" : \"enabled\"\r\n    },\r\n    \"effect-a70ca396-0a34-413a-88e1-b956c1e683be\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-aa633080-8b72-40c4-a2d7-d00c03e80bed\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-abfb4388-5bf4-4ad7-ba82-2cd2f41ceae9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-abfb7388-5bf4-4ad7-ba99-2cd2f41cebb9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-af6cd1bd-1635-48cb-bde7-5b15693900b9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\" : { \r\n    \"value\" : \"NetworkWatcherRG\"\r\n    },\r\n    \"effect-b7ddfbdc-1260-477d-91fd-98bd9be789a6\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-c3f317a7-a95c-4547-b7e7-11017ebdf2fe\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-cb510bfd-1cba-4d9f-a230-cb0976f4bb71\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e2c1c086-2d84-4019-bff3-c44ccd95113c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e3576e28-8b17-4677-84c3-db2990658d64\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e8cbc669-f12d-49eb-93e7-9273119e9933\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e9c8d085-d9cc-4b17-9cdc-059f1f01f19e\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-ebb62a0c-3560-49e1-89ed-27e074e9f8ad\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-efbde977-ba53-4479-b8e9-10b957924fbf\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-f0e6e85b-9b9f-4a4b-b67b-f730d42f1b0b\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-f6de0be7-9a8a-4b8a-b349-43cf02d22f7c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-f8456c1c-aa66-4dfb-861a-25d127b775c9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-f9d614c5-c173-4d56-95a7-b4437057d193\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-fb893a29-21bb-418c-a157-e99480ec364c\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-feedbf84-6b99-488c-acc2-71c829aa5ffc\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-3b980d31-7904-4bb7-8575-5665739a8052\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-6e2593d9-add6-4083-9c9b-4b7d2188c899\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b607c5de-e7d9-4eee-9e5c-83f1bcee4fa0\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"modeRequirement-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \r\n    \"value\" : \"Detection\"\r\n    },\r\n    \"effect-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"modeRequirement-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \r\n    \"value\" : \"Detection\"\r\n    },\r\n    \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-013e242c-8828-4970-87b3-ab247555486d\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-d38fc420-0735-4ef3-ac11-c806f651a570\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-a1181c5f-672a-477a-979a-7d58aa086233\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-308fbb08-4ab8-4e67-9b29-592e93fb94fa\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-4da35fc9-c9e7-4960-aec9-797fe7d9051d\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-523b5cd1-3e23-492f-a539-13118b6d1e3a\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-7fe3b40f-802b-4cdd-8bd4-fd799c948cc2\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-c25d9a16-bc35-4e15-a7e5-9db606bf9ed4\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b0f33259-77d7-4c9e-aac6-3aabcfae693c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-0820b7b9-23aa-4725-a1ce-ae4558f718e5\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fab\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-358c20a6-3f9e-4f0e-97ff-c6ce485e2aac\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-5744710e-cc2f-4ee8-8809-3b11e89f4bc9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-ac4a19c2-fa67-49b4-8ae5-0b2e78c49457\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-c9d007d0-c057-4772-b18c-01e546713bcd\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-e372f825-a257-4fb8-9175-797a8a8627d6\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-d158790f-bfb0-486c-8631-2dc6b4e8e6af\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-e802a67a-daf5-4436-9ea6-f6d821dd0c5d\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-a451c1ef-c6ca-483d-87ed-f49761e3ffb5\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftSql-servers-firewallRules-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-securityRules-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-securityRules-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-ae89ebca-1c92-4898-ac2c-9f63decb045c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-d26f7642-7545-4e18-9b75-8c9bbdee3a9a\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-1a4e592a-6a6e-44a5-9814-e36264ca96e7\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-7796937f-307b-4598-941c-67d3a05ebfe7\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-c5447c04-a4d7-4ba8-a263-c9ee321a6858\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-41388f1c-2db0-4c25-95b2-35d7f5ccbfa9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b02aacc0-b073-424e-8298-42b22829ee0a\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-057d6cfe-9c4f-4a6d-bc60-14420ea1f1a9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0ec47710-77ff-4a3d-9181-6aa50af424d0\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-48af4db5-9b8b-401c-8e74-076be876a430\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-82339799-d096-41ae-8538-b108becf0970\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-1b7aa243-30e4-4c9e-bca8-d0d3022b634a\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-ef2a8f2a-b3d9-49cd-a8a8-9a3aaaf647d9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-bb91dfba-c30d-4263-9add-9c2384e659a6\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e71308d3-144b-4262-b144-efdc3cc90517\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-2bdd0062-9d75-436e-89df-487dd8e4b3c7\" : { \r\n    \"value\" : \"Disabled\"\r\n    },\r\n    \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-6fac406b-40ca-413b-bf8e-0bf964659c25\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-048248b0-55cd-46da-b1ff-39efd52db260\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0d134df8-db83-46fb-ad72-fe0c9428c8dd\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fb2\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \r\n    \"value\" : \"audit\"\r\n    },\r\n    \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-c43e4a30-77cb-48ab-a4dd-93f175c63b57\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-1f314764-cb73-4fc9-b863-8eca98ac36e9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-123a3936-f020-408a-ba0c-47873faf1534\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    }\r\n}\r\n",
             "modifiedAssignment": "[if(and(equals(toLower(environment().name), toLower('AzureCloud')), equals(toLower(parameters('builtInAssignment')), toLower('IL5'))), 'NISTRev4', parameters('builtInAssignment'))]",
             "assignmentName": "[format('{0} {1}', variables('modifiedAssignment'), resourceGroup().name)]",
             "agentVmssAssignmentName": "[format('Deploy VMSS Agents {0}', resourceGroup().name)]",
@@ -5446,7 +5446,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('Assign-Laws-Role-Policy-{0}', resourceGroup().name)]",
               "subscriptionId": "[parameters('operationsSubscriptionId')]",
               "resourceGroup": "[parameters('logAnalyticsWorkspaceResourceGroupName')]",
@@ -5472,8 +5472,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "15761836246481461949"
+                      "version": "0.24.24.22086",
+                      "templateHash": "8686326864657481429"
                     }
                   },
                   "parameters": {
@@ -5528,13 +5528,13 @@
       ]
     },
     {
-      "condition": "[parameters('deployPolicy')]",
       "copy": {
         "name": "spokePolicyAssignments",
         "count": "[length(variables('spokes'))]"
       },
+      "condition": "[parameters('deployPolicy')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('assign-policy-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "resourceGroup": "[variables('spokes')[copyIndex()].resourceGroupName]",
@@ -5548,10 +5548,10 @@
             "value": "[parameters('policy')]"
           },
           "logAnalyticsWorkspaceName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.name.value]"
           },
           "logAnalyticsWorkspaceResourceGroupName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.resourceGroupName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.resourceGroupName.value]"
           },
           "operationsSubscriptionId": {
             "value": "[parameters('operationsSubscriptionId')]"
@@ -5566,23 +5566,23 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "3765055138598353912"
+              "version": "0.24.24.22086",
+              "templateHash": "16693295535307781768"
             }
           },
           "parameters": {
             "builtInAssignment": {
               "type": "string",
               "defaultValue": "NISTRev4",
-              "metadata": {
-                "description": "[NISTRev4/NISTRev5/IL5/CMMC] Built-in policy assignments to assign, default is NISTRev4. IL5 is only available for AzureUsGovernment and will switch to NISTRev4 if tried in AzureCloud."
-              },
               "allowedValues": [
                 "NISTRev4",
                 "NISTRev5",
                 "IL5",
                 "CMMC"
-              ]
+              ],
+              "metadata": {
+                "description": "[NISTRev4/NISTRev5/IL5/CMMC] Built-in policy assignments to assign, default is NISTRev4. IL5 is only available for AzureUsGovernment and will switch to NISTRev4 if tried in AzureCloud."
+              }
             },
             "logAnalyticsWorkspaceName": {
               "type": "string"
@@ -5609,10 +5609,10 @@
             }
           },
           "variables": {
-            "$fxv#0": "    {\n        \"listOfMembersToExcludeFromWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"admin\"\n        },\n        \"listOfMembersToIncludeInWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"azureuser\"\n        },\n        \"logAnalyticsWorkspaceIdforVMReporting\": \n        {\n        \"value\": \"<LAWORKSPACE>\"\n        },\n        \"IncludeArcMachines\": \n        {\n            \"value\": \"true\"\n        },\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \n        {\n            \"value\": \"1.2\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \n        {\n            \"value\": \"Compliant\"\n        },\n        \"requiredRetentionDays\": \n        {\n            \"value\": \"365\"\n        },\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \n        {\n            \"value\": \"NetworkWatcherRG\"\n        }\n    }",
-            "$fxv#1": "    {\n        \"IncludeArcMachines\": \n        {\n            \"value\": \"true\"\n        },\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \n        {\n            \"value\": \"1.2\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \n        {\n            \"value\": \"Compliant\"\n        },\n        \"requiredRetentionDays\": \n        {\n            \"value\": \"365\"\n        },\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \n        {\n            \"value\": \"NetworkWatcherRG\"\n        }\n    }",
-            "$fxv#2": "{\n    \"IncludeArcMachines\" : { \n        \"value\" : \"false\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\" : { \n        \"value\" : \"Compliant\"\n        },\n        \"MinimumTLSVersionForWindowsServers\" : { \n        \"value\" : \"1.2\"\n        },\n        \"requiredRetentionDays\" : { \n        \"value\" : \"365\"\n        },\n        \"effect-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"audit\"\n        },\n        \"allowedContainerImagesRegex-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"^(.+){0}$\"\n        },\n        \"effect-95edb821-ddaf-4404-9732-666045e056b4\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-440b515e-a580-421e-abeb-b159a61ddcbc\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-233a2a17-77ca-4fb1-9b6b-69223d272a44\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"audit\"\n        },\n        \"cpuLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"memoryLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"effect-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"audit\"\n        },\n        \"runAsUserRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"MustRunAsNonRoot\"\n        },\n        \"runAsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"supplementalGroupsRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"fsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"effect-1c6e92c9-99f0-4e55-9cf2-0c234dc48f99\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-47a1ee2f-2a2a-4576-bf2a-e0e36709c2b8\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-df49d893-a74c-421d-bc95-c663042e5b80\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-1a5b4dca-0b6f-4cf5-907c-56316bc1bf3d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-c26596ff-4d70-4e6a-9a30-c2506bd2f80c\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-511f5417-5d12-434d-ab2e-816901e72a5e\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-82985f06-dc18-4a48-bc1c-b9f4f0098cfe\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-098fc59e-46c7-4d99-9b16-64990e543d75\" : { \n        \"value\" : \"audit\"\n        },\n        \"NetworkWatcherResourceGroupName\" : { \n        \"value\" : \"NetworkWatcherRG\"\n        },\n        \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n        \"value\" : \"enabled\"\n        },\n        \"aadAuthenticationInServiceFabricMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-71ef260a-8f18-47b7-abcb-62d0673d94dc\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-862e97cf-49fc-4a5c-9de4-40d4e2e7c8eb\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d9da03a1-f3c3-412a-9709-947156872263\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-b4ac1030-89c5-4697-8e00-28b5ba6a8811\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-ea0dfaed-95fb-448c-934e-d6e713ce393d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-41425d9f-d1a5-499a-9932-f8ed8453932c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fc4d8e41-e223-45ea-9bf5-eada37891d87\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-86efb160-8de7-451d-bc08-5d475b0aadae\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-4ec52d6d-beb7-40c4-9a9e-fe753254690e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-64d314f6-6062-4780-a861-c23e8951bee5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fd32ebd-e4c3-4e13-a54a-d7422d4d95f6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fa298e57-9444-42ba-bf04-86e8470e32c7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f905d99-2ab7-462c-a6b0-f709acca6c8f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ba769a63-b8cc-4b2d-abf6-ac33c7204be8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0aa61e00-0a01-4a3c-9945-e93cffedf0e6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-47031206-ce96-41f8-861b-6a915f3de284\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-51522a96-0869-4791-82f3-981000c2c67f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-b5ec538c-daa0-4006-8596-35468b9148e8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-56a5ee18-2ae6-4810-86f7-18e39ce5629b\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2e94d99a-8a36-4563-bc77-810d8893b671\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fafeaf6-7927-4059-a50a-8eb2a7a6f2b5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-99e9ccd8-3db9-4592-b0d1-14b1715a4d8a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f68a601-6e6d-4e42-babf-3f643a047ea2\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ca91455f-eace-4f96-be59-e6e2c35b4816\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-702dd420-7fcc-42c5-afe8-4026edd20fe0\" : { \n        \"value\" : \"Audit\"\n        },\n        \"diagnosticsLogsInRedisCacheMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"secureTransferToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d092e0a-7acd-40d2-a975-dca21cae48c4\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"disableUnrestrictedNetworkToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-55615ac9-af46-4a59-874e-391cc3dfb490\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1b8ca024-1d5c-4dec-8995-b1a932b41780\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-53503636-bcc9-4748-9663-5348217f160f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-40cec1dd-a100-4920-b15b-3024fe8901ab\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-a049bf77-880b-470f-ba6d-9f21c530cf83\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ee980b6d-0eca-4501-8d54-f6290fd512c3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1d84d5fb-01f6-4d12-ba4f-4a26081d403d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-37e0d2fe-28a5-43d6-a273-67d37d1f5606\" : { \n        \"value\" : \"Audit\"\n        },\n        \"identityDesignateMoreThanOneOwnerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"diskEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"emailNotificationToSubscriptionOwnerHighSeverityAlertsEnabledEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlDbEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"aadAuthenticationInSqlServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssEndpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssOsVulnerabilitiesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"adaptiveApplicationControlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForPostgreSQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensureJavaVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityDesignateLessThanOwnersMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"securityContactEmailAddressForSubscriptionEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRestrictCORSAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensurePythonVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForMySQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"systemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"nextGenerationFirewallMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"useRbacRulesMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"webAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlServerAuditingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vnetEnableDDoSProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlServerAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"endpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"jitNetworkAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"geoRedundantStorageShouldBeEnabledForStorageAccountsEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"vmssSystemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"longtermGeoRedundantBackupEnabledAzureSQLDatabasesEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"systemConfigurationsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"containerBenchmarkMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"kubernetesServiceVersionUpToDateMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlDbVulnerabilityAssesmentMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"membersToIncludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"membersToExcludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"logAnalyticsWorkspaceIDForVMAgents\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n        },\n        \"PHPLatestVersionForAppServices\" : { \n        \"value\" : \"7.4\"\n        },\n        \"JavaLatestVersionForAppServices\" : { \n        \"value\" : \"11\"\n        },\n        \"WindowsPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.6\"\n        },\n        \"LinuxPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.9\"\n        },\n        \"ensureDotNetFrameworkLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"vulnerabilityAssessmentMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForWebAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"microsoftIaaSAntimalwareExtensionShouldBeDeployedOnWindowsServersEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityCenterStandardPricingTierShouldBeSelectedEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachinesEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensurePHPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityContactPhoneNumberShouldBeProvidedForSubscriptionEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForAPIAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnServerMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachineScaleSetsEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        }\n}",
-            "$fxv#3": "{\n    \"logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n    },\n    \"effect-09024ccc-0c5f-475e-9457-b7c0d9ed487b\" : { \n        \"value\" : \"AuditIfNotExists\"\n    },\n    \"MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f\" :{\n        \"value\": \"\"\n    },\n    \"MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7\": {\n        \"value\": \"\"\n    },\n    \"effect-0961003e-5a0a-4549-abde-af6a37f2724d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b15565f-aa9e-48ba-8619-45960f2c314d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0e60b895-3786-45da-8377-9c6b4b6ac5f9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-17k78e20-9358-41c9-923c-fb736d382a12\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1bc1795e-d44a-4d48-9b3b-6fff0fd5f9ba\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"PHPLatestVersion\" : { \n    \"value\" : \"7.3\"\n    },\n    \"effect-22bee202-a82f-4305-9a2a-6d7f44d4dedb\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-26a828e1-e88f-464e-bbb3-c134a282b9de\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-34c877ad-507e-4c82-993e-3452a6e0ad3c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3c735d8a-a4ba-4a3a-b7cf-db7754cf57f4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-404c3081-a854-4457-ae30-26a93ef643f9\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-47a6b606-51aa-4496-8bb7-64b11cf66adc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-496223c3-ad65-4ecd-878a-bae78737e9ed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"JavaLatestVersion\" : { \n    \"value\" : \"11\"\n    },\n    \"effect-4f11b553-d42e-4e3a-89be-32ca364cad4c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4f4f78b8-e367-4b10-a341-d9a4ad5cf1c7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5c607a2e-c700-4744-8254-d77e7c9eb5e4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5f76cf89-fbf2-47fd-a3f4-b891fa780b60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6b1cbf55-e8b6-442f-ba4c-7246b6381474\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6d555dd1-86f2-4f1c-8ed7-5abae7c6cbab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7008174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"LinuxPythonLatestVersion\" : { \n    \"value\" : \"3.8\"\n    },\n    \"effect-7238174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7261b898-8a84-4db8-9e04-18527132abb3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-74c3584d-afae-46f7-a20a-6f8adba71a16\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-86b3d65f-7626-441e-b690-81a8b71cff60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-88999f4c-376a-45c8-bcb3-4058f713cf39\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8c122334-9d20-4eb8-89ea-ac9a705b74ae\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8cb6aa8b-9e41-4f4e-aa25-089a7ac2581e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9297c21d-2ed6-4474-b48f-163f75654ce3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-991310cd-e9f3-47bc-b7b6-f57b557d07db\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9b597639-28e4-48eb-b506-56b05d366257\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9d0b6ea4-93e2-4578-bf2f-6bb17d22b4bc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9daedab3-fb2d-461e-b861-71790eead4f6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a4af4a39-4135-47fb-b175-47fbdf85311d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"enabled\"\n    },\n    \"effect-a70ca396-0a34-413a-88e1-b956c1e683be\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-aa633080-8b72-40c4-a2d7-d00c03e80bed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb4388-5bf4-4ad7-ba82-2cd2f41ceae9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb7388-5bf4-4ad7-ba99-2cd2f41cebb9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-af6cd1bd-1635-48cb-bde7-5b15693900b9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\" : { \n    \"value\" : \"NetworkWatcherRG\"\n    },\n    \"effect-b7ddfbdc-1260-477d-91fd-98bd9be789a6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c3f317a7-a95c-4547-b7e7-11017ebdf2fe\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-cb510bfd-1cba-4d9f-a230-cb0976f4bb71\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e2c1c086-2d84-4019-bff3-c44ccd95113c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e3576e28-8b17-4677-84c3-db2990658d64\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e8cbc669-f12d-49eb-93e7-9273119e9933\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e9c8d085-d9cc-4b17-9cdc-059f1f01f19e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ebb62a0c-3560-49e1-89ed-27e074e9f8ad\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-efbde977-ba53-4479-b8e9-10b957924fbf\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f0e6e85b-9b9f-4a4b-b67b-f730d42f1b0b\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f6de0be7-9a8a-4b8a-b349-43cf02d22f7c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f8456c1c-aa66-4dfb-861a-25d127b775c9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f9d614c5-c173-4d56-95a7-b4437057d193\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-fb893a29-21bb-418c-a157-e99480ec364c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-feedbf84-6b99-488c-acc2-71c829aa5ffc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-3b980d31-7904-4bb7-8575-5665739a8052\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6e2593d9-add6-4083-9c9b-4b7d2188c899\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b607c5de-e7d9-4eee-9e5c-83f1bcee4fa0\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-013e242c-8828-4970-87b3-ab247555486d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d38fc420-0735-4ef3-ac11-c806f651a570\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a1181c5f-672a-477a-979a-7d58aa086233\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-308fbb08-4ab8-4e67-9b29-592e93fb94fa\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4da35fc9-c9e7-4960-aec9-797fe7d9051d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-523b5cd1-3e23-492f-a539-13118b6d1e3a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7fe3b40f-802b-4cdd-8bd4-fd799c948cc2\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c25d9a16-bc35-4e15-a7e5-9db606bf9ed4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b0f33259-77d7-4c9e-aac6-3aabcfae693c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0820b7b9-23aa-4725-a1ce-ae4558f718e5\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-358c20a6-3f9e-4f0e-97ff-c6ce485e2aac\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5744710e-cc2f-4ee8-8809-3b11e89f4bc9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ac4a19c2-fa67-49b4-8ae5-0b2e78c49457\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c9d007d0-c057-4772-b18c-01e546713bcd\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e372f825-a257-4fb8-9175-797a8a8627d6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d158790f-bfb0-486c-8631-2dc6b4e8e6af\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e802a67a-daf5-4436-9ea6-f6d821dd0c5d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a451c1ef-c6ca-483d-87ed-f49761e3ffb5\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftSql-servers-firewallRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ae89ebca-1c92-4898-ac2c-9f63decb045c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d26f7642-7545-4e18-9b75-8c9bbdee3a9a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1a4e592a-6a6e-44a5-9814-e36264ca96e7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7796937f-307b-4598-941c-67d3a05ebfe7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c5447c04-a4d7-4ba8-a263-c9ee321a6858\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-41388f1c-2db0-4c25-95b2-35d7f5ccbfa9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b02aacc0-b073-424e-8298-42b22829ee0a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-057d6cfe-9c4f-4a6d-bc60-14420ea1f1a9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0ec47710-77ff-4a3d-9181-6aa50af424d0\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-48af4db5-9b8b-401c-8e74-076be876a430\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-82339799-d096-41ae-8538-b108becf0970\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1b7aa243-30e4-4c9e-bca8-d0d3022b634a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ef2a8f2a-b3d9-49cd-a8a8-9a3aaaf647d9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-bb91dfba-c30d-4263-9add-9c2384e659a6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e71308d3-144b-4262-b144-efdc3cc90517\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2bdd0062-9d75-436e-89df-487dd8e4b3c7\" : { \n    \"value\" : \"Disabled\"\n    },\n    \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-6fac406b-40ca-413b-bf8e-0bf964659c25\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-048248b0-55cd-46da-b1ff-39efd52db260\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0d134df8-db83-46fb-ad72-fe0c9428c8dd\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fb2\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n    \"value\" : \"audit\"\n    },\n    \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c43e4a30-77cb-48ab-a4dd-93f175c63b57\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1f314764-cb73-4fc9-b863-8eca98ac36e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-123a3936-f020-408a-ba0c-47873faf1534\" : { \n    \"value\" : \"AuditIfNotExists\"\n    }\n}\n",
+            "$fxv#0": "    {\r\n        \"listOfMembersToExcludeFromWindowsVMAdministratorsGroup\": \r\n        {\r\n        \"value\": \"admin\"\r\n        },\r\n        \"listOfMembersToIncludeInWindowsVMAdministratorsGroup\": \r\n        {\r\n        \"value\": \"azureuser\"\r\n        },\r\n        \"logAnalyticsWorkspaceIdforVMReporting\": \r\n        {\r\n        \"value\": \"<LAWORKSPACE>\"\r\n        },\r\n        \"IncludeArcMachines\": \r\n        {\r\n            \"value\": \"true\"\r\n        },\r\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \r\n        {\r\n            \"value\": \"1.2\"\r\n        },\r\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \r\n        {\r\n            \"value\": \"Compliant\"\r\n        },\r\n        \"requiredRetentionDays\": \r\n        {\r\n            \"value\": \"365\"\r\n        },\r\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \r\n        {\r\n            \"value\": \"NetworkWatcherRG\"\r\n        }\r\n    }",
+            "$fxv#1": "    {\r\n        \"IncludeArcMachines\": \r\n        {\r\n            \"value\": \"true\"\r\n        },\r\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \r\n        {\r\n            \"value\": \"1.2\"\r\n        },\r\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \r\n        {\r\n            \"value\": \"Compliant\"\r\n        },\r\n        \"requiredRetentionDays\": \r\n        {\r\n            \"value\": \"365\"\r\n        },\r\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \r\n        {\r\n            \"value\": \"NetworkWatcherRG\"\r\n        }\r\n    }",
+            "$fxv#2": "{\r\n    \"IncludeArcMachines\" : { \r\n        \"value\" : \"false\"\r\n        },\r\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\" : { \r\n        \"value\" : \"Compliant\"\r\n        },\r\n        \"MinimumTLSVersionForWindowsServers\" : { \r\n        \"value\" : \"1.2\"\r\n        },\r\n        \"requiredRetentionDays\" : { \r\n        \"value\" : \"365\"\r\n        },\r\n        \"effect-febd0533-8e55-448f-b837-bd0e06f16469\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"allowedContainerImagesRegex-febd0533-8e55-448f-b837-bd0e06f16469\" : { \r\n        \"value\" : \"^(.+){0}$\"\r\n        },\r\n        \"effect-95edb821-ddaf-4404-9732-666045e056b4\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-440b515e-a580-421e-abeb-b159a61ddcbc\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-233a2a17-77ca-4fb1-9b6b-69223d272a44\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"cpuLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \r\n        \"value\" : \"0\"\r\n        },\r\n        \"memoryLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \r\n        \"value\" : \"0\"\r\n        },\r\n        \"effect-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"runAsUserRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"MustRunAsNonRoot\"\r\n        },\r\n        \"runAsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"RunAsAny\"\r\n        },\r\n        \"supplementalGroupsRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"RunAsAny\"\r\n        },\r\n        \"fsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"RunAsAny\"\r\n        },\r\n        \"effect-1c6e92c9-99f0-4e55-9cf2-0c234dc48f99\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-47a1ee2f-2a2a-4576-bf2a-e0e36709c2b8\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-df49d893-a74c-421d-bc95-c663042e5b80\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-1a5b4dca-0b6f-4cf5-907c-56316bc1bf3d\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-c26596ff-4d70-4e6a-9a30-c2506bd2f80c\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-511f5417-5d12-434d-ab2e-816901e72a5e\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-82985f06-dc18-4a48-bc1c-b9f4f0098cfe\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-098fc59e-46c7-4d99-9b16-64990e543d75\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"NetworkWatcherResourceGroupName\" : { \r\n        \"value\" : \"NetworkWatcherRG\"\r\n        },\r\n        \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \r\n        \"value\" : \"enabled\"\r\n        },\r\n        \"aadAuthenticationInServiceFabricMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-71ef260a-8f18-47b7-abcb-62d0673d94dc\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-862e97cf-49fc-4a5c-9de4-40d4e2e7c8eb\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-d9da03a1-f3c3-412a-9709-947156872263\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-b4ac1030-89c5-4697-8e00-28b5ba6a8811\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-ea0dfaed-95fb-448c-934e-d6e713ce393d\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-41425d9f-d1a5-499a-9932-f8ed8453932c\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-fc4d8e41-e223-45ea-9bf5-eada37891d87\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-86efb160-8de7-451d-bc08-5d475b0aadae\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-4ec52d6d-beb7-40c4-9a9e-fe753254690e\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-64d314f6-6062-4780-a861-c23e8951bee5\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1fd32ebd-e4c3-4e13-a54a-d7422d4d95f6\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-fa298e57-9444-42ba-bf04-86e8470e32c7\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1f905d99-2ab7-462c-a6b0-f709acca6c8f\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-ba769a63-b8cc-4b2d-abf6-ac33c7204be8\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-0aa61e00-0a01-4a3c-9945-e93cffedf0e6\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-47031206-ce96-41f8-861b-6a915f3de284\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-51522a96-0869-4791-82f3-981000c2c67f\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-b5ec538c-daa0-4006-8596-35468b9148e8\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-56a5ee18-2ae6-4810-86f7-18e39ce5629b\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-2e94d99a-8a36-4563-bc77-810d8893b671\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1fafeaf6-7927-4059-a50a-8eb2a7a6f2b5\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-99e9ccd8-3db9-4592-b0d1-14b1715a4d8a\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1f68a601-6e6d-4e42-babf-3f643a047ea2\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-ca91455f-eace-4f96-be59-e6e2c35b4816\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-702dd420-7fcc-42c5-afe8-4026edd20fe0\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"diagnosticsLogsInRedisCacheMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"secureTransferToStorageAccountMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-7d092e0a-7acd-40d2-a975-dca21cae48c4\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"disableUnrestrictedNetworkToStorageAccountMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-55615ac9-af46-4a59-874e-391cc3dfb490\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1b8ca024-1d5c-4dec-8995-b1a932b41780\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-53503636-bcc9-4748-9663-5348217f160f\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-40cec1dd-a100-4920-b15b-3024fe8901ab\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-a049bf77-880b-470f-ba6d-9f21c530cf83\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-ee980b6d-0eca-4501-8d54-f6290fd512c3\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1d84d5fb-01f6-4d12-ba4f-4a26081d403d\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-37e0d2fe-28a5-43d6-a273-67d37d1f5606\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"identityDesignateMoreThanOneOwnerMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"diskEncryptionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"emailNotificationToSubscriptionOwnerHighSeverityAlertsEnabledEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"functionAppDisableRemoteDebuggingMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"sqlDbEncryptionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vulnerabilityAssessmentOnManagedInstanceMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensurePHPVersionLatestForAPIAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"aadAuthenticationInSqlServerMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vmssEndpointProtectionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vmssOsVulnerabilitiesMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"adaptiveApplicationControlsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForPostgreSQLEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"ensureJavaVersionLatestForWebAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityDesignateLessThanOwnersMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"securityContactEmailAddressForSubscriptionEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"webAppRestrictCORSAccessMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveDeprecatedAccountMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"functionAppEnforceHttpsMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"ensurePythonVersionLatestForWebAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensurePythonVersionLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensurePHPVersionLatestForWebAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensurePythonVersionLatestForAPIAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForMySQLEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"systemUpdatesMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureJavaVersionLatestForAPIAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureHTTPVersionLatestForWebAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"apiAppRequireLatestTlsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityEnableMFAForWritePermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureHTTPVersionLatestForAPIAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureJavaVersionLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"nextGenerationFirewallMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"useRbacRulesMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"webAppEnforceHttpsMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"sqlServerAuditingMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vnetEnableDDoSProtectionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityEnableMFAForOwnerPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"sqlServerAdvancedDataSecurityMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"sqlManagedInstanceAdvancedDataSecurityMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"endpointProtectionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"jitNetworkAccessMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"apiAppEnforceHttpsMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"geoRedundantStorageShouldBeEnabledForStorageAccountsEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"vmssSystemUpdatesMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"webAppDisableRemoteDebuggingMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"longtermGeoRedundantBackupEnabledAzureSQLDatabasesEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"systemConfigurationsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureHTTPVersionLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityEnableMFAForReadPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"containerBenchmarkMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"apiAppDisableRemoteDebuggingMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vulnerabilityAssessmentOnServerMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"webAppRequireLatestTlsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"functionAppRequireLatestTlsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"kubernetesServiceVersionUpToDateMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"sqlDbVulnerabilityAssesmentMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"membersToIncludeInLocalAdministratorsGroup\" : { \r\n        \"value\" : \"\"\r\n        },\r\n        \"membersToExcludeInLocalAdministratorsGroup\" : { \r\n        \"value\" : \"\"\r\n        },\r\n        \"logAnalyticsWorkspaceIDForVMAgents\" : { \r\n        \"value\" : \"<LAWORKSPACE>\"\r\n        },\r\n        \"PHPLatestVersionForAppServices\" : { \r\n        \"value\" : \"7.4\"\r\n        },\r\n        \"JavaLatestVersionForAppServices\" : { \r\n        \"value\" : \"11\"\r\n        },\r\n        \"WindowsPythonLatestVersionForAppServices\" : { \r\n        \"value\" : \"3.6\"\r\n        },\r\n        \"LinuxPythonLatestVersionForAppServices\" : { \r\n        \"value\" : \"3.9\"\r\n        },\r\n        \"ensureDotNetFrameworkLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"vulnerabilityAssessmentMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"ensureDotNetFrameworkLatestForWebAppEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"sqlServerAdvancedDataSecurityEmailsMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"microsoftIaaSAntimalwareExtensionShouldBeDeployedOnWindowsServersEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"securityCenterStandardPricingTierShouldBeSelectedEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachinesEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"ensurePHPVersionLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"securityContactPhoneNumberShouldBeProvidedForSubscriptionEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"threatDetectionTypesOnManagedInstanceMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"ensureDotNetFrameworkLatestForAPIAppEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"threatDetectionTypesOnServerMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachineScaleSetsEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        }\r\n}",
+            "$fxv#3": "{\r\n    \"logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917\" : { \r\n        \"value\" : \"<LAWORKSPACE>\"\r\n    },\r\n    \"effect-09024ccc-0c5f-475e-9457-b7c0d9ed487b\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f\" :{\r\n        \"value\": \"\"\r\n    },\r\n    \"MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7\": {\r\n        \"value\": \"\"\r\n    },\r\n    \"effect-0961003e-5a0a-4549-abde-af6a37f2724d\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0b15565f-aa9e-48ba-8619-45960f2c314d\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0e60b895-3786-45da-8377-9c6b4b6ac5f9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-17k78e20-9358-41c9-923c-fb736d382a12\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-1bc1795e-d44a-4d48-9b3b-6fff0fd5f9ba\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"PHPLatestVersion\" : { \r\n    \"value\" : \"7.3\"\r\n    },\r\n    \"effect-22bee202-a82f-4305-9a2a-6d7f44d4dedb\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-26a828e1-e88f-464e-bbb3-c134a282b9de\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-34c877ad-507e-4c82-993e-3452a6e0ad3c\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-3c735d8a-a4ba-4a3a-b7cf-db7754cf57f4\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-404c3081-a854-4457-ae30-26a93ef643f9\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-47a6b606-51aa-4496-8bb7-64b11cf66adc\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-496223c3-ad65-4ecd-878a-bae78737e9ed\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"JavaLatestVersion\" : { \r\n    \"value\" : \"11\"\r\n    },\r\n    \"effect-4f11b553-d42e-4e3a-89be-32ca364cad4c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-4f4f78b8-e367-4b10-a341-d9a4ad5cf1c7\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-5c607a2e-c700-4744-8254-d77e7c9eb5e4\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-5f76cf89-fbf2-47fd-a3f4-b891fa780b60\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-6b1cbf55-e8b6-442f-ba4c-7246b6381474\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-6d555dd1-86f2-4f1c-8ed7-5abae7c6cbab\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-7008174a-fd10-4ef0-817e-fc820a951d73\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"LinuxPythonLatestVersion\" : { \r\n    \"value\" : \"3.8\"\r\n    },\r\n    \"effect-7238174a-fd10-4ef0-817e-fc820a951d73\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-7261b898-8a84-4db8-9e04-18527132abb3\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-74c3584d-afae-46f7-a20a-6f8adba71a16\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-86b3d65f-7626-441e-b690-81a8b71cff60\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-88999f4c-376a-45c8-bcb3-4058f713cf39\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-8c122334-9d20-4eb8-89ea-ac9a705b74ae\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-8cb6aa8b-9e41-4f4e-aa25-089a7ac2581e\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-9297c21d-2ed6-4474-b48f-163f75654ce3\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-991310cd-e9f3-47bc-b7b6-f57b557d07db\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-9b597639-28e4-48eb-b506-56b05d366257\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-9d0b6ea4-93e2-4578-bf2f-6bb17d22b4bc\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-9daedab3-fb2d-461e-b861-71790eead4f6\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-a4af4a39-4135-47fb-b175-47fbdf85311d\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \r\n    \"value\" : \"enabled\"\r\n    },\r\n    \"effect-a70ca396-0a34-413a-88e1-b956c1e683be\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-aa633080-8b72-40c4-a2d7-d00c03e80bed\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-abfb4388-5bf4-4ad7-ba82-2cd2f41ceae9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-abfb7388-5bf4-4ad7-ba99-2cd2f41cebb9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-af6cd1bd-1635-48cb-bde7-5b15693900b9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\" : { \r\n    \"value\" : \"NetworkWatcherRG\"\r\n    },\r\n    \"effect-b7ddfbdc-1260-477d-91fd-98bd9be789a6\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-c3f317a7-a95c-4547-b7e7-11017ebdf2fe\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-cb510bfd-1cba-4d9f-a230-cb0976f4bb71\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e2c1c086-2d84-4019-bff3-c44ccd95113c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e3576e28-8b17-4677-84c3-db2990658d64\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e8cbc669-f12d-49eb-93e7-9273119e9933\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e9c8d085-d9cc-4b17-9cdc-059f1f01f19e\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-ebb62a0c-3560-49e1-89ed-27e074e9f8ad\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-efbde977-ba53-4479-b8e9-10b957924fbf\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-f0e6e85b-9b9f-4a4b-b67b-f730d42f1b0b\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-f6de0be7-9a8a-4b8a-b349-43cf02d22f7c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-f8456c1c-aa66-4dfb-861a-25d127b775c9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-f9d614c5-c173-4d56-95a7-b4437057d193\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-fb893a29-21bb-418c-a157-e99480ec364c\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-feedbf84-6b99-488c-acc2-71c829aa5ffc\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-3b980d31-7904-4bb7-8575-5665739a8052\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-6e2593d9-add6-4083-9c9b-4b7d2188c899\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b607c5de-e7d9-4eee-9e5c-83f1bcee4fa0\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"modeRequirement-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \r\n    \"value\" : \"Detection\"\r\n    },\r\n    \"effect-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"modeRequirement-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \r\n    \"value\" : \"Detection\"\r\n    },\r\n    \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-013e242c-8828-4970-87b3-ab247555486d\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-d38fc420-0735-4ef3-ac11-c806f651a570\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-a1181c5f-672a-477a-979a-7d58aa086233\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-308fbb08-4ab8-4e67-9b29-592e93fb94fa\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-4da35fc9-c9e7-4960-aec9-797fe7d9051d\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-523b5cd1-3e23-492f-a539-13118b6d1e3a\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-7fe3b40f-802b-4cdd-8bd4-fd799c948cc2\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-c25d9a16-bc35-4e15-a7e5-9db606bf9ed4\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b0f33259-77d7-4c9e-aac6-3aabcfae693c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-0820b7b9-23aa-4725-a1ce-ae4558f718e5\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fab\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-358c20a6-3f9e-4f0e-97ff-c6ce485e2aac\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-5744710e-cc2f-4ee8-8809-3b11e89f4bc9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-ac4a19c2-fa67-49b4-8ae5-0b2e78c49457\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-c9d007d0-c057-4772-b18c-01e546713bcd\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-e372f825-a257-4fb8-9175-797a8a8627d6\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-d158790f-bfb0-486c-8631-2dc6b4e8e6af\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-e802a67a-daf5-4436-9ea6-f6d821dd0c5d\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-a451c1ef-c6ca-483d-87ed-f49761e3ffb5\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftSql-servers-firewallRules-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-securityRules-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-securityRules-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-ae89ebca-1c92-4898-ac2c-9f63decb045c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-d26f7642-7545-4e18-9b75-8c9bbdee3a9a\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-1a4e592a-6a6e-44a5-9814-e36264ca96e7\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-7796937f-307b-4598-941c-67d3a05ebfe7\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-c5447c04-a4d7-4ba8-a263-c9ee321a6858\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-41388f1c-2db0-4c25-95b2-35d7f5ccbfa9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b02aacc0-b073-424e-8298-42b22829ee0a\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-057d6cfe-9c4f-4a6d-bc60-14420ea1f1a9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0ec47710-77ff-4a3d-9181-6aa50af424d0\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-48af4db5-9b8b-401c-8e74-076be876a430\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-82339799-d096-41ae-8538-b108becf0970\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-1b7aa243-30e4-4c9e-bca8-d0d3022b634a\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-ef2a8f2a-b3d9-49cd-a8a8-9a3aaaf647d9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-bb91dfba-c30d-4263-9add-9c2384e659a6\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e71308d3-144b-4262-b144-efdc3cc90517\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-2bdd0062-9d75-436e-89df-487dd8e4b3c7\" : { \r\n    \"value\" : \"Disabled\"\r\n    },\r\n    \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-6fac406b-40ca-413b-bf8e-0bf964659c25\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-048248b0-55cd-46da-b1ff-39efd52db260\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0d134df8-db83-46fb-ad72-fe0c9428c8dd\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fb2\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \r\n    \"value\" : \"audit\"\r\n    },\r\n    \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-c43e4a30-77cb-48ab-a4dd-93f175c63b57\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-1f314764-cb73-4fc9-b863-8eca98ac36e9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-123a3936-f020-408a-ba0c-47873faf1534\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    }\r\n}\r\n",
             "modifiedAssignment": "[if(and(equals(toLower(environment().name), toLower('AzureCloud')), equals(toLower(parameters('builtInAssignment')), toLower('IL5'))), 'NISTRev4', parameters('builtInAssignment'))]",
             "assignmentName": "[format('{0} {1}', variables('modifiedAssignment'), resourceGroup().name)]",
             "agentVmssAssignmentName": "[format('Deploy VMSS Agents {0}', resourceGroup().name)]",
@@ -5722,7 +5722,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('Assign-Laws-Role-Policy-{0}', resourceGroup().name)]",
               "subscriptionId": "[parameters('operationsSubscriptionId')]",
               "resourceGroup": "[parameters('logAnalyticsWorkspaceResourceGroupName')]",
@@ -5748,8 +5748,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "15761836246481461949"
+                      "version": "0.24.24.22086",
+                      "templateHash": "8686326864657481429"
                     }
                   },
                   "parameters": {
@@ -5805,7 +5805,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "azure-private-dns",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
       "resourceGroup": "[variables('hubResourceGroupName')]",
@@ -5816,7 +5816,7 @@
         "mode": "Incremental",
         "parameters": {
           "vnetName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.virtualNetworkName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.virtualNetworkName.value]"
           },
           "tags": {
             "value": "[parameters('tags')]"
@@ -5828,8 +5828,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "6749325396712016817"
+              "version": "0.24.24.22086",
+              "templateHash": "4602601230334937372"
             }
           },
           "parameters": {
@@ -5861,6 +5861,13 @@
             }
           },
           "variables": {
+            "copy": [
+              {
+                "name": "privatelink_backup_names",
+                "count": "[length(items(variables('locations')))]",
+                "input": "[format('privatelink.backup.{0}.{1}', items(variables('locations'))[copyIndex('privatelink_backup_names')].value.recoveryServicesGeo, variables('cloudSuffix'))]"
+              }
+            ],
             "$fxv#0": {
               "AzureChina": {
                 "chinaeast": {
@@ -6245,13 +6252,6 @@
                 }
               }
             },
-            "copy": [
-              {
-                "name": "privatelink_backup_names",
-                "count": "[length(items(variables('locations')))]",
-                "input": "[format('privatelink.backup.{0}.{1}', items(variables('locations'))[copyIndex('privatelink_backup_names')].value.recoveryServicesGeo, variables('cloudSuffix'))]"
-              }
-            ],
             "cloudSuffix": "[replace(replace(environment().resourceManager, 'https://management.', ''), '/', '')]",
             "automationSuffix": "[replace(environment().suffixes.storage, 'core.windows.', '')]",
             "locations": "[variables('$fxv#0')[environment().name]]",
@@ -6283,11 +6283,11 @@
               "tags": "[parameters('tags')]"
             },
             {
-              "condition": "[not(contains(variables('privatelink_backup_names')[copyIndex()], '..'))]",
               "copy": {
                 "name": "privateDnsZone_backup_rsv",
                 "count": "[length(variables('privatelink_backup_names'))]"
               },
+              "condition": "[not(contains(variables('privatelink_backup_names')[copyIndex()], '..'))]",
               "type": "Microsoft.Network/privateDnsZones",
               "apiVersion": "2018-09-01",
               "name": "[variables('privatelink_backup_names')[copyIndex()]]",
@@ -6603,7 +6603,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('activity-logs-hub-{0}', parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
       "location": "[deployment().location]",
@@ -6614,10 +6614,10 @@
         "mode": "Incremental",
         "parameters": {
           "diagnosticSettingName": {
-            "value": "[format('log-hub-sub-activity-to-{0}', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.name.value)]"
+            "value": "[format('log-hub-sub-activity-to-{0}', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.name.value)]"
           },
           "logAnalyticsWorkspaceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.id.value]"
           }
         },
         "template": {
@@ -6626,8 +6626,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "4564752438272570911"
+              "version": "0.24.24.22086",
+              "templateHash": "3850477028148266020"
             }
           },
           "parameters": {
@@ -6700,7 +6700,7 @@
     {
       "condition": "[contains(parameters('supportedClouds'), environment().name)]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "azure-monitor-private-link",
       "subscriptionId": "[parameters('operationsSubscriptionId')]",
       "resourceGroup": "[variables('operationsResourceGroupName')]",
@@ -6711,10 +6711,10 @@
         "mode": "Incremental",
         "parameters": {
           "logAnalyticsWorkspaceName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.name.value]"
           },
           "logAnalyticsWorkspaceResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.id.value]"
           },
           "privateEndpointSubnetName": {
             "value": "[variables('operationsSubnetName')]"
@@ -6723,16 +6723,16 @@
             "value": "[variables('operationsVirtualNetworkName')]"
           },
           "monitorPrivateDnsZoneId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', 'azure-private-dns')).outputs.monitorPrivateDnsZoneId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', 'azure-private-dns'), '2022-09-01').outputs.monitorPrivateDnsZoneId.value]"
           },
           "omsPrivateDnsZoneId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', 'azure-private-dns')).outputs.omsPrivateDnsZoneId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', 'azure-private-dns'), '2022-09-01').outputs.omsPrivateDnsZoneId.value]"
           },
           "odsPrivateDnsZoneId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', 'azure-private-dns')).outputs.odsPrivateDnsZoneId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', 'azure-private-dns'), '2022-09-01').outputs.odsPrivateDnsZoneId.value]"
           },
           "agentsvcPrivateDnsZoneId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', 'azure-private-dns')).outputs.agentsvcPrivateDnsZoneId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', 'azure-private-dns'), '2022-09-01').outputs.agentsvcPrivateDnsZoneId.value]"
           },
           "location": {
             "value": "[parameters('location')]"
@@ -6747,8 +6747,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "10271763324309057378"
+              "version": "0.24.24.22086",
+              "templateHash": "8401513239082999873"
             }
           },
           "parameters": {
@@ -6933,13 +6933,13 @@
       ]
     },
     {
-      "condition": "[not(equals(variables('spokes')[copyIndex()].subscriptionId, parameters('hubSubscriptionId')))]",
       "copy": {
         "name": "spokeSubscriptionActivityLogging",
         "count": "[length(variables('spokes'))]"
       },
+      "condition": "[not(equals(variables('spokes')[copyIndex()].subscriptionId, parameters('hubSubscriptionId')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('activity-logs-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "location": "[deployment().location]",
@@ -6950,10 +6950,10 @@
         "mode": "Incremental",
         "parameters": {
           "diagnosticSettingName": {
-            "value": "[format('log-{0}-sub-activity-to-{1}', variables('spokes')[copyIndex()].name, reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.name.value)]"
+            "value": "[format('log-{0}-sub-activity-to-{1}', variables('spokes')[copyIndex()].name, reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.name.value)]"
           },
           "logAnalyticsWorkspaceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.id.value]"
           }
         },
         "template": {
@@ -6962,8 +6962,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "4564752438272570911"
+              "version": "0.24.24.22086",
+              "templateHash": "3850477028148266020"
             }
           },
           "parameters": {
@@ -7035,7 +7035,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('deploy-diagnostic-logging-{0}', parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[parameters('operationsSubscriptionId')]",
       "resourceGroup": "[variables('operationsResourceGroupName')]",
@@ -7049,7 +7049,7 @@
             "value": "[variables('operationsLogStorageAccountName')]"
           },
           "logAnalyticsWorkspaceName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.name.value]"
           }
         },
         "template": {
@@ -7058,8 +7058,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "5252752072010358356"
+              "version": "0.24.24.22086",
+              "templateHash": "6866155279282592403"
             }
           },
           "parameters": {
@@ -7113,7 +7113,7 @@
     {
       "condition": "[parameters('deployDefender')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('set-hub-sub-defender-{0}', parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
       "location": "[deployment().location]",
@@ -7124,7 +7124,7 @@
         "mode": "Incremental",
         "parameters": {
           "logAnalyticsWorkspaceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.id.value]"
           },
           "emailSecurityContact": {
             "value": "[parameters('emailSecurityContact')]"
@@ -7139,8 +7139,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "9863600299947422102"
+              "version": "0.24.24.22086",
+              "templateHash": "17349871984393503749"
             }
           },
           "parameters": {
@@ -7258,13 +7258,13 @@
       ]
     },
     {
-      "condition": "[and(parameters('deployDefender'), not(equals(variables('spokes')[copyIndex()].subscriptionId, parameters('hubSubscriptionId'))))]",
       "copy": {
         "name": "spokeDefender",
         "count": "[length(variables('spokes'))]"
       },
+      "condition": "[and(parameters('deployDefender'), not(equals(variables('spokes')[copyIndex()].subscriptionId, parameters('hubSubscriptionId'))))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('set-{0}-sub-defender', variables('spokes')[copyIndex()].name)]",
       "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
       "location": "[deployment().location]",
@@ -7275,7 +7275,7 @@
         "mode": "Incremental",
         "parameters": {
           "logAnalyticsWorkspaceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.id.value]"
           },
           "emailSecurityContact": {
             "value": "[parameters('emailSecurityContact')]"
@@ -7290,8 +7290,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "9863600299947422102"
+              "version": "0.24.24.22086",
+              "templateHash": "17349871984393503749"
             }
           },
           "parameters": {
@@ -7411,7 +7411,7 @@
     {
       "condition": "[parameters('deployRemoteAccess')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('deploy-remote-access-{0}', parameters('deploymentNameSuffix'))]",
       "subscriptionId": "[parameters('hubSubscriptionId')]",
       "resourceGroup": "[variables('hubResourceGroupName')]",
@@ -7425,13 +7425,13 @@
             "value": "[parameters('location')]"
           },
           "hubVirtualNetworkName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.virtualNetworkName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.virtualNetworkName.value]"
           },
           "hubSubnetResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.subnetResourceId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.subnetResourceId.value]"
           },
           "hubNetworkSecurityGroupResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.networkSecurityGroupResourceId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.networkSecurityGroupResourceId.value]"
           },
           "bastionHostName": {
             "value": "[variables('bastionHostName')]"
@@ -7536,7 +7536,7 @@
             "value": "[parameters('windowsVmStorageAccountType')]"
           },
           "logAnalyticsWorkspaceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.id.value]"
           }
         },
         "template": {
@@ -7545,8 +7545,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.10.61.36676",
-              "templateHash": "12263908493790666338"
+              "version": "0.24.24.22086",
+              "templateHash": "850140298199002098"
             }
           },
           "parameters": {
@@ -7631,7 +7631,7 @@
               ]
             },
             "linuxVmAdminPasswordOrKey": {
-              "type": "secureString",
+              "type": "securestring",
               "minLength": 12
             },
             "windowsNetworkInterfaceName": {
@@ -7653,7 +7653,7 @@
               "type": "string"
             },
             "windowsVmAdminPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "minLength": 12
             },
             "windowsVmPublisher": {
@@ -7681,7 +7681,7 @@
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "remoteAccess-bastionHost",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -7726,8 +7726,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "9188768803513020911"
+                      "version": "0.24.24.22086",
+                      "templateHash": "4117826795668037867"
                     }
                   },
                   "parameters": {
@@ -7821,7 +7821,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "remoteAccess-linuxNetworkInterface",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -7857,8 +7857,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "11989297668424739974"
+                      "version": "0.24.24.22086",
+                      "templateHash": "16624262267285514706"
                     }
                   },
                   "parameters": {
@@ -7925,7 +7925,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "remoteAccess-linuxVirtualMachine",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -7973,7 +7973,7 @@
                     "value": "[parameters('linuxVmAdminPasswordOrKey')]"
                   },
                   "networkInterfaceName": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'remoteAccess-linuxNetworkInterface')).outputs.name.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'remoteAccess-linuxNetworkInterface'), '2022-09-01').outputs.name.value]"
                   },
                   "logAnalyticsWorkspaceId": {
                     "value": "[parameters('logAnalyticsWorkspaceId')]"
@@ -7985,8 +7985,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "13732851487663219597"
+                      "version": "0.24.24.22086",
+                      "templateHash": "13305191497922116456"
                     }
                   },
                   "parameters": {
@@ -8035,7 +8035,7 @@
                       ]
                     },
                     "adminPasswordOrKey": {
-                      "type": "secureString",
+                      "type": "securestring",
                       "minLength": 12
                     },
                     "logAnalyticsWorkspaceId": {
@@ -8183,7 +8183,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "remoteAccess-windowsNetworkInterface",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -8219,8 +8219,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "11989297668424739974"
+                      "version": "0.24.24.22086",
+                      "templateHash": "16624262267285514706"
                     }
                   },
                   "parameters": {
@@ -8287,7 +8287,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "remoteAccess-windowsVirtualMachine",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -8332,7 +8332,7 @@
                     "value": "[parameters('windowsVmStorageAccountType')]"
                   },
                   "networkInterfaceName": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'remoteAccess-windowsNetworkInterface')).outputs.name.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'remoteAccess-windowsNetworkInterface'), '2022-09-01').outputs.name.value]"
                   },
                   "logAnalyticsWorkspaceId": {
                     "value": "[parameters('logAnalyticsWorkspaceId')]"
@@ -8344,8 +8344,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.10.61.36676",
-                      "templateHash": "3741703278800278886"
+                      "version": "0.24.24.22086",
+                      "templateHash": "5715082252299512525"
                     }
                   },
                   "parameters": {
@@ -8369,7 +8369,7 @@
                       "type": "string"
                     },
                     "adminPassword": {
-                      "type": "secureString",
+                      "type": "securestring",
                       "minLength": 12
                     },
                     "publisher": {
@@ -8522,6 +8522,7 @@
       "dependsOn": [
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', 'azure-monitor-private-link')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-DNS-{0}', parameters('deploymentNameSuffix')))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))]"
       ]
     }
@@ -8533,21 +8534,21 @@
     },
     "firewallPrivateIPAddress": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.firewallPrivateIPAddress.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.firewallPrivateIPAddress.value]"
     },
     "hub": {
       "type": "object",
       "value": {
         "subscriptionId": "[parameters('hubSubscriptionId')]",
-        "resourceGroupName": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-rg-hub-{0}', parameters('deploymentNameSuffix')))).outputs.name.value]",
-        "resourceGroupResourceId": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-rg-hub-{0}', parameters('deploymentNameSuffix')))).outputs.id.value]",
-        "virtualNetworkName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.virtualNetworkName.value]",
-        "virtualNetworkResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.virtualNetworkResourceId.value]",
-        "subnetName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.subnetName.value]",
-        "subnetResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.subnetResourceId.value]",
-        "subnetAddressPrefix": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.subnetAddressPrefix.value]",
-        "networkSecurityGroupName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.networkSecurityGroupName.value]",
-        "networkSecurityGroupResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix')))).outputs.networkSecurityGroupResourceId.value]"
+        "resourceGroupName": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-rg-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.name.value]",
+        "resourceGroupResourceId": "[reference(subscriptionResourceId(parameters('hubSubscriptionId'), 'Microsoft.Resources/deployments', format('deploy-rg-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.id.value]",
+        "virtualNetworkName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.virtualNetworkName.value]",
+        "virtualNetworkResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.virtualNetworkResourceId.value]",
+        "subnetName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.subnetName.value]",
+        "subnetResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.subnetResourceId.value]",
+        "subnetAddressPrefix": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.subnetAddressPrefix.value]",
+        "networkSecurityGroupName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.networkSecurityGroupName.value]",
+        "networkSecurityGroupResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('hubSubscriptionId'), variables('hubResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vnet-hub-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.networkSecurityGroupResourceId.value]"
       }
     },
     "deployDefender": {
@@ -8560,11 +8561,11 @@
     },
     "logAnalyticsWorkspaceName": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.name.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.name.value]"
     },
     "logAnalyticsWorkspaceResourceId": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix')))).outputs.id.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('operationsSubscriptionId'), variables('operationsResourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-laws-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.id.value]"
     },
     "diagnosticStorageAccountName": {
       "type": "string",
@@ -8585,15 +8586,15 @@
         "input": {
           "name": "[variables('spokes')[copyIndex()].name]",
           "subscriptionId": "[variables('spokes')[copyIndex()].subscriptionId]",
-          "resourceGroupName": "[reference(subscriptionResourceId(variables('spokes')[copyIndex()].subscriptionId, 'Microsoft.Resources/deployments', format('deploy-rg-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix')))).outputs.name.value]",
-          "resourceGroupId": "[reference(subscriptionResourceId(variables('spokes')[copyIndex()].subscriptionId, 'Microsoft.Resources/deployments', format('deploy-rg-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix')))).outputs.id.value]",
-          "virtualNetworkName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix')))).outputs.virtualNetworkName.value]",
-          "virtualNetworkResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix')))).outputs.virtualNetworkResourceId.value]",
-          "subnetName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix')))).outputs.subnetName.value]",
-          "subnetResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix')))).outputs.subnetResourceId.value]",
-          "subnetAddressPrefix": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix')))).outputs.subnetAddressPrefix.value]",
-          "networkSecurityGroupName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix')))).outputs.networkSecurityGroupName.value]",
-          "networkSecurityGroupResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix')))).outputs.networkSecurityGroupResourceId.value]"
+          "resourceGroupName": "[reference(subscriptionResourceId(variables('spokes')[copyIndex()].subscriptionId, 'Microsoft.Resources/deployments', format('deploy-rg-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))), '2022-09-01').outputs.name.value]",
+          "resourceGroupId": "[reference(subscriptionResourceId(variables('spokes')[copyIndex()].subscriptionId, 'Microsoft.Resources/deployments', format('deploy-rg-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))), '2022-09-01').outputs.id.value]",
+          "virtualNetworkName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))), '2022-09-01').outputs.virtualNetworkName.value]",
+          "virtualNetworkResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))), '2022-09-01').outputs.virtualNetworkResourceId.value]",
+          "subnetName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))), '2022-09-01').outputs.subnetName.value]",
+          "subnetResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))), '2022-09-01').outputs.subnetResourceId.value]",
+          "subnetAddressPrefix": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))), '2022-09-01').outputs.subnetAddressPrefix.value]",
+          "networkSecurityGroupName": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))), '2022-09-01').outputs.networkSecurityGroupName.value]",
+          "networkSecurityGroupResourceId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('spokes')[copyIndex()].subscriptionId, variables('spokes')[copyIndex()].resourceGroupName), 'Microsoft.Resources/deployments', format('deploy-vnet-{0}-{1}', variables('spokes')[copyIndex()].name, parameters('deploymentNameSuffix'))), '2022-09-01').outputs.networkSecurityGroupResourceId.value]"
         }
       }
     }


### PR DESCRIPTION
Previously the hub DNS deployment was happening at the same time as remote access deployment. This would create a conflict since the hub DNS deployment would update the VNET the remote access VMs were trying to use for their NICs.  Adding a dependency on the remote access deployment for the hub DNS deployment has resolved the issue.
