### PR TITLE
Removed locations missing geo codes

### DIFF
--- a/src/bicep/data/locations.json
+++ b/src/bicep/data/locations.json
@@ -23,12 +23,6 @@
             "recoveryServicesGeo": "bjb2",
             "timeDifference": "+8:00",
             "timeZone": "China Standard Time"
-        },
-        "chinanorth3": {
-            "abbreviation": "cnn3",
-            "recoveryServicesGeo": "",
-            "timeDifference": "+8:00",
-            "timeZone": "China Standard Time"
         }
     },
     "AzureCloud": {
@@ -181,12 +175,6 @@
             "recoveryServicesGeo": "krs",
             "timeDifference": "+9:00",
             "timeZone": "Korea Standard Time"
-        },
-        "newzealandnorth": {
-            "abbreviation": "nzn",
-            "recoveryServicesGeo": "",
-            "timeDifference": "+13:00",
-            "timeZone": "New Zealand Standard Time"
         },
         "northcentralus": {
             "abbreviation": "usnc",


### PR DESCRIPTION
Locations were added that were about to come online but not GA yet and therefore were missing geo codes for recovery services.  Removed the locations for now and will be added back when they go GA.
