### PR TITLE
Fixed friendly name for AVD feed workspace

### DIFF
--- a/src/bicep/add-ons/azureVirtualDesktop/modules/controlPlane/controlPlane.bicep
+++ b/src/bicep/add-ons/azureVirtualDesktop/modules/controlPlane/controlPlane.bicep
@@ -30,11 +30,11 @@ param tags object
 param timestamp string
 param validationEnvironment bool
 param vmTemplate string
-param workspaceFriendlyName string
-param workspaceFeedName string
 param workspaceFeedDiagnoticSettingName string
+param workspaceFeedName string
 param workspaceFeedNetworkInterfaceName string
 param workspaceFeedPrivateEndpointName string
+param workspaceFriendlyName string
 param workspacePublicNetworkAccess string
 
 module hostPool 'hostPool.bicep' = {
@@ -90,7 +90,6 @@ module workspace 'workspace.bicep' = {
     avdPrivateDnsZoneResourceId: avdPrivateDnsZoneResourceId
     deploymentUserAssignedIdentityClientId: deploymentUserAssignedIdentityClientId
     existing: existingFeedWorkspace
-    friendlyName: workspaceFriendlyName
     hostPoolName: hostPoolName
     locationControlPlane: locationControlPlane
     locationVirtualMachines: locationVirtualMachines
@@ -105,6 +104,7 @@ module workspace 'workspace.bicep' = {
     workspaceFeedName: workspaceFeedName
     workspaceFeedNetworkInterfaceName: workspaceFeedNetworkInterfaceName
     workspaceFeedPrivateEndpointName: workspaceFeedPrivateEndpointName
+    workspaceFriendlyName: workspaceFriendlyName
     workspacePublicNetworkAccess: workspacePublicNetworkAccess
   }
 }

--- a/src/bicep/add-ons/azureVirtualDesktop/modules/controlPlane/workspace.bicep
+++ b/src/bicep/add-ons/azureVirtualDesktop/modules/controlPlane/workspace.bicep
@@ -3,7 +3,6 @@ param artifactsUri string
 param avdPrivateDnsZoneResourceId string
 param deploymentUserAssignedIdentityClientId string
 param existing bool
-param friendlyName string
 param hostPoolName string
 param locationControlPlane string
 param locationVirtualMachines string
@@ -18,6 +17,7 @@ param workspaceFeedDiagnoticSettingName string
 param workspaceFeedName string
 param workspaceFeedNetworkInterfaceName string
 param workspaceFeedPrivateEndpointName string
+param workspaceFriendlyName string
 param workspacePublicNetworkAccess string
 
 module addApplicationGroups '../common/customScriptExtensions.bicep' = if (existing) {
@@ -44,7 +44,7 @@ resource workspace 'Microsoft.DesktopVirtualization/workspaces@2023-09-05' = if 
   tags: {}
   properties: {
     applicationGroupReferences: applicationGroupReferences
-    friendlyName: empty(friendlyName) ? hostPoolName : '${friendlyName} (${locationControlPlane})'
+    friendlyName: workspaceFriendlyName
     publicNetworkAccess: workspacePublicNetworkAccess
   }
 }

--- a/src/bicep/add-ons/azureVirtualDesktop/modules/resourceNames.bicep
+++ b/src/bicep/add-ons/azureVirtualDesktop/modules/resourceNames.bicep
@@ -39,156 +39,98 @@ var locations = (loadJsonContent('../../../data/locations.json'))[environment().
 var resourceAbbreviations = loadJsonContent('../../../data/resourceAbbreviations.json')
 
 // RESOURCE NAMES AND PREFIXES
-
-var agentSvcPrivateDnsZoneName = 'privatelink.agentsvc.azure-automation.${privateDnsZoneSuffixes_AzureAutomation[environment().name] ?? cloudEndpointSuffix}'
-var automationAccountDiagnosticSettingName = replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.diagnosticSettings), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var automationAccountName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.automationAccounts), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var automationAccountNetworkInterfaceName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, 'DSCAndHybridWorker-${resourceAbbreviations.automationAccounts}' ), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var automationAccountPrivateEndpointName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, 'DSCAndHybridWorker-${resourceAbbreviations.automationAccounts}' ), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var availabilitySetNamePrefix = '${replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.availabilitySets), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)}-'
-var avdGlobalPrivateDnsZoneName = 'privatelink-global.wvd.${privateDnsZoneSuffixes_AzureVirtualDesktop[environment().name] ?? cloudEndpointSuffix}'
-var avdPrivateDnsZoneName = 'privatelink.wvd.${privateDnsZoneSuffixes_AzureVirtualDesktop[environment().name] ?? cloudEndpointSuffix}'
-var azureAutomationPrivateDnsZoneName = 'privatelink.azure-automation.${privateDnsZoneSuffixes_AzureAutomation[environment().name] ?? cloudEndpointSuffix}'
-var backupPrivateDnsZoneName = 'privatelink.${locations[locationVirtualMachines].recoveryServicesGeo}.backup.${privateDnsZoneSuffixes_Backup[environment().name] ?? cloudEndpointSuffix}'
-var blobPrivateDnsZoneName = 'privatelink.blob.${environment().suffixes.storage}'
-var dataCollectionRuleAssociationName = '${replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.dataCollectionRuleAssociations), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)}-avdi'
-var dataCollectionRuleName = 'microsoft-avdi-${locations[locationVirtualMachines].abbreviation}'
-var desktopApplicationGroupName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.desktopApplicationGroups), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var diskAccessName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.diskAccesses), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var diskEncryptionSetName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.diskEncryptionSets), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var diskNamePrefix = replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.disks), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var filePrivateDnsZoneName = 'privatelink.file.${environment().suffixes.storage}'
-var fileShareNames = {
-  CloudCacheProfileContainer: [
-    'profile-containers'
+var resources = {
+  agentSvcPrivateDnsZoneName: 'privatelink.agentsvc.azure-automation.${privateDnsZoneSuffixes_AzureAutomation[environment().name] ?? cloudEndpointSuffix}'
+  automationAccountDiagnosticSettingName: replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.diagnosticSettings), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  automationAccountName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.automationAccounts), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  automationAccountNetworkInterfaceName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, 'DSCAndHybridWorker-${resourceAbbreviations.automationAccounts}' ), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  automationAccountPrivateEndpointName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, 'DSCAndHybridWorker-${resourceAbbreviations.automationAccounts}' ), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  availabilitySetNamePrefix: '${replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.availabilitySets), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)}-'
+  avdGlobalPrivateDnsZoneName: 'privatelink-global.wvd.${privateDnsZoneSuffixes_AzureVirtualDesktop[environment().name] ?? cloudEndpointSuffix}'
+  avdPrivateDnsZoneName: 'privatelink.wvd.${privateDnsZoneSuffixes_AzureVirtualDesktop[environment().name] ?? cloudEndpointSuffix}'
+  azureAutomationPrivateDnsZoneName: 'privatelink.azure-automation.${privateDnsZoneSuffixes_AzureAutomation[environment().name] ?? cloudEndpointSuffix}'
+  backupPrivateDnsZoneName: 'privatelink.${locations[locationVirtualMachines].recoveryServicesGeo}.backup.${privateDnsZoneSuffixes_Backup[environment().name] ?? cloudEndpointSuffix}'
+  blobPrivateDnsZoneName: 'privatelink.blob.${environment().suffixes.storage}'
+  dataCollectionRuleAssociationName: '${replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.dataCollectionRuleAssociations), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)}-avdi'
+  dataCollectionRuleName: 'microsoft-avdi-${locations[locationVirtualMachines].abbreviation}'
+  desktopApplicationGroupName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.desktopApplicationGroups), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  diskAccessName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.diskAccesses), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  diskEncryptionSetName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.diskEncryptionSets), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  diskNamePrefix: replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.disks), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  filePrivateDnsZoneName: 'privatelink.file.${environment().suffixes.storage}'
+  fileShareNames: {
+    CloudCacheProfileContainer: [
+      'profile-containers'
+    ]
+    CloudCacheProfileOfficeContainer: [
+      'office-containers'
+      'profile-containers'
+    ]
+    ProfileContainer: [
+      'profile-containers'
+    ]
+    ProfileOfficeContainer: [
+      'office-containers'
+      'profile-containers'
+    ]
+  }
+  hostPoolDiagnosticSettingName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.diagnosticSettings), serviceName, resourceAbbreviations.hostPools), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  hostPoolName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.hostPools), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  hostPoolNetworkInterfaceName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, resourceAbbreviations.hostPools), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  hostPoolPrivateEndpointName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, resourceAbbreviations.hostPools), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  keyVaultName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.keyVaults), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  keyVaultNetworkInterfaceName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, resourceAbbreviations.keyVaults), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  keyVaultPrivateDnsZoneName: replace('privatelink${environment().suffixes.keyvaultDns}', 'vault', 'vaultcore')
+  keyVaultPrivateEndpointName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, resourceAbbreviations.keyVaults), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  logAnalyticsWorkspaceName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.logAnalyticsWorkspaces), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  netAppAccountName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.netAppAccounts), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  netAppCapacityPoolName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.netAppCapacityPools), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  networkInterfaceNamePrefix: replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkInterfaces), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  networkSecurityGroupNames: [
+    replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkSecurityGroups), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
+    replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkSecurityGroups), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
   ]
-  CloudCacheProfileOfficeContainer: [
-    'office-containers'
-    'profile-containers'
+  monitorPrivateDnsZoneName: 'privatelink.monitor.${privateDnsZoneSuffixes_Monitor[environment().name] ?? cloudEndpointSuffix}'
+  odsOpinsightsPrivateDnsZoneName: 'privatelink.ods.opinsights.${privateDnsZoneSuffixes_Monitor[environment().name] ?? cloudEndpointSuffix}'
+  omsOpinsightsPrivateDnsZoneName: 'privatelink.oms.opinsights.${privateDnsZoneSuffixes_Monitor[environment().name] ?? cloudEndpointSuffix}'
+  queuePrivateDnsZoneName: 'privatelink.queue.${environment().suffixes.storage}'
+  recoveryServicesVaultName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.recoveryServicesVaults), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  recoveryServicesVaultNetworkInterfaceName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, resourceAbbreviations.recoveryServicesVaults), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  recoveryServicesVaultPrivateEndpointName: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, resourceAbbreviations.recoveryServicesVaults), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  resourceGroupControlPlane: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'controlPlane'), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  resourceGroupFeedWorkspace: replace(replace(replace(namingConvention_Shared, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'feedWorkspace'), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  resourceGroupGlobalWorkspace: replace(replace(replace(namingConvention_Global, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'globalWorkspace'), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  resourceGroupHosts: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'sessionHosts'), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  resourceGroupManagement: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'management'), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  resourceGroupsNetwork: [
+    replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'network'), locationAbbreviation, locations[locationControlPlane].abbreviation)
+    replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'network'), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
   ]
-  ProfileContainer: [
-    'profile-containers'
+  resourceGroupStorage: replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'profileStorage'), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  routeTableNames: [
+    replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.routeTables), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
+    replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.routeTables), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
   ]
-  ProfileOfficeContainer: [
-    'office-containers'
-    'profile-containers'
+  storageAccountNamePrefix: replace(replace(replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.storageAccounts), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation), environmentAbbreviation, first(environmentAbbreviation)), '-', '')
+  storageAccountNetworkInterfaceNamePrefix: replace(replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, resourceAbbreviations.storageAccounts), locationAbbreviation, locations[locationVirtualMachines].abbreviation), environmentAbbreviation, first(environmentAbbreviation))
+  storageAccountPrivateEndpointNamePrefix: replace(replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, resourceAbbreviations.storageAccounts), locationAbbreviation, locations[locationVirtualMachines].abbreviation), environmentAbbreviation, first(environmentAbbreviation))
+  userAssignedIdentityNamePrefix: replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.userAssignedIdentities), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
+  virtualMachineNamePrefix: replace(replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.virtualMachines), locationAbbreviation, locations[locationVirtualMachines].abbreviation), environmentAbbreviation, first(environmentAbbreviation)), '-', '')
+  virtualNetworkNames: [
+    replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.virtualNetworks), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
+    replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.virtualNetworks), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
   ]
+  workspaceFeedDiagnosticSettingName: replace(replace(replace(namingConvention_Shared, resourceAbbreviation, resourceAbbreviations.diagnosticSettings), serviceName, 'feed-${resourceAbbreviations.workspaces}'), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  workspaceFeedName: replace(replace(replace(namingConvention_Shared, resourceAbbreviation, 'feed-${resourceAbbreviations.workspaces}'), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  workspaceFeedNetworkInterfaceName: replace(replace(replace(namingConvention_Shared, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, 'feed-${resourceAbbreviations.workspaces}'), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  workspaceFeedPrivateEndpointName: replace(replace(replace(namingConvention_Shared, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, 'feed-${resourceAbbreviations.workspaces}'), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  workspaceFriendlyName: replace(replace(replace(namingConvention_Shared, resourceAbbreviation, resourceAbbreviations.workspaces), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  workspaceGlobalName: replace(replace(replace(namingConvention_Global, resourceAbbreviation, 'global-${resourceAbbreviations.workspaces}'), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  workspaceGlobalNetworkInterfaceName: replace(replace(replace(namingConvention_Global, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, 'global-${resourceAbbreviations.workspaces}'), locationAbbreviation, locations[locationControlPlane].abbreviation)
+  workspaceGlobalPrivateEndpointName: replace(replace(replace(namingConvention_Global, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, 'global-${resourceAbbreviations.workspaces}'), locationAbbreviation, locations[locationControlPlane].abbreviation)
 }
-var hostPoolDiagnosticSettingName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.diagnosticSettings), serviceName, resourceAbbreviations.hostPools), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var hostPoolName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.hostPools), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var hostPoolNetworkInterfaceName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, resourceAbbreviations.hostPools), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var hostPoolPrivateEndpointName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, resourceAbbreviations.hostPools), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var keyVaultName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.keyVaults), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var keyVaultNetworkInterfaceName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, resourceAbbreviations.keyVaults), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var keyVaultPrivateDnsZoneName = replace('privatelink${environment().suffixes.keyvaultDns}', 'vault', 'vaultcore')
-var keyVaultPrivateEndpointName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, resourceAbbreviations.keyVaults), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var logAnalyticsWorkspaceName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.logAnalyticsWorkspaces), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var netAppAccountName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.netAppAccounts), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var netAppCapacityPoolName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.netAppCapacityPools), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var networkInterfaceNamePrefix = replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkInterfaces), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var networkSecurityGroupNames = [
-  replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkSecurityGroups), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
-  replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkSecurityGroups), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-]
-var monitorPrivateDnsZoneName = 'privatelink.monitor.${privateDnsZoneSuffixes_Monitor[environment().name] ?? cloudEndpointSuffix}'
-var odsOpinsightsPrivateDnsZoneName = 'privatelink.ods.opinsights.${privateDnsZoneSuffixes_Monitor[environment().name] ?? cloudEndpointSuffix}'
-var omsOpinsightsPrivateDnsZoneName = 'privatelink.oms.opinsights.${privateDnsZoneSuffixes_Monitor[environment().name] ?? cloudEndpointSuffix}'
-var queuePrivateDnsZoneName = 'privatelink.queue.${environment().suffixes.storage}'
-var recoveryServicesVaultName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.recoveryServicesVaults), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var recoveryServicesVaultNetworkInterfaceName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, resourceAbbreviations.recoveryServicesVaults), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var recoveryServicesVaultPrivateEndpointName = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, resourceAbbreviations.recoveryServicesVaults), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var resourceGroupControlPlane = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'controlPlane'), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var resourceGroupFeedWorkspace = replace(replace(replace(namingConvention_Shared, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'feedWorkspace'), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var resourceGroupGlobalWorkspace = replace(replace(replace(namingConvention_Global, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'globalWorkspace'), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var resourceGroupHosts = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'sessionHosts'), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var resourceGroupManagement = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'management'), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var resourceGroupsNetwork = [
-  replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'network'), locationAbbreviation, locations[locationControlPlane].abbreviation)
-  replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'network'), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-]
-var resourceGroupStorage = replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.resourceGroups), serviceName, 'profileStorage'), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var routeTables = [
-  replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.routeTables), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
-  replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.routeTables), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-]
-var storageAccountNamePrefix = replace(replace(replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.storageAccounts), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation), environmentAbbreviation, first(environmentAbbreviation)), '-', '')
-var storageAccountNetworkInterfaceNamePrefix = replace(replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, resourceAbbreviations.storageAccounts), locationAbbreviation, locations[locationVirtualMachines].abbreviation), environmentAbbreviation, first(environmentAbbreviation))
-var storageAccountPrivateEndpointNamePrefix = replace(replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, resourceAbbreviations.storageAccounts), locationAbbreviation, locations[locationVirtualMachines].abbreviation), environmentAbbreviation, first(environmentAbbreviation))
-var userAssignedIdentityNamePrefix = replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.userAssignedIdentities), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-var virtualMachineNamePrefix = replace(replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.virtualMachines), locationAbbreviation, locations[locationVirtualMachines].abbreviation), environmentAbbreviation, first(environmentAbbreviation)), '-', '')
-var virtualNetworkNames = [
-  replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.virtualNetworks), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
-  replace(replace(replace(namingConvention, resourceAbbreviation, resourceAbbreviations.virtualNetworks), '-${serviceName}', ''), locationAbbreviation, locations[locationVirtualMachines].abbreviation)
-]
-var workspaceFeedDiagnosticSettingName = replace(replace(replace(namingConvention_Shared, resourceAbbreviation, resourceAbbreviations.diagnosticSettings), serviceName, 'feed-${resourceAbbreviations.workspaces}'), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var workspaceFeedName = replace(replace(replace(namingConvention_Shared, resourceAbbreviation, 'feed-${resourceAbbreviations.workspaces}'), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var workspaceFeedNetworkInterfaceName = replace(replace(replace(namingConvention_Shared, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, 'feed-${resourceAbbreviations.workspaces}'), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var workspaceFeedPrivateEndpointName = replace(replace(replace(namingConvention_Shared, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, 'feed-${resourceAbbreviations.workspaces}'), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var workspaceGlobalName = replace(replace(replace(namingConvention_Global, resourceAbbreviation, 'global-${resourceAbbreviations.workspaces}'), '-${serviceName}', ''), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var workspaceGlobalNetworkInterfaceName = replace(replace(replace(namingConvention_Global, resourceAbbreviation, resourceAbbreviations.networkInterfaces), serviceName, 'global-${resourceAbbreviations.workspaces}'), locationAbbreviation, locations[locationControlPlane].abbreviation)
-var workspaceGlobalPrivateEndpointName = replace(replace(replace(namingConvention_Global, resourceAbbreviation, resourceAbbreviations.privateEndpoints), serviceName, 'global-${resourceAbbreviations.workspaces}'), locationAbbreviation, locations[locationControlPlane].abbreviation)
 
-output agentSvcPrivateDnsZoneName string = agentSvcPrivateDnsZoneName
-output automationAccountDiagnosticSettingName string = automationAccountDiagnosticSettingName
-output automationAccountName string = automationAccountName
-output automationAccountNetworkInterfaceName string = automationAccountNetworkInterfaceName
-output automationAccountPrivateEndpointName string = automationAccountPrivateEndpointName
-output availabilitySetNamePrefix string = availabilitySetNamePrefix
-output avdGlobalPrivateDnsZoneName string = avdGlobalPrivateDnsZoneName
-output avdPrivateDnsZoneName string = avdPrivateDnsZoneName
-output azureAutomationPrivateDnsZoneName string = azureAutomationPrivateDnsZoneName
-output backupPrivateDnsZoneName string = backupPrivateDnsZoneName
-output blobPrivateDnsZoneName string = blobPrivateDnsZoneName
-output dataCollectionRuleAssociationName string = dataCollectionRuleAssociationName
-output dataCollectionRuleName string = dataCollectionRuleName
-output desktopApplicationGroupName string = desktopApplicationGroupName
-output diskAccessName string = diskAccessName
-output diskEncryptionSetName string = diskEncryptionSetName
-output diskNamePrefix string = diskNamePrefix
-output filePrivateDnsZoneName string = filePrivateDnsZoneName
-output fileShareNames object = fileShareNames
-output hostPoolDiagnosticSettingName string = hostPoolDiagnosticSettingName
-output hostPoolName string = hostPoolName
-output hostPoolNetworkInterfaceName string = hostPoolNetworkInterfaceName
-output hostPoolPrivateEndpointName string = hostPoolPrivateEndpointName
-output keyVaultName string = keyVaultName
-output keyVaultNetworkInterfaceName string = keyVaultNetworkInterfaceName
-output keyVaultPrivateDnsZoneName string = keyVaultPrivateDnsZoneName
-output keyVaultPrivateEndpointName string = keyVaultPrivateEndpointName
 output locations object = locations
-output logAnalyticsWorkspaceName string = logAnalyticsWorkspaceName
-output monitorPrivateDnsZoneName string = monitorPrivateDnsZoneName
-output odsOpinsightsPrivateDnsZoneName string = odsOpinsightsPrivateDnsZoneName
-output omsOpinsightsPrivateDnsZoneName string = omsOpinsightsPrivateDnsZoneName
-output netAppAccountName string = netAppAccountName
-output netAppCapacityPoolName string = netAppCapacityPoolName
-output networkInterfaceNamePrefix string = networkInterfaceNamePrefix
 output networkName string = networkName
-output networkSecurityGroupNames array = networkSecurityGroupNames
-output queuePrivateDnsZoneName string = queuePrivateDnsZoneName
-output recoveryServicesVaultName string = recoveryServicesVaultName
-output recoveryServicesVaultNetworkInterfaceName string = recoveryServicesVaultNetworkInterfaceName
-output recoveryServicesVaultPrivateEndpointName string = recoveryServicesVaultPrivateEndpointName
-output resourceAbbreviations object = resourceAbbreviations
-output resourceGroupControlPlane string = resourceGroupControlPlane
-output resourceGroupFeedWorkspace string = resourceGroupFeedWorkspace
-output resourceGroupGlobalWorkspace string = resourceGroupGlobalWorkspace
-output resourceGroupHosts string = resourceGroupHosts
-output resourceGroupManagement string = resourceGroupManagement
-output resourceGroupsNetwork array = resourceGroupsNetwork
-output resourceGroupStorage string = resourceGroupStorage
-output routeTables array = routeTables
+output resources object = resources
 output serviceName string = serviceName
-output storageAccountNamePrefix string = storageAccountNamePrefix
-output storageAccountNetworkInterfaceNamePrefix string = storageAccountNetworkInterfaceNamePrefix
-output storageAccountPrivateEndpointNamePrefix string = storageAccountPrivateEndpointNamePrefix
-output userAssignedIdentityNamePrefix string = userAssignedIdentityNamePrefix
-output virtualMachineNamePrefix string = virtualMachineNamePrefix
-output virtulNetworkNames array = virtualNetworkNames
-output workspaceFeedDiagnosticSettingName string = workspaceFeedDiagnosticSettingName
-output workspaceFeedName string = workspaceFeedName
-output workspaceFeedNetworkInterfaceName string = workspaceFeedNetworkInterfaceName
-output workspaceFeedPrivateEndpointName string = workspaceFeedPrivateEndpointName
-output workspaceGlobalName string = workspaceGlobalName
-output workspaceGlobalNetworkInterfaceName string = workspaceGlobalNetworkInterfaceName
-output workspaceGlobalPrivateEndpointName string = workspaceGlobalPrivateEndpointName

--- a/src/bicep/add-ons/azureVirtualDesktop/solution.bicep
+++ b/src/bicep/add-ons/azureVirtualDesktop/solution.bicep
@@ -41,7 +41,7 @@ param azurePowerShellModuleMsiName string
 @description('The RDP properties to add or remove RDP functionality on the AVD host pool. The string must end with a semi-colon. Settings reference: https://learn.microsoft.com/windows-server/remote/remote-desktop-services/clients/rdp-files')
 param customRdpProperty string = 'audiocapturemode:i:1;camerastoredirect:s:*;use multimon:i:0;drivestoredirect:s:;encode redirected video capture:i:1;redirected video capture encoding quality:i:1;audiomode:i:0;devicestoredirect:s:;redirectclipboard:i:0;redirectcomports:i:0;redirectlocation:i:1;redirectprinters:i:0;redirectsmartcards:i:1;redirectwebauthn:i:1;usbdevicestoredirect:s:;keyboardhook:i:2;'
 
-@description('The friendly name for the Desktop application in the desktop application group.')
+@description('The friendly name for the SessionDesktop application in the desktop application group.')
 param desktopFriendlyName string = ''
 
 @description('Disabling BGP route propagation is a route table configuration that prevents the propagation of on-premises routes to network interfaces in the associated subnets.')
@@ -281,8 +281,8 @@ var deploymentLocations = union([
 var resourceGroupsCount = 4 + length(deploymentLocations) + (fslogixStorageService == 'None' ? 0 : 1)
 
 // Resource Names
-module resourceNames 'modules/resourceNames.bicep' = {
-  name: 'ResourceNames_${timestamp}'
+module names 'modules/resourceNames.bicep' = {
+  name: 'Names_${timestamp}'
   params: {
     environmentAbbreviation: environmentAbbreviation
     identifier: identifier
@@ -300,25 +300,25 @@ module logic 'modules/logic.bicep' = {
     deploymentLocations: deploymentLocations
     diskSku: diskSku
     domainName: domainName
-    fileShareNames: resourceNames.outputs.fileShareNames
+    fileShareNames: names.outputs.resources.fileShareNames
     fslogixContainerType: fslogixContainerType
     fslogixStorageService: fslogixStorageService
     hostPoolType: hostPoolType
     imageOffer: imageOffer
     imagePublisher: imagePublisher
     imageSku: imageSku
-    locations: resourceNames.outputs.locations
+    locations: names.outputs.locations
     locationVirtualMachines: locationVirtualMachines
-    resourceGroupControlPlane: resourceNames.outputs.resourceGroupControlPlane
-    resourceGroupFeedWorkspace: resourceNames.outputs.resourceGroupFeedWorkspace
-    resourceGroupHosts: resourceNames.outputs.resourceGroupHosts
-    resourceGroupManagement: resourceNames.outputs.resourceGroupManagement
-    resourceGroupsNetwork: resourceNames.outputs.resourceGroupsNetwork
-    resourceGroupStorage: resourceNames.outputs.resourceGroupStorage
+    resourceGroupControlPlane: names.outputs.resources.resourceGroupControlPlane
+    resourceGroupFeedWorkspace: names.outputs.resources.resourceGroupFeedWorkspace
+    resourceGroupHosts: names.outputs.resources.resourceGroupHosts
+    resourceGroupManagement: names.outputs.resources.resourceGroupManagement
+    resourceGroupsNetwork: names.outputs.resources.resourceGroupsNetwork
+    resourceGroupStorage: names.outputs.resources.resourceGroupStorage
     securityPrincipals: securityPrincipals
     sessionHostCount: sessionHostCount
     sessionHostIndex: sessionHostIndex
-    virtualMachineNamePrefix: resourceNames.outputs.virtualMachineNamePrefix
+    virtualMachineNamePrefix: names.outputs.resources.virtualMachineNamePrefix
     virtualMachineSize: virtualMachineSize
   }
 }
@@ -342,13 +342,13 @@ module network_controlPlane 'modules/network/networking.bicep' =  {
     hubVirtualNetworkResourceId: hubVirtualNetworkResourceId
     index: 0
     location: deploymentLocations[0]
-    networkSecurityGroupName: resourceNames.outputs.networkSecurityGroupNames[0]
-    resourceGroupNetwork: resourceNames.outputs.resourceGroupsNetwork[0]
-    routeTableName: resourceNames.outputs.routeTables[0]
+    networkSecurityGroupName: names.outputs.resources.networkSecurityGroupNames[0]
+    resourceGroupNetwork: names.outputs.resources.resourceGroupsNetwork[0]
+    routeTableName: names.outputs.resources.routeTableNames[0]
     subnetAddressPrefixes: subnetAddressPrefixes
     timestamp: timestamp
     virtualNetworkAddressPrefixes: virtualNetworkAddressPrefixes
-    virtualNetworkName: resourceNames.outputs.virtulNetworkNames[0]
+    virtualNetworkName: names.outputs.resources.virtualNetworkNames[0]
   }
   dependsOn: [
     rgs
@@ -364,13 +364,13 @@ module network_hosts 'modules/network/networking.bicep' = if (length(deploymentL
     hubVirtualNetworkResourceId: hubVirtualNetworkResourceId
     index: 1
     location: deploymentLocations[1]
-    networkSecurityGroupName: resourceNames.outputs.networkSecurityGroupNames[1]
-    resourceGroupNetwork: length(deploymentLocations) == 1 ? resourceNames.outputs.resourceGroupsNetwork[0] : resourceNames.outputs.resourceGroupsNetwork[1]
-    routeTableName: resourceNames.outputs.routeTables[1]
+    networkSecurityGroupName: names.outputs.resources.networkSecurityGroupNames[1]
+    resourceGroupNetwork: length(deploymentLocations) == 1 ? names.outputs.resources.resourceGroupsNetwork[0] : names.outputs.resources.resourceGroupsNetwork[1]
+    routeTableName: names.outputs.resources.routeTableNames[1]
     subnetAddressPrefixes: subnetAddressPrefixes
     timestamp: timestamp
     virtualNetworkAddressPrefixes: virtualNetworkAddressPrefixes
-    virtualNetworkName: resourceNames.outputs.virtulNetworkNames[1]
+    virtualNetworkName: names.outputs.resources.virtualNetworkNames[1]
   }
   dependsOn: [
     rgs
@@ -381,23 +381,23 @@ module network_hosts 'modules/network/networking.bicep' = if (length(deploymentL
 module management 'modules/management/management.bicep' = {
   name: 'Management_${timestamp}'
   params: {
-    //diskAccessName: resourceNames.outputs.diskAccessName
+    //diskAccessName: names.outputs.resources.diskAccessName
     activeDirectorySolution: activeDirectorySolution
     artifactsStorageAccountResourceId: artifactsStorageAccountResourceId
     artifactsUri: artifactsUri
-    automationAccountDiagnosticSettingName: resourceNames.outputs.automationAccountDiagnosticSettingName
-    automationAccountName: resourceNames.outputs.automationAccountName
-    automationAccountNetworkInterfaceName: resourceNames.outputs.automationAccountNetworkInterfaceName
-    automationAccountPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${resourceNames.outputs.azureAutomationPrivateDnsZoneName}'
-    automationAccountPrivateEndpointName: resourceNames.outputs.automationAccountPrivateEndpointName
+    automationAccountDiagnosticSettingName: names.outputs.resources.automationAccountDiagnosticSettingName
+    automationAccountName: names.outputs.resources.automationAccountName
+    automationAccountNetworkInterfaceName: names.outputs.resources.automationAccountNetworkInterfaceName
+    automationAccountPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${names.outputs.resources.azureAutomationPrivateDnsZoneName}'
+    automationAccountPrivateEndpointName: names.outputs.resources.automationAccountPrivateEndpointName
     availability: availability
     avdObjectId: avdObjectId
-    azureBlobsPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${resourceNames.outputs.blobPrivateDnsZoneName}'
+    azureBlobsPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${names.outputs.resources.blobPrivateDnsZoneName}'
     azurePowerShellModuleMsiName: azurePowerShellModuleMsiName 
-    azureQueueStoragePrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${resourceNames.outputs.queuePrivateDnsZoneName}'
-    dataCollectionRuleName: resourceNames.outputs.dataCollectionRuleName
-    diskEncryptionSetName: resourceNames.outputs.diskEncryptionSetName
-    diskNamePrefix: resourceNames.outputs.diskNamePrefix
+    azureQueueStoragePrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${names.outputs.resources.queuePrivateDnsZoneName}'
+    dataCollectionRuleName: names.outputs.resources.dataCollectionRuleName
+    diskEncryptionSetName: names.outputs.resources.diskEncryptionSetName
+    diskNamePrefix: names.outputs.resources.diskNamePrefix
     diskSku: diskSku
     domainJoinPassword: domainJoinPassword
     domainJoinUserPrincipalName: domainJoinUserPrincipalName
@@ -406,47 +406,47 @@ module management 'modules/management/management.bicep' = {
     environmentAbbreviation: environmentAbbreviation
     fslogix: logic.outputs.fslogix
     fslogixStorageService: fslogixStorageService
-    hostPoolName: resourceNames.outputs.hostPoolName
+    hostPoolName: names.outputs.resources.hostPoolName
     hostPoolType: hostPoolType
     imageDefinitionResourceId: imageDefinitionResourceId
-    keyVaultName: resourceNames.outputs.keyVaultName
-    keyVaultNetworkInterfaceName: resourceNames.outputs.keyVaultNetworkInterfaceName
-    keyVaultPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${resourceNames.outputs.keyVaultPrivateDnsZoneName}'
-    keyVaultPrivateEndpointName: resourceNames.outputs.keyVaultPrivateEndpointName
+    keyVaultName: names.outputs.resources.keyVaultName
+    keyVaultNetworkInterfaceName: names.outputs.resources.keyVaultNetworkInterfaceName
+    keyVaultPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${names.outputs.resources.keyVaultPrivateDnsZoneName}'
+    keyVaultPrivateEndpointName: names.outputs.resources.keyVaultPrivateEndpointName
     locationVirtualMachines: locationVirtualMachines
-    logAnalyticsWorkspaceName: resourceNames.outputs.logAnalyticsWorkspaceName
+    logAnalyticsWorkspaceName: names.outputs.resources.logAnalyticsWorkspaceName
     logAnalyticsWorkspaceRetention: logAnalyticsWorkspaceRetention
     logAnalyticsWorkspaceSku: logAnalyticsWorkspaceSku
-    networkInterfaceNamePrefix: resourceNames.outputs.networkInterfaceNamePrefix
-    networkName: resourceNames.outputs.networkName
+    networkInterfaceNamePrefix: names.outputs.resources.networkInterfaceNamePrefix
+    networkName: names.outputs.networkName
     organizationalUnitPath: organizationalUnitPath
     recoveryServices: recoveryServices
-    recoveryServicesPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${resourceNames.outputs.backupPrivateDnsZoneName}'
-    recoveryServicesVaultName: resourceNames.outputs.recoveryServicesVaultName
-    recoveryServicesVaultNetworkInterfaceName: resourceNames.outputs.recoveryServicesVaultNetworkInterfaceName
-    recoveryServicesVaultPrivateEndpointName: resourceNames.outputs.recoveryServicesVaultPrivateEndpointName
-    resourceGroupControlPlane: resourceNames.outputs.resourceGroupControlPlane
-    resourceGroupFeedWorkspace: resourceNames.outputs.resourceGroupFeedWorkspace
-    resourceGroupHosts: resourceNames.outputs.resourceGroupHosts
-    resourceGroupManagement: resourceNames.outputs.resourceGroupManagement
-    resourceGroupStorage: resourceNames.outputs.resourceGroupStorage
+    recoveryServicesPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${names.outputs.resources.backupPrivateDnsZoneName}'
+    recoveryServicesVaultName: names.outputs.resources.recoveryServicesVaultName
+    recoveryServicesVaultNetworkInterfaceName: names.outputs.resources.recoveryServicesVaultNetworkInterfaceName
+    recoveryServicesVaultPrivateEndpointName: names.outputs.resources.recoveryServicesVaultPrivateEndpointName
+    resourceGroupControlPlane: names.outputs.resources.resourceGroupControlPlane
+    resourceGroupFeedWorkspace: names.outputs.resources.resourceGroupFeedWorkspace
+    resourceGroupHosts: names.outputs.resources.resourceGroupHosts
+    resourceGroupManagement: names.outputs.resources.resourceGroupManagement
+    resourceGroupStorage: names.outputs.resources.resourceGroupStorage
     roleDefinitions: logic.outputs.roleDefinitions
     scalingTool: scalingTool
     securityLogAnalyticsWorkspaceResourceId: securityLogAnalyticsWorkspaceResourceId
-    serviceName: resourceNames.outputs.serviceName
+    serviceName: names.outputs.serviceName
     sessionHostCount: sessionHostCount
     storageService: logic.outputs.storageService
     subnetResourceId: length(deploymentLocations) == 1 ? network_controlPlane.outputs.subnetResourceId : network_hosts.outputs.subnetResourceId
     tags: tags
     timestamp: timestamp
     timeZone: logic.outputs.timeZone
-    userAssignedIdentityNamePrefix: resourceNames.outputs.userAssignedIdentityNamePrefix
+    userAssignedIdentityNamePrefix: names.outputs.resources.userAssignedIdentityNamePrefix
     virtualMachineMonitoringAgent: virtualMachineMonitoringAgent
-    virtualMachineNamePrefix: resourceNames.outputs.virtualMachineNamePrefix
+    virtualMachineNamePrefix: names.outputs.resources.virtualMachineNamePrefix
     virtualMachinePassword: virtualMachinePassword
     virtualMachineSize: virtualMachineSize
     virtualMachineUsername: virtualMachineUsername
-    workspaceFeedName: resourceNames.outputs.workspaceFeedName
+    workspaceFeedName: names.outputs.resources.workspaceFeedName
   }
   dependsOn: [
     rgs
@@ -460,13 +460,13 @@ module hub 'modules/hub/hub.bicep' = {
   scope: subscription(split(hubSubnetResourceId, '/')[2])
   params: {
     existingWorkspace: management.outputs.existingFeedWorkspace
-    globalWorkspacePrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${resourceNames.outputs.avdGlobalPrivateDnsZoneName}'
+    globalWorkspacePrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${names.outputs.resources.avdGlobalPrivateDnsZoneName}'
     hubSubnetResourceId: hubSubnetResourceId
-    resourceGroupName: resourceNames.outputs.resourceGroupGlobalWorkspace
+    resourceGroupName: names.outputs.resources.resourceGroupGlobalWorkspace
     timestamp: timestamp
-    workspaceGlobalName: resourceNames.outputs.workspaceGlobalName
-    workspaceGlobalNetworkInterfaceName: resourceNames.outputs.workspaceGlobalNetworkInterfaceName
-    workspaceGlobalPrivateEndpointName: resourceNames.outputs.workspaceGlobalPrivateEndpointName
+    workspaceGlobalName: names.outputs.resources.workspaceGlobalName
+    workspaceGlobalNetworkInterfaceName: names.outputs.resources.workspaceGlobalNetworkInterfaceName
+    workspaceGlobalPrivateEndpointName: names.outputs.resources.workspaceGlobalPrivateEndpointName
   }
 }
 
@@ -477,16 +477,16 @@ module controlPlane 'modules/controlPlane/controlPlane.bicep' = {
   params: {
     activeDirectorySolution: activeDirectorySolution
     artifactsUri: artifactsUri
-    avdPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${resourceNames.outputs.avdPrivateDnsZoneName}'
+    avdPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${names.outputs.resources.avdPrivateDnsZoneName}'
     customRdpProperty: customRdpProperty
     deploymentUserAssignedIdentityClientId: management.outputs.deploymentUserAssignedIdentityClientId
-    desktopApplicationGroupName: resourceNames.outputs.desktopApplicationGroupName
-    desktopFriendlyName: desktopFriendlyName
+    desktopApplicationGroupName: names.outputs.resources.desktopApplicationGroupName
+    desktopFriendlyName: empty(desktopFriendlyName) ? string(stampIndex) : desktopFriendlyName
     existingFeedWorkspace: management.outputs.existingFeedWorkspace
-    hostPoolDiagnosticSettingName: resourceNames.outputs.hostPoolDiagnosticSettingName
-    hostPoolName: resourceNames.outputs.hostPoolName
-    hostPoolNetworkInterfaceName: resourceNames.outputs.hostPoolNetworkInterfaceName
-    hostPoolPrivateEndpointName: resourceNames.outputs.hostPoolPrivateEndpointName
+    hostPoolDiagnosticSettingName: names.outputs.resources.hostPoolDiagnosticSettingName
+    hostPoolName: names.outputs.resources.hostPoolName
+    hostPoolNetworkInterfaceName: names.outputs.resources.hostPoolNetworkInterfaceName
+    hostPoolPrivateEndpointName: names.outputs.resources.hostPoolPrivateEndpointName
     hostPoolPublicNetworkAccess: hostPoolPublicNetworkAccess
     hostPoolType: hostPoolType
     locationControlPlane: locationControlPlane
@@ -495,9 +495,9 @@ module controlPlane 'modules/controlPlane/controlPlane.bicep' = {
     managementVirtualMachineName: management.outputs.virtualMachineName
     maxSessionLimit: usersPerCore * virtualMachineVirtualCpuCount
     monitoring: monitoring
-    resourceGroupControlPlane: resourceNames.outputs.resourceGroupControlPlane
-    resourceGroupFeedWorkspace: resourceNames.outputs.resourceGroupFeedWorkspace
-    resourceGroupManagement: resourceNames.outputs.resourceGroupManagement
+    resourceGroupControlPlane: names.outputs.resources.resourceGroupControlPlane
+    resourceGroupFeedWorkspace: names.outputs.resources.resourceGroupFeedWorkspace
+    resourceGroupManagement: names.outputs.resources.resourceGroupManagement
     roleDefinitions: logic.outputs.roleDefinitions
     securityPrincipalObjectIds: map(securityPrincipals, item => item.objectId)
     subnetResourceId: network_controlPlane.outputs.subnetResourceId
@@ -505,11 +505,11 @@ module controlPlane 'modules/controlPlane/controlPlane.bicep' = {
     timestamp: timestamp
     validationEnvironment: validationEnvironment
     vmTemplate: logic.outputs.vmTemplate
-    workspaceFeedDiagnoticSettingName: resourceNames.outputs.workspaceFeedDiagnosticSettingName
-    workspaceFeedName: resourceNames.outputs.workspaceFeedName
-    workspaceFeedNetworkInterfaceName: resourceNames.outputs.workspaceFeedNetworkInterfaceName
-    workspaceFeedPrivateEndpointName: resourceNames.outputs.workspaceFeedPrivateEndpointName
-    workspaceFriendlyName: workspaceFriendlyName
+    workspaceFeedDiagnoticSettingName: names.outputs.resources.workspaceFeedDiagnosticSettingName
+    workspaceFeedName: names.outputs.resources.workspaceFeedName
+    workspaceFeedNetworkInterfaceName: names.outputs.resources.workspaceFeedNetworkInterfaceName
+    workspaceFeedPrivateEndpointName: names.outputs.resources.workspaceFeedPrivateEndpointName
+    workspaceFriendlyName: empty(workspaceFriendlyName) ? names.outputs.resources.workspaceFriendlyName : '${workspaceFriendlyName} (${locationControlPlane})'
     workspacePublicNetworkAccess: workspacePublicNetworkAccess
   }
   dependsOn: [
@@ -523,9 +523,9 @@ module fslogix 'modules/fslogix/fslogix.bicep' = {
     activeDirectoryConnection: management.outputs.validateANFfActiveDirectory
     activeDirectorySolution: activeDirectorySolution
     artifactsUri: artifactsUri
-    automationAccountName: resourceNames.outputs.automationAccountName
+    automationAccountName: names.outputs.resources.automationAccountName
     availability: availability
-    azureFilesPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${resourceNames.outputs.filePrivateDnsZoneName}'
+    azureFilesPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${names.outputs.resources.filePrivateDnsZoneName}'
     delegatedSubnetId: management.outputs.validateANFSubnetId
     deploymentUserAssignedIdentityClientId: management.outputs.deploymentUserAssignedIdentityClientId
     dnsServers: management.outputs.validateANFDnsServers
@@ -537,27 +537,27 @@ module fslogix 'modules/fslogix/fslogix.bicep' = {
     fslogixContainerType: fslogixContainerType
     fslogixShareSizeInGB: fslogixShareSizeInGB
     fslogixStorageService: fslogixStorageService
-    hostPoolName: resourceNames.outputs.hostPoolName
+    hostPoolName: names.outputs.resources.hostPoolName
     hostPoolType: hostPoolType
     keyVaultUri: management.outputs.keyVaultUri
     location: locationVirtualMachines
     managementVirtualMachineName: management.outputs.virtualMachineName
-    netAppAccountName: resourceNames.outputs.netAppAccountName
-    netAppCapacityPoolName: resourceNames.outputs.netAppCapacityPoolName
+    netAppAccountName: names.outputs.resources.netAppAccountName
+    netAppCapacityPoolName: names.outputs.resources.netAppCapacityPoolName
     netbios: logic.outputs.netbios
     organizationalUnitPath: organizationalUnitPath
     recoveryServices: recoveryServices
-    recoveryServicesVaultName: resourceNames.outputs.recoveryServicesVaultName
-    resourceGroupControlPlane: resourceNames.outputs.resourceGroupControlPlane
-    resourceGroupManagement: resourceNames.outputs.resourceGroupManagement
-    resourceGroupStorage: resourceNames.outputs.resourceGroupStorage
+    recoveryServicesVaultName: names.outputs.resources.recoveryServicesVaultName
+    resourceGroupControlPlane: names.outputs.resources.resourceGroupControlPlane
+    resourceGroupManagement: names.outputs.resources.resourceGroupManagement
+    resourceGroupStorage: names.outputs.resources.resourceGroupStorage
     securityPrincipalNames: map(securityPrincipals, item => item.name)
     securityPrincipalObjectIds: map(securityPrincipals, item => item.objectId)
-    serviceName: resourceNames.outputs.serviceName
+    serviceName: names.outputs.serviceName
     smbServerLocation: logic.outputs.smbServerLocation
-    storageAccountNamePrefix: resourceNames.outputs.storageAccountNamePrefix
-    storageAccountNetworkInterfaceNamePrefix: resourceNames.outputs.storageAccountNetworkInterfaceNamePrefix
-    storageAccountPrivateEndpointNamePrefix: resourceNames.outputs.storageAccountPrivateEndpointNamePrefix
+    storageAccountNamePrefix: names.outputs.resources.storageAccountNamePrefix
+    storageAccountNetworkInterfaceNamePrefix: names.outputs.resources.storageAccountNetworkInterfaceNamePrefix
+    storageAccountPrivateEndpointNamePrefix: names.outputs.resources.storageAccountPrivateEndpointNamePrefix
     storageCount: storageCount
     storageEncryptionKeyName: management.outputs.storageEncryptionKeyName
     storageIndex: storageIndex
@@ -584,19 +584,19 @@ module sessionHosts 'modules/sessionHosts/sessionHosts.bicep' = {
     artifactsUri: artifactsUri
     artifactsUserAssignedIdentityClientId: management.outputs.artifactsUserAssignedIdentityClientId
     artifactsUserAssignedIdentityResourceId: management.outputs.artifactsUserAssignedIdentityResourceId
-    automationAccountName: resourceNames.outputs.automationAccountName
+    automationAccountName: names.outputs.resources.automationAccountName
     availability: availability
-    availabilitySetNamePrefix: resourceNames.outputs.availabilitySetNamePrefix
+    availabilitySetNamePrefix: names.outputs.resources.availabilitySetNamePrefix
     availabilitySetsCount: logic.outputs.availabilitySetsCount
     availabilitySetsIndex: logic.outputs.beginAvSetRange
     availabilityZones: management.outputs.validateAvailabilityZones
     avdAgentBootLoaderMsiName: avdAgentBootLoaderMsiName
     avdAgentMsiName: avdAgentMsiName
-    dataCollectionRuleAssociationName: resourceNames.outputs.dataCollectionRuleAssociationName
+    dataCollectionRuleAssociationName: names.outputs.resources.dataCollectionRuleAssociationName
     dataCollectionRuleResourceId: management.outputs.dataCollectionRuleResourceId
     deploymentUserAssignedIdentityClientId: management.outputs.deploymentUserAssignedIdentityClientId
     diskEncryptionSetResourceId: management.outputs.diskEncryptionSetResourceId
-    diskNamePrefix: resourceNames.outputs.diskNamePrefix
+    diskNamePrefix: names.outputs.resources.diskNamePrefix
     diskSku: diskSku
     divisionRemainderValue: logic.outputs.divisionRemainderValue
     domainJoinPassword: domainJoinPassword
@@ -607,7 +607,7 @@ module sessionHosts 'modules/sessionHosts/sessionHosts.bicep' = {
     enableScalingTool: scalingTool
     fslogix: logic.outputs.fslogix
     fslogixContainerType: fslogixContainerType
-    hostPoolName: resourceNames.outputs.hostPoolName
+    hostPoolName: names.outputs.resources.hostPoolName
     hostPoolType: hostPoolType
     hybridRunbookWorkerGroupName: management.outputs.hybridRunbookWorkerGroupName
     imageOffer: imageOffer
@@ -615,21 +615,21 @@ module sessionHosts 'modules/sessionHosts/sessionHosts.bicep' = {
     imageSku: imageSku
     imageDefinitionResourceId: imageDefinitionResourceId
     location: locationVirtualMachines
-    logAnalyticsWorkspaceName: resourceNames.outputs.logAnalyticsWorkspaceName
+    logAnalyticsWorkspaceName: names.outputs.resources.logAnalyticsWorkspaceName
     managementVirtualMachineName: management.outputs.virtualMachineName
     maxResourcesPerTemplateDeployment: logic.outputs.maxResourcesPerTemplateDeployment
     monitoring: monitoring
     netAppFileShares: logic.outputs.fslogix ? fslogix.outputs.netAppShares : [
       'None'
     ]
-    networkInterfaceNamePrefix: resourceNames.outputs.networkInterfaceNamePrefix
-    networkName: resourceNames.outputs.networkName
+    networkInterfaceNamePrefix: names.outputs.resources.networkInterfaceNamePrefix
+    networkName: names.outputs.networkName
     organizationalUnitPath: organizationalUnitPath
     pooledHostPool: logic.outputs.pooledHostPool
-    recoveryServicesVaultName: resourceNames.outputs.recoveryServicesVaultName
-    resourceGroupControlPlane: resourceNames.outputs.resourceGroupControlPlane
-    resourceGroupHosts: resourceNames.outputs.resourceGroupHosts
-    resourceGroupManagement: resourceNames.outputs.resourceGroupManagement
+    recoveryServicesVaultName: names.outputs.resources.recoveryServicesVaultName
+    resourceGroupControlPlane: names.outputs.resources.resourceGroupControlPlane
+    resourceGroupHosts: names.outputs.resources.resourceGroupHosts
+    resourceGroupManagement: names.outputs.resources.resourceGroupManagement
     roleDefinitions: logic.outputs.roleDefinitions
     scalingBeginPeakTime: scalingBeginPeakTime
     scalingEndPeakTime: scalingEndPeakTime
@@ -638,10 +638,10 @@ module sessionHosts 'modules/sessionHosts/sessionHosts.bicep' = {
     scalingSessionThresholdPerCPU: scalingSessionThresholdPerCPU
     securityPrincipalObjectIds: map(securityPrincipals, item => item.objectId)
     securityLogAnalyticsWorkspaceResourceId: securityLogAnalyticsWorkspaceResourceId
-    serviceName: resourceNames.outputs.serviceName
+    serviceName: names.outputs.serviceName
     sessionHostBatchCount: logic.outputs.sessionHostBatchCount
     sessionHostIndex: sessionHostIndex
-    storageAccountPrefix: resourceNames.outputs.storageAccountNamePrefix
+    storageAccountPrefix: names.outputs.resources.storageAccountNamePrefix
     storageCount: storageCount
     storageIndex: storageIndex
     storageService: logic.outputs.storageService
@@ -652,7 +652,7 @@ module sessionHosts 'modules/sessionHosts/sessionHosts.bicep' = {
     timestamp: timestamp
     timeZone: logic.outputs.timeZone
     virtualMachineMonitoringAgent: virtualMachineMonitoringAgent
-    virtualMachineNamePrefix: resourceNames.outputs.virtualMachineNamePrefix
+    virtualMachineNamePrefix: names.outputs.resources.virtualMachineNamePrefix
     virtualMachinePassword: virtualMachinePassword
     virtualMachineSize: virtualMachineSize
     virtualMachineUsername: virtualMachineUsername
@@ -670,7 +670,7 @@ module cleanUp 'modules/cleanUp/cleanUp.bicep' = {
   params: {
     fslogixStorageService: fslogixStorageService
     location: locationVirtualMachines
-    resourceGroupManagement: resourceNames.outputs.resourceGroupManagement
+    resourceGroupManagement: names.outputs.resources.resourceGroupManagement
     scalingTool: scalingTool
     timestamp: timestamp
     userAssignedIdentityClientId: management.outputs.deploymentUserAssignedIdentityClientId

--- a/src/bicep/add-ons/azureVirtualDesktop/solution.json
+++ b/src/bicep/add-ons/azureVirtualDesktop/solution.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.25.53.49325",
-      "templateHash": "863071023426264754"
+      "templateHash": "8912363601065196823"
     }
   },
   "parameters": {
@@ -87,7 +87,7 @@
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "The friendly name for the Desktop application in the desktop application group."
+        "description": "The friendly name for the SessionDesktop application in the desktop application group."
       }
     },
     "disableBgpRoutePropagation": {
@@ -527,7 +527,7 @@
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('ResourceNames_{0}', parameters('timestamp'))]",
+      "name": "[format('Names_{0}', parameters('timestamp'))]",
       "location": "[deployment().location]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -558,7 +558,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.25.53.49325",
-              "templateHash": "6310782610199200457"
+              "templateHash": "1132830422672341823"
             }
           },
           "parameters": {
@@ -1017,351 +1017,114 @@
             },
             "locations": "[variables('$fxv#0')[environment().name]]",
             "resourceAbbreviations": "[variables('$fxv#1')]",
-            "agentSvcPrivateDnsZoneName": "[format('privatelink.agentsvc.azure-automation.{0}', coalesce(variables('privateDnsZoneSuffixes_AzureAutomation')[environment().name], variables('cloudEndpointSuffix')))]",
-            "automationAccountDiagnosticSettingName": "[replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').diagnosticSettings), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "automationAccountName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').automationAccounts), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "automationAccountNetworkInterfaceName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), format('DSCAndHybridWorker-{0}', variables('resourceAbbreviations').automationAccounts)), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "automationAccountPrivateEndpointName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), format('DSCAndHybridWorker-{0}', variables('resourceAbbreviations').automationAccounts)), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "availabilitySetNamePrefix": "[format('{0}-', replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').availabilitySets), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation))]",
-            "avdGlobalPrivateDnsZoneName": "[format('privatelink-global.wvd.{0}', coalesce(variables('privateDnsZoneSuffixes_AzureVirtualDesktop')[environment().name], variables('cloudEndpointSuffix')))]",
-            "avdPrivateDnsZoneName": "[format('privatelink.wvd.{0}', coalesce(variables('privateDnsZoneSuffixes_AzureVirtualDesktop')[environment().name], variables('cloudEndpointSuffix')))]",
-            "azureAutomationPrivateDnsZoneName": "[format('privatelink.azure-automation.{0}', coalesce(variables('privateDnsZoneSuffixes_AzureAutomation')[environment().name], variables('cloudEndpointSuffix')))]",
-            "backupPrivateDnsZoneName": "[format('privatelink.{0}.backup.{1}', variables('locations')[parameters('locationVirtualMachines')].recoveryServicesGeo, coalesce(variables('privateDnsZoneSuffixes_Backup')[environment().name], variables('cloudEndpointSuffix')))]",
-            "blobPrivateDnsZoneName": "[format('privatelink.blob.{0}', environment().suffixes.storage)]",
-            "dataCollectionRuleAssociationName": "[format('{0}-avdi', replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').dataCollectionRuleAssociations), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation))]",
-            "dataCollectionRuleName": "[format('microsoft-avdi-{0}', variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "desktopApplicationGroupName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').desktopApplicationGroups), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "diskAccessName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').diskAccesses), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "diskEncryptionSetName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').diskEncryptionSets), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "diskNamePrefix": "[replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').disks), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "filePrivateDnsZoneName": "[format('privatelink.file.{0}', environment().suffixes.storage)]",
-            "fileShareNames": {
-              "CloudCacheProfileContainer": [
-                "profile-containers"
+            "resources": {
+              "agentSvcPrivateDnsZoneName": "[format('privatelink.agentsvc.azure-automation.{0}', coalesce(variables('privateDnsZoneSuffixes_AzureAutomation')[environment().name], variables('cloudEndpointSuffix')))]",
+              "automationAccountDiagnosticSettingName": "[replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').diagnosticSettings), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "automationAccountName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').automationAccounts), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "automationAccountNetworkInterfaceName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), format('DSCAndHybridWorker-{0}', variables('resourceAbbreviations').automationAccounts)), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "automationAccountPrivateEndpointName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), format('DSCAndHybridWorker-{0}', variables('resourceAbbreviations').automationAccounts)), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "availabilitySetNamePrefix": "[format('{0}-', replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').availabilitySets), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation))]",
+              "avdGlobalPrivateDnsZoneName": "[format('privatelink-global.wvd.{0}', coalesce(variables('privateDnsZoneSuffixes_AzureVirtualDesktop')[environment().name], variables('cloudEndpointSuffix')))]",
+              "avdPrivateDnsZoneName": "[format('privatelink.wvd.{0}', coalesce(variables('privateDnsZoneSuffixes_AzureVirtualDesktop')[environment().name], variables('cloudEndpointSuffix')))]",
+              "azureAutomationPrivateDnsZoneName": "[format('privatelink.azure-automation.{0}', coalesce(variables('privateDnsZoneSuffixes_AzureAutomation')[environment().name], variables('cloudEndpointSuffix')))]",
+              "backupPrivateDnsZoneName": "[format('privatelink.{0}.backup.{1}', variables('locations')[parameters('locationVirtualMachines')].recoveryServicesGeo, coalesce(variables('privateDnsZoneSuffixes_Backup')[environment().name], variables('cloudEndpointSuffix')))]",
+              "blobPrivateDnsZoneName": "[format('privatelink.blob.{0}', environment().suffixes.storage)]",
+              "dataCollectionRuleAssociationName": "[format('{0}-avdi', replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').dataCollectionRuleAssociations), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation))]",
+              "dataCollectionRuleName": "[format('microsoft-avdi-{0}', variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "desktopApplicationGroupName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').desktopApplicationGroups), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "diskAccessName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').diskAccesses), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "diskEncryptionSetName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').diskEncryptionSets), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "diskNamePrefix": "[replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').disks), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "filePrivateDnsZoneName": "[format('privatelink.file.{0}', environment().suffixes.storage)]",
+              "fileShareNames": {
+                "CloudCacheProfileContainer": [
+                  "profile-containers"
+                ],
+                "CloudCacheProfileOfficeContainer": [
+                  "office-containers",
+                  "profile-containers"
+                ],
+                "ProfileContainer": [
+                  "profile-containers"
+                ],
+                "ProfileOfficeContainer": [
+                  "office-containers",
+                  "profile-containers"
+                ]
+              },
+              "hostPoolDiagnosticSettingName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').diagnosticSettings), variables('serviceName'), variables('resourceAbbreviations').hostPools), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "hostPoolName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').hostPools), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "hostPoolNetworkInterfaceName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), variables('resourceAbbreviations').hostPools), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "hostPoolPrivateEndpointName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), variables('resourceAbbreviations').hostPools), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "keyVaultName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').keyVaults), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "keyVaultNetworkInterfaceName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), variables('resourceAbbreviations').keyVaults), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "keyVaultPrivateDnsZoneName": "[replace(format('privatelink{0}', environment().suffixes.keyvaultDns), 'vault', 'vaultcore')]",
+              "keyVaultPrivateEndpointName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), variables('resourceAbbreviations').keyVaults), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "logAnalyticsWorkspaceName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').logAnalyticsWorkspaces), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "netAppAccountName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').netAppAccounts), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "netAppCapacityPoolName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').netAppCapacityPools), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "networkInterfaceNamePrefix": "[replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "networkSecurityGroupNames": [
+                "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkSecurityGroups), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+                "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkSecurityGroups), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]"
               ],
-              "CloudCacheProfileOfficeContainer": [
-                "office-containers",
-                "profile-containers"
+              "monitorPrivateDnsZoneName": "[format('privatelink.monitor.{0}', coalesce(variables('privateDnsZoneSuffixes_Monitor')[environment().name], variables('cloudEndpointSuffix')))]",
+              "odsOpinsightsPrivateDnsZoneName": "[format('privatelink.ods.opinsights.{0}', coalesce(variables('privateDnsZoneSuffixes_Monitor')[environment().name], variables('cloudEndpointSuffix')))]",
+              "omsOpinsightsPrivateDnsZoneName": "[format('privatelink.oms.opinsights.{0}', coalesce(variables('privateDnsZoneSuffixes_Monitor')[environment().name], variables('cloudEndpointSuffix')))]",
+              "queuePrivateDnsZoneName": "[format('privatelink.queue.{0}', environment().suffixes.storage)]",
+              "recoveryServicesVaultName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').recoveryServicesVaults), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "recoveryServicesVaultNetworkInterfaceName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), variables('resourceAbbreviations').recoveryServicesVaults), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "recoveryServicesVaultPrivateEndpointName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), variables('resourceAbbreviations').recoveryServicesVaults), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "resourceGroupControlPlane": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'controlPlane'), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "resourceGroupFeedWorkspace": "[replace(replace(replace(variables('namingConvention_Shared'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'feedWorkspace'), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "resourceGroupGlobalWorkspace": "[replace(replace(replace(variables('namingConvention_Global'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'globalWorkspace'), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "resourceGroupHosts": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'sessionHosts'), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "resourceGroupManagement": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'management'), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "resourceGroupsNetwork": [
+                "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'network'), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+                "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'network'), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]"
               ],
-              "ProfileContainer": [
-                "profile-containers"
+              "resourceGroupStorage": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'profileStorage'), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "routeTableNames": [
+                "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').routeTables), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+                "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').routeTables), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]"
               ],
-              "ProfileOfficeContainer": [
-                "office-containers",
-                "profile-containers"
-              ]
-            },
-            "hostPoolDiagnosticSettingName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').diagnosticSettings), variables('serviceName'), variables('resourceAbbreviations').hostPools), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "hostPoolName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').hostPools), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "hostPoolNetworkInterfaceName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), variables('resourceAbbreviations').hostPools), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "hostPoolPrivateEndpointName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), variables('resourceAbbreviations').hostPools), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "keyVaultName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').keyVaults), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "keyVaultNetworkInterfaceName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), variables('resourceAbbreviations').keyVaults), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "keyVaultPrivateDnsZoneName": "[replace(format('privatelink{0}', environment().suffixes.keyvaultDns), 'vault', 'vaultcore')]",
-            "keyVaultPrivateEndpointName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), variables('resourceAbbreviations').keyVaults), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "logAnalyticsWorkspaceName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').logAnalyticsWorkspaces), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "netAppAccountName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').netAppAccounts), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "netAppCapacityPoolName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').netAppCapacityPools), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "networkInterfaceNamePrefix": "[replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "networkSecurityGroupNames": [
-              "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkSecurityGroups), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-              "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkSecurityGroups), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]"
-            ],
-            "monitorPrivateDnsZoneName": "[format('privatelink.monitor.{0}', coalesce(variables('privateDnsZoneSuffixes_Monitor')[environment().name], variables('cloudEndpointSuffix')))]",
-            "odsOpinsightsPrivateDnsZoneName": "[format('privatelink.ods.opinsights.{0}', coalesce(variables('privateDnsZoneSuffixes_Monitor')[environment().name], variables('cloudEndpointSuffix')))]",
-            "omsOpinsightsPrivateDnsZoneName": "[format('privatelink.oms.opinsights.{0}', coalesce(variables('privateDnsZoneSuffixes_Monitor')[environment().name], variables('cloudEndpointSuffix')))]",
-            "queuePrivateDnsZoneName": "[format('privatelink.queue.{0}', environment().suffixes.storage)]",
-            "recoveryServicesVaultName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').recoveryServicesVaults), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "recoveryServicesVaultNetworkInterfaceName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), variables('resourceAbbreviations').recoveryServicesVaults), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "recoveryServicesVaultPrivateEndpointName": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), variables('resourceAbbreviations').recoveryServicesVaults), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "resourceGroupControlPlane": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'controlPlane'), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "resourceGroupFeedWorkspace": "[replace(replace(replace(variables('namingConvention_Shared'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'feedWorkspace'), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "resourceGroupGlobalWorkspace": "[replace(replace(replace(variables('namingConvention_Global'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'globalWorkspace'), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "resourceGroupHosts": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'sessionHosts'), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "resourceGroupManagement": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'management'), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "resourceGroupsNetwork": [
-              "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'network'), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-              "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'network'), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]"
-            ],
-            "resourceGroupStorage": "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').resourceGroups), variables('serviceName'), 'profileStorage'), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "routeTables": [
-              "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').routeTables), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-              "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').routeTables), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]"
-            ],
-            "storageAccountNamePrefix": "[replace(replace(replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').storageAccounts), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation), parameters('environmentAbbreviation'), first(parameters('environmentAbbreviation'))), '-', '')]",
-            "storageAccountNetworkInterfaceNamePrefix": "[replace(replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), variables('resourceAbbreviations').storageAccounts), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation), parameters('environmentAbbreviation'), first(parameters('environmentAbbreviation')))]",
-            "storageAccountPrivateEndpointNamePrefix": "[replace(replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), variables('resourceAbbreviations').storageAccounts), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation), parameters('environmentAbbreviation'), first(parameters('environmentAbbreviation')))]",
-            "userAssignedIdentityNamePrefix": "[replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').userAssignedIdentities), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
-            "virtualMachineNamePrefix": "[replace(replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').virtualMachines), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation), parameters('environmentAbbreviation'), first(parameters('environmentAbbreviation'))), '-', '')]",
-            "virtualNetworkNames": [
-              "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').virtualNetworks), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-              "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').virtualNetworks), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]"
-            ],
-            "workspaceFeedDiagnosticSettingName": "[replace(replace(replace(variables('namingConvention_Shared'), variables('resourceAbbreviation'), variables('resourceAbbreviations').diagnosticSettings), variables('serviceName'), format('feed-{0}', variables('resourceAbbreviations').workspaces)), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "workspaceFeedName": "[replace(replace(replace(variables('namingConvention_Shared'), variables('resourceAbbreviation'), format('feed-{0}', variables('resourceAbbreviations').workspaces)), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "workspaceFeedNetworkInterfaceName": "[replace(replace(replace(variables('namingConvention_Shared'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), format('feed-{0}', variables('resourceAbbreviations').workspaces)), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "workspaceFeedPrivateEndpointName": "[replace(replace(replace(variables('namingConvention_Shared'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), format('feed-{0}', variables('resourceAbbreviations').workspaces)), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "workspaceGlobalName": "[replace(replace(replace(variables('namingConvention_Global'), variables('resourceAbbreviation'), format('global-{0}', variables('resourceAbbreviations').workspaces)), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "workspaceGlobalNetworkInterfaceName": "[replace(replace(replace(variables('namingConvention_Global'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), format('global-{0}', variables('resourceAbbreviations').workspaces)), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
-            "workspaceGlobalPrivateEndpointName": "[replace(replace(replace(variables('namingConvention_Global'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), format('global-{0}', variables('resourceAbbreviations').workspaces)), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]"
+              "storageAccountNamePrefix": "[replace(replace(replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').storageAccounts), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation), parameters('environmentAbbreviation'), first(parameters('environmentAbbreviation'))), '-', '')]",
+              "storageAccountNetworkInterfaceNamePrefix": "[replace(replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), variables('resourceAbbreviations').storageAccounts), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation), parameters('environmentAbbreviation'), first(parameters('environmentAbbreviation')))]",
+              "storageAccountPrivateEndpointNamePrefix": "[replace(replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), variables('resourceAbbreviations').storageAccounts), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation), parameters('environmentAbbreviation'), first(parameters('environmentAbbreviation')))]",
+              "userAssignedIdentityNamePrefix": "[replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').userAssignedIdentities), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]",
+              "virtualMachineNamePrefix": "[replace(replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').virtualMachines), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation), parameters('environmentAbbreviation'), first(parameters('environmentAbbreviation'))), '-', '')]",
+              "virtualNetworkNames": [
+                "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').virtualNetworks), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+                "[replace(replace(replace(variables('namingConvention'), variables('resourceAbbreviation'), variables('resourceAbbreviations').virtualNetworks), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationVirtualMachines')].abbreviation)]"
+              ],
+              "workspaceFeedDiagnosticSettingName": "[replace(replace(replace(variables('namingConvention_Shared'), variables('resourceAbbreviation'), variables('resourceAbbreviations').diagnosticSettings), variables('serviceName'), format('feed-{0}', variables('resourceAbbreviations').workspaces)), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "workspaceFeedName": "[replace(replace(replace(variables('namingConvention_Shared'), variables('resourceAbbreviation'), format('feed-{0}', variables('resourceAbbreviations').workspaces)), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "workspaceFeedNetworkInterfaceName": "[replace(replace(replace(variables('namingConvention_Shared'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), format('feed-{0}', variables('resourceAbbreviations').workspaces)), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "workspaceFeedPrivateEndpointName": "[replace(replace(replace(variables('namingConvention_Shared'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), format('feed-{0}', variables('resourceAbbreviations').workspaces)), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "workspaceFriendlyName": "[replace(replace(replace(variables('namingConvention_Shared'), variables('resourceAbbreviation'), variables('resourceAbbreviations').workspaces), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "workspaceGlobalName": "[replace(replace(replace(variables('namingConvention_Global'), variables('resourceAbbreviation'), format('global-{0}', variables('resourceAbbreviations').workspaces)), format('-{0}', variables('serviceName')), ''), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "workspaceGlobalNetworkInterfaceName": "[replace(replace(replace(variables('namingConvention_Global'), variables('resourceAbbreviation'), variables('resourceAbbreviations').networkInterfaces), variables('serviceName'), format('global-{0}', variables('resourceAbbreviations').workspaces)), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]",
+              "workspaceGlobalPrivateEndpointName": "[replace(replace(replace(variables('namingConvention_Global'), variables('resourceAbbreviation'), variables('resourceAbbreviations').privateEndpoints), variables('serviceName'), format('global-{0}', variables('resourceAbbreviations').workspaces)), variables('locationAbbreviation'), variables('locations')[parameters('locationControlPlane')].abbreviation)]"
+            }
           },
           "resources": [],
           "outputs": {
-            "agentSvcPrivateDnsZoneName": {
-              "type": "string",
-              "value": "[variables('agentSvcPrivateDnsZoneName')]"
-            },
-            "automationAccountDiagnosticSettingName": {
-              "type": "string",
-              "value": "[variables('automationAccountDiagnosticSettingName')]"
-            },
-            "automationAccountName": {
-              "type": "string",
-              "value": "[variables('automationAccountName')]"
-            },
-            "automationAccountNetworkInterfaceName": {
-              "type": "string",
-              "value": "[variables('automationAccountNetworkInterfaceName')]"
-            },
-            "automationAccountPrivateEndpointName": {
-              "type": "string",
-              "value": "[variables('automationAccountPrivateEndpointName')]"
-            },
-            "availabilitySetNamePrefix": {
-              "type": "string",
-              "value": "[variables('availabilitySetNamePrefix')]"
-            },
-            "avdGlobalPrivateDnsZoneName": {
-              "type": "string",
-              "value": "[variables('avdGlobalPrivateDnsZoneName')]"
-            },
-            "avdPrivateDnsZoneName": {
-              "type": "string",
-              "value": "[variables('avdPrivateDnsZoneName')]"
-            },
-            "azureAutomationPrivateDnsZoneName": {
-              "type": "string",
-              "value": "[variables('azureAutomationPrivateDnsZoneName')]"
-            },
-            "backupPrivateDnsZoneName": {
-              "type": "string",
-              "value": "[variables('backupPrivateDnsZoneName')]"
-            },
-            "blobPrivateDnsZoneName": {
-              "type": "string",
-              "value": "[variables('blobPrivateDnsZoneName')]"
-            },
-            "dataCollectionRuleAssociationName": {
-              "type": "string",
-              "value": "[variables('dataCollectionRuleAssociationName')]"
-            },
-            "dataCollectionRuleName": {
-              "type": "string",
-              "value": "[variables('dataCollectionRuleName')]"
-            },
-            "desktopApplicationGroupName": {
-              "type": "string",
-              "value": "[variables('desktopApplicationGroupName')]"
-            },
-            "diskAccessName": {
-              "type": "string",
-              "value": "[variables('diskAccessName')]"
-            },
-            "diskEncryptionSetName": {
-              "type": "string",
-              "value": "[variables('diskEncryptionSetName')]"
-            },
-            "diskNamePrefix": {
-              "type": "string",
-              "value": "[variables('diskNamePrefix')]"
-            },
-            "filePrivateDnsZoneName": {
-              "type": "string",
-              "value": "[variables('filePrivateDnsZoneName')]"
-            },
-            "fileShareNames": {
-              "type": "object",
-              "value": "[variables('fileShareNames')]"
-            },
-            "hostPoolDiagnosticSettingName": {
-              "type": "string",
-              "value": "[variables('hostPoolDiagnosticSettingName')]"
-            },
-            "hostPoolName": {
-              "type": "string",
-              "value": "[variables('hostPoolName')]"
-            },
-            "hostPoolNetworkInterfaceName": {
-              "type": "string",
-              "value": "[variables('hostPoolNetworkInterfaceName')]"
-            },
-            "hostPoolPrivateEndpointName": {
-              "type": "string",
-              "value": "[variables('hostPoolPrivateEndpointName')]"
-            },
-            "keyVaultName": {
-              "type": "string",
-              "value": "[variables('keyVaultName')]"
-            },
-            "keyVaultNetworkInterfaceName": {
-              "type": "string",
-              "value": "[variables('keyVaultNetworkInterfaceName')]"
-            },
-            "keyVaultPrivateDnsZoneName": {
-              "type": "string",
-              "value": "[variables('keyVaultPrivateDnsZoneName')]"
-            },
-            "keyVaultPrivateEndpointName": {
-              "type": "string",
-              "value": "[variables('keyVaultPrivateEndpointName')]"
-            },
             "locations": {
               "type": "object",
               "value": "[variables('locations')]"
-            },
-            "logAnalyticsWorkspaceName": {
-              "type": "string",
-              "value": "[variables('logAnalyticsWorkspaceName')]"
-            },
-            "monitorPrivateDnsZoneName": {
-              "type": "string",
-              "value": "[variables('monitorPrivateDnsZoneName')]"
-            },
-            "odsOpinsightsPrivateDnsZoneName": {
-              "type": "string",
-              "value": "[variables('odsOpinsightsPrivateDnsZoneName')]"
-            },
-            "omsOpinsightsPrivateDnsZoneName": {
-              "type": "string",
-              "value": "[variables('omsOpinsightsPrivateDnsZoneName')]"
-            },
-            "netAppAccountName": {
-              "type": "string",
-              "value": "[variables('netAppAccountName')]"
-            },
-            "netAppCapacityPoolName": {
-              "type": "string",
-              "value": "[variables('netAppCapacityPoolName')]"
-            },
-            "networkInterfaceNamePrefix": {
-              "type": "string",
-              "value": "[variables('networkInterfaceNamePrefix')]"
             },
             "networkName": {
               "type": "string",
               "value": "[variables('networkName')]"
             },
-            "networkSecurityGroupNames": {
-              "type": "array",
-              "value": "[variables('networkSecurityGroupNames')]"
-            },
-            "queuePrivateDnsZoneName": {
-              "type": "string",
-              "value": "[variables('queuePrivateDnsZoneName')]"
-            },
-            "recoveryServicesVaultName": {
-              "type": "string",
-              "value": "[variables('recoveryServicesVaultName')]"
-            },
-            "recoveryServicesVaultNetworkInterfaceName": {
-              "type": "string",
-              "value": "[variables('recoveryServicesVaultNetworkInterfaceName')]"
-            },
-            "recoveryServicesVaultPrivateEndpointName": {
-              "type": "string",
-              "value": "[variables('recoveryServicesVaultPrivateEndpointName')]"
-            },
-            "resourceAbbreviations": {
+            "resources": {
               "type": "object",
-              "value": "[variables('resourceAbbreviations')]"
-            },
-            "resourceGroupControlPlane": {
-              "type": "string",
-              "value": "[variables('resourceGroupControlPlane')]"
-            },
-            "resourceGroupFeedWorkspace": {
-              "type": "string",
-              "value": "[variables('resourceGroupFeedWorkspace')]"
-            },
-            "resourceGroupGlobalWorkspace": {
-              "type": "string",
-              "value": "[variables('resourceGroupGlobalWorkspace')]"
-            },
-            "resourceGroupHosts": {
-              "type": "string",
-              "value": "[variables('resourceGroupHosts')]"
-            },
-            "resourceGroupManagement": {
-              "type": "string",
-              "value": "[variables('resourceGroupManagement')]"
-            },
-            "resourceGroupsNetwork": {
-              "type": "array",
-              "value": "[variables('resourceGroupsNetwork')]"
-            },
-            "resourceGroupStorage": {
-              "type": "string",
-              "value": "[variables('resourceGroupStorage')]"
-            },
-            "routeTables": {
-              "type": "array",
-              "value": "[variables('routeTables')]"
+              "value": "[variables('resources')]"
             },
             "serviceName": {
               "type": "string",
               "value": "[variables('serviceName')]"
-            },
-            "storageAccountNamePrefix": {
-              "type": "string",
-              "value": "[variables('storageAccountNamePrefix')]"
-            },
-            "storageAccountNetworkInterfaceNamePrefix": {
-              "type": "string",
-              "value": "[variables('storageAccountNetworkInterfaceNamePrefix')]"
-            },
-            "storageAccountPrivateEndpointNamePrefix": {
-              "type": "string",
-              "value": "[variables('storageAccountPrivateEndpointNamePrefix')]"
-            },
-            "userAssignedIdentityNamePrefix": {
-              "type": "string",
-              "value": "[variables('userAssignedIdentityNamePrefix')]"
-            },
-            "virtualMachineNamePrefix": {
-              "type": "string",
-              "value": "[variables('virtualMachineNamePrefix')]"
-            },
-            "virtulNetworkNames": {
-              "type": "array",
-              "value": "[variables('virtualNetworkNames')]"
-            },
-            "workspaceFeedDiagnosticSettingName": {
-              "type": "string",
-              "value": "[variables('workspaceFeedDiagnosticSettingName')]"
-            },
-            "workspaceFeedName": {
-              "type": "string",
-              "value": "[variables('workspaceFeedName')]"
-            },
-            "workspaceFeedNetworkInterfaceName": {
-              "type": "string",
-              "value": "[variables('workspaceFeedNetworkInterfaceName')]"
-            },
-            "workspaceFeedPrivateEndpointName": {
-              "type": "string",
-              "value": "[variables('workspaceFeedPrivateEndpointName')]"
-            },
-            "workspaceGlobalName": {
-              "type": "string",
-              "value": "[variables('workspaceGlobalName')]"
-            },
-            "workspaceGlobalNetworkInterfaceName": {
-              "type": "string",
-              "value": "[variables('workspaceGlobalNetworkInterfaceName')]"
-            },
-            "workspaceGlobalPrivateEndpointName": {
-              "type": "string",
-              "value": "[variables('workspaceGlobalPrivateEndpointName')]"
             }
           }
         }
@@ -1391,7 +1154,7 @@
             "value": "[parameters('domainName')]"
           },
           "fileShareNames": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.fileShareNames.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.fileShareNames]"
           },
           "fslogixContainerType": {
             "value": "[parameters('fslogixContainerType')]"
@@ -1412,28 +1175,28 @@
             "value": "[parameters('imageSku')]"
           },
           "locations": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.locations.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.locations.value]"
           },
           "locationVirtualMachines": {
             "value": "[parameters('locationVirtualMachines')]"
           },
           "resourceGroupControlPlane": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupControlPlane.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupControlPlane]"
           },
           "resourceGroupFeedWorkspace": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupFeedWorkspace.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupFeedWorkspace]"
           },
           "resourceGroupHosts": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupHosts.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupHosts]"
           },
           "resourceGroupManagement": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupManagement.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupManagement]"
           },
           "resourceGroupsNetwork": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupsNetwork.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupsNetwork]"
           },
           "resourceGroupStorage": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupStorage.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupStorage]"
           },
           "securityPrincipals": {
             "value": "[parameters('securityPrincipals')]"
@@ -1445,7 +1208,7 @@
             "value": "[parameters('sessionHostIndex')]"
           },
           "virtualMachineNamePrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.virtualMachineNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.virtualMachineNamePrefix]"
           },
           "virtualMachineSize": {
             "value": "[parameters('virtualMachineSize')]"
@@ -1654,7 +1417,7 @@
         }
       },
       "dependsOn": [
-        "[subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp')))]"
+        "[subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp')))]"
       ]
     },
     {
@@ -1744,13 +1507,13 @@
             "value": "[variables('deploymentLocations')[0]]"
           },
           "networkSecurityGroupName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.networkSecurityGroupNames.value[0]]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.networkSecurityGroupNames[0]]"
           },
           "resourceGroupNetwork": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupsNetwork.value[0]]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupsNetwork[0]]"
           },
           "routeTableName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.routeTables.value[0]]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.routeTableNames[0]]"
           },
           "subnetAddressPrefixes": {
             "value": "[parameters('subnetAddressPrefixes')]"
@@ -1762,7 +1525,7 @@
             "value": "[parameters('virtualNetworkAddressPrefixes')]"
           },
           "virtualNetworkName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.virtulNetworkNames.value[0]]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.virtualNetworkNames[0]]"
           }
         },
         "template": {
@@ -2256,7 +2019,7 @@
         }
       },
       "dependsOn": [
-        "[subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp')))]",
+        "[subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp')))]",
         "rgs"
       ]
     },
@@ -2289,11 +2052,11 @@
             "value": "[variables('deploymentLocations')[1]]"
           },
           "networkSecurityGroupName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.networkSecurityGroupNames.value[1]]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.networkSecurityGroupNames[1]]"
           },
-          "resourceGroupNetwork": "[if(equals(length(variables('deploymentLocations')), 1), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupsNetwork.value[0]), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupsNetwork.value[1]))]",
+          "resourceGroupNetwork": "[if(equals(length(variables('deploymentLocations')), 1), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupsNetwork[0]), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupsNetwork[1]))]",
           "routeTableName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.routeTables.value[1]]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.routeTableNames[1]]"
           },
           "subnetAddressPrefixes": {
             "value": "[parameters('subnetAddressPrefixes')]"
@@ -2305,7 +2068,7 @@
             "value": "[parameters('virtualNetworkAddressPrefixes')]"
           },
           "virtualNetworkName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.virtulNetworkNames.value[1]]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.virtualNetworkNames[1]]"
           }
         },
         "template": {
@@ -2799,7 +2562,7 @@
         }
       },
       "dependsOn": [
-        "[subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp')))]",
+        "[subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp')))]",
         "rgs"
       ]
     },
@@ -2824,19 +2587,19 @@
             "value": "[variables('artifactsUri')]"
           },
           "automationAccountDiagnosticSettingName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.automationAccountDiagnosticSettingName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.automationAccountDiagnosticSettingName]"
           },
           "automationAccountName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.automationAccountName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.automationAccountName]"
           },
           "automationAccountNetworkInterfaceName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.automationAccountNetworkInterfaceName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.automationAccountNetworkInterfaceName]"
           },
           "automationAccountPrivateDnsZoneResourceId": {
-            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.azureAutomationPrivateDnsZoneName.value)]"
+            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.azureAutomationPrivateDnsZoneName)]"
           },
           "automationAccountPrivateEndpointName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.automationAccountPrivateEndpointName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.automationAccountPrivateEndpointName]"
           },
           "availability": {
             "value": "[parameters('availability')]"
@@ -2845,22 +2608,22 @@
             "value": "[parameters('avdObjectId')]"
           },
           "azureBlobsPrivateDnsZoneResourceId": {
-            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.blobPrivateDnsZoneName.value)]"
+            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.blobPrivateDnsZoneName)]"
           },
           "azurePowerShellModuleMsiName": {
             "value": "[parameters('azurePowerShellModuleMsiName')]"
           },
           "azureQueueStoragePrivateDnsZoneResourceId": {
-            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.queuePrivateDnsZoneName.value)]"
+            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.queuePrivateDnsZoneName)]"
           },
           "dataCollectionRuleName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.dataCollectionRuleName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.dataCollectionRuleName]"
           },
           "diskEncryptionSetName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.diskEncryptionSetName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.diskEncryptionSetName]"
           },
           "diskNamePrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.diskNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.diskNamePrefix]"
           },
           "diskSku": {
             "value": "[parameters('diskSku')]"
@@ -2887,7 +2650,7 @@
             "value": "[parameters('fslogixStorageService')]"
           },
           "hostPoolName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.hostPoolName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.hostPoolName]"
           },
           "hostPoolType": {
             "value": "[parameters('hostPoolType')]"
@@ -2896,22 +2659,22 @@
             "value": "[parameters('imageDefinitionResourceId')]"
           },
           "keyVaultName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.keyVaultName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.keyVaultName]"
           },
           "keyVaultNetworkInterfaceName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.keyVaultNetworkInterfaceName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.keyVaultNetworkInterfaceName]"
           },
           "keyVaultPrivateDnsZoneResourceId": {
-            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.keyVaultPrivateDnsZoneName.value)]"
+            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.keyVaultPrivateDnsZoneName)]"
           },
           "keyVaultPrivateEndpointName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.keyVaultPrivateEndpointName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.keyVaultPrivateEndpointName]"
           },
           "locationVirtualMachines": {
             "value": "[parameters('locationVirtualMachines')]"
           },
           "logAnalyticsWorkspaceName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.logAnalyticsWorkspaceName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.logAnalyticsWorkspaceName]"
           },
           "logAnalyticsWorkspaceRetention": {
             "value": "[parameters('logAnalyticsWorkspaceRetention')]"
@@ -2920,10 +2683,10 @@
             "value": "[parameters('logAnalyticsWorkspaceSku')]"
           },
           "networkInterfaceNamePrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.networkInterfaceNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.networkInterfaceNamePrefix]"
           },
           "networkName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.networkName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.networkName.value]"
           },
           "organizationalUnitPath": {
             "value": "[parameters('organizationalUnitPath')]"
@@ -2932,31 +2695,31 @@
             "value": "[parameters('recoveryServices')]"
           },
           "recoveryServicesPrivateDnsZoneResourceId": {
-            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.backupPrivateDnsZoneName.value)]"
+            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.backupPrivateDnsZoneName)]"
           },
           "recoveryServicesVaultName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.recoveryServicesVaultName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.recoveryServicesVaultName]"
           },
           "recoveryServicesVaultNetworkInterfaceName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.recoveryServicesVaultNetworkInterfaceName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.recoveryServicesVaultNetworkInterfaceName]"
           },
           "recoveryServicesVaultPrivateEndpointName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.recoveryServicesVaultPrivateEndpointName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.recoveryServicesVaultPrivateEndpointName]"
           },
           "resourceGroupControlPlane": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupControlPlane.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupControlPlane]"
           },
           "resourceGroupFeedWorkspace": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupFeedWorkspace.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupFeedWorkspace]"
           },
           "resourceGroupHosts": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupHosts.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupHosts]"
           },
           "resourceGroupManagement": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupManagement.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupManagement]"
           },
           "resourceGroupStorage": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupStorage.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupStorage]"
           },
           "roleDefinitions": {
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp'))), '2022-09-01').outputs.roleDefinitions.value]"
@@ -2968,7 +2731,7 @@
             "value": "[parameters('securityLogAnalyticsWorkspaceResourceId')]"
           },
           "serviceName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.serviceName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.serviceName.value]"
           },
           "sessionHostCount": {
             "value": "[parameters('sessionHostCount')]"
@@ -2987,13 +2750,13 @@
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp'))), '2022-09-01').outputs.timeZone.value]"
           },
           "userAssignedIdentityNamePrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.userAssignedIdentityNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.userAssignedIdentityNamePrefix]"
           },
           "virtualMachineMonitoringAgent": {
             "value": "[parameters('virtualMachineMonitoringAgent')]"
           },
           "virtualMachineNamePrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.virtualMachineNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.virtualMachineNamePrefix]"
           },
           "virtualMachinePassword": {
             "value": "[parameters('virtualMachinePassword')]"
@@ -3005,7 +2768,7 @@
             "value": "[parameters('virtualMachineUsername')]"
           },
           "workspaceFeedName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.workspaceFeedName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.workspaceFeedName]"
           }
         },
         "template": {
@@ -6114,9 +5877,9 @@
       },
       "dependsOn": [
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp')))]",
+        "[subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Network_ControlPlane_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Network_Hosts_{0}', parameters('timestamp')))]",
-        "[subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp')))]",
         "rgs"
       ]
     },
@@ -6136,25 +5899,25 @@
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp'))), '2022-09-01').outputs.existingFeedWorkspace.value]"
           },
           "globalWorkspacePrivateDnsZoneResourceId": {
-            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.avdGlobalPrivateDnsZoneName.value)]"
+            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.avdGlobalPrivateDnsZoneName)]"
           },
           "hubSubnetResourceId": {
             "value": "[parameters('hubSubnetResourceId')]"
           },
           "resourceGroupName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupGlobalWorkspace.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupGlobalWorkspace]"
           },
           "timestamp": {
             "value": "[parameters('timestamp')]"
           },
           "workspaceGlobalName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.workspaceGlobalName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.workspaceGlobalName]"
           },
           "workspaceGlobalNetworkInterfaceName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.workspaceGlobalNetworkInterfaceName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.workspaceGlobalNetworkInterfaceName]"
           },
           "workspaceGlobalPrivateEndpointName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.workspaceGlobalPrivateEndpointName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.workspaceGlobalPrivateEndpointName]"
           }
         },
         "template": {
@@ -6418,7 +6181,7 @@
       },
       "dependsOn": [
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp')))]",
-        "[subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp')))]"
+        "[subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp')))]"
       ]
     },
     {
@@ -6439,7 +6202,7 @@
             "value": "[variables('artifactsUri')]"
           },
           "avdPrivateDnsZoneResourceId": {
-            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.avdPrivateDnsZoneName.value)]"
+            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.avdPrivateDnsZoneName)]"
           },
           "customRdpProperty": {
             "value": "[parameters('customRdpProperty')]"
@@ -6448,25 +6211,23 @@
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp'))), '2022-09-01').outputs.deploymentUserAssignedIdentityClientId.value]"
           },
           "desktopApplicationGroupName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.desktopApplicationGroupName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.desktopApplicationGroupName]"
           },
-          "desktopFriendlyName": {
-            "value": "[parameters('desktopFriendlyName')]"
-          },
+          "desktopFriendlyName": "[if(empty(parameters('desktopFriendlyName')), createObject('value', string(parameters('stampIndex'))), createObject('value', parameters('desktopFriendlyName')))]",
           "existingFeedWorkspace": {
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp'))), '2022-09-01').outputs.existingFeedWorkspace.value]"
           },
           "hostPoolDiagnosticSettingName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.hostPoolDiagnosticSettingName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.hostPoolDiagnosticSettingName]"
           },
           "hostPoolName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.hostPoolName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.hostPoolName]"
           },
           "hostPoolNetworkInterfaceName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.hostPoolNetworkInterfaceName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.hostPoolNetworkInterfaceName]"
           },
           "hostPoolPrivateEndpointName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.hostPoolPrivateEndpointName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.hostPoolPrivateEndpointName]"
           },
           "hostPoolPublicNetworkAccess": {
             "value": "[parameters('hostPoolPublicNetworkAccess')]"
@@ -6491,13 +6252,13 @@
             "value": "[parameters('monitoring')]"
           },
           "resourceGroupControlPlane": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupControlPlane.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupControlPlane]"
           },
           "resourceGroupFeedWorkspace": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupFeedWorkspace.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupFeedWorkspace]"
           },
           "resourceGroupManagement": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupManagement.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupManagement]"
           },
           "roleDefinitions": {
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp'))), '2022-09-01').outputs.roleDefinitions.value]"
@@ -6521,20 +6282,18 @@
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp'))), '2022-09-01').outputs.vmTemplate.value]"
           },
           "workspaceFeedDiagnoticSettingName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.workspaceFeedDiagnosticSettingName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.workspaceFeedDiagnosticSettingName]"
           },
           "workspaceFeedName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.workspaceFeedName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.workspaceFeedName]"
           },
           "workspaceFeedNetworkInterfaceName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.workspaceFeedNetworkInterfaceName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.workspaceFeedNetworkInterfaceName]"
           },
           "workspaceFeedPrivateEndpointName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.workspaceFeedPrivateEndpointName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.workspaceFeedPrivateEndpointName]"
           },
-          "workspaceFriendlyName": {
-            "value": "[parameters('workspaceFriendlyName')]"
-          },
+          "workspaceFriendlyName": "[if(empty(parameters('workspaceFriendlyName')), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.workspaceFriendlyName), createObject('value', format('{0} ({1})', parameters('workspaceFriendlyName'), parameters('locationControlPlane'))))]",
           "workspacePublicNetworkAccess": {
             "value": "[parameters('workspacePublicNetworkAccess')]"
           }
@@ -6546,7 +6305,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.25.53.49325",
-              "templateHash": "13136411049517467464"
+              "templateHash": "8562591390584308199"
             }
           },
           "parameters": {
@@ -6640,19 +6399,19 @@
             "vmTemplate": {
               "type": "string"
             },
-            "workspaceFriendlyName": {
+            "workspaceFeedDiagnoticSettingName": {
               "type": "string"
             },
             "workspaceFeedName": {
-              "type": "string"
-            },
-            "workspaceFeedDiagnoticSettingName": {
               "type": "string"
             },
             "workspaceFeedNetworkInterfaceName": {
               "type": "string"
             },
             "workspaceFeedPrivateEndpointName": {
+              "type": "string"
+            },
+            "workspaceFriendlyName": {
               "type": "string"
             },
             "workspacePublicNetworkAccess": {
@@ -7198,9 +6957,6 @@
                   "existing": {
                     "value": "[parameters('existingFeedWorkspace')]"
                   },
-                  "friendlyName": {
-                    "value": "[parameters('workspaceFriendlyName')]"
-                  },
                   "hostPoolName": {
                     "value": "[parameters('hostPoolName')]"
                   },
@@ -7243,6 +6999,9 @@
                   "workspaceFeedPrivateEndpointName": {
                     "value": "[parameters('workspaceFeedPrivateEndpointName')]"
                   },
+                  "workspaceFriendlyName": {
+                    "value": "[parameters('workspaceFriendlyName')]"
+                  },
                   "workspacePublicNetworkAccess": {
                     "value": "[parameters('workspacePublicNetworkAccess')]"
                   }
@@ -7254,7 +7013,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.25.53.49325",
-                      "templateHash": "6054507976035578125"
+                      "templateHash": "13068066753709662450"
                     }
                   },
                   "parameters": {
@@ -7272,9 +7031,6 @@
                     },
                     "existing": {
                       "type": "bool"
-                    },
-                    "friendlyName": {
-                      "type": "string"
                     },
                     "hostPoolName": {
                       "type": "string"
@@ -7318,6 +7074,9 @@
                     "workspaceFeedPrivateEndpointName": {
                       "type": "string"
                     },
+                    "workspaceFriendlyName": {
+                      "type": "string"
+                    },
                     "workspacePublicNetworkAccess": {
                       "type": "string"
                     }
@@ -7332,7 +7091,7 @@
                       "tags": {},
                       "properties": {
                         "applicationGroupReferences": "[parameters('applicationGroupReferences')]",
-                        "friendlyName": "[if(empty(parameters('friendlyName')), parameters('hostPoolName'), format('{0} ({1})', parameters('friendlyName'), parameters('locationControlPlane')))]",
+                        "friendlyName": "[parameters('workspaceFriendlyName')]",
                         "publicNetworkAccess": "[parameters('workspacePublicNetworkAccess')]"
                       }
                     },
@@ -7534,8 +7293,8 @@
       "dependsOn": [
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp')))]",
+        "[subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Network_ControlPlane_{0}', parameters('timestamp')))]",
-        "[subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp')))]",
         "rgs"
       ]
     },
@@ -7560,13 +7319,13 @@
             "value": "[variables('artifactsUri')]"
           },
           "automationAccountName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.automationAccountName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.automationAccountName]"
           },
           "availability": {
             "value": "[parameters('availability')]"
           },
           "azureFilesPrivateDnsZoneResourceId": {
-            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.filePrivateDnsZoneName.value)]"
+            "value": "[format('{0}{1}', variables('privateDnsZoneResourceIdPrefix'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.filePrivateDnsZoneName)]"
           },
           "delegatedSubnetId": {
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp'))), '2022-09-01').outputs.validateANFSubnetId.value]"
@@ -7602,7 +7361,7 @@
             "value": "[parameters('fslogixStorageService')]"
           },
           "hostPoolName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.hostPoolName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.hostPoolName]"
           },
           "hostPoolType": {
             "value": "[parameters('hostPoolType')]"
@@ -7617,10 +7376,10 @@
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp'))), '2022-09-01').outputs.virtualMachineName.value]"
           },
           "netAppAccountName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.netAppAccountName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.netAppAccountName]"
           },
           "netAppCapacityPoolName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.netAppCapacityPoolName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.netAppCapacityPoolName]"
           },
           "netbios": {
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp'))), '2022-09-01').outputs.netbios.value]"
@@ -7632,16 +7391,16 @@
             "value": "[parameters('recoveryServices')]"
           },
           "recoveryServicesVaultName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.recoveryServicesVaultName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.recoveryServicesVaultName]"
           },
           "resourceGroupControlPlane": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupControlPlane.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupControlPlane]"
           },
           "resourceGroupManagement": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupManagement.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupManagement]"
           },
           "resourceGroupStorage": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupStorage.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupStorage]"
           },
           "securityPrincipalNames": {
             "value": "[map(parameters('securityPrincipals'), lambda('item', lambdaVariables('item').name))]"
@@ -7650,19 +7409,19 @@
             "value": "[map(parameters('securityPrincipals'), lambda('item', lambdaVariables('item').objectId))]"
           },
           "serviceName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.serviceName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.serviceName.value]"
           },
           "smbServerLocation": {
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp'))), '2022-09-01').outputs.smbServerLocation.value]"
           },
           "storageAccountNamePrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.storageAccountNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.storageAccountNamePrefix]"
           },
           "storageAccountNetworkInterfaceNamePrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.storageAccountNetworkInterfaceNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.storageAccountNetworkInterfaceNamePrefix]"
           },
           "storageAccountPrivateEndpointNamePrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.storageAccountPrivateEndpointNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.storageAccountPrivateEndpointNamePrefix]"
           },
           "storageCount": {
             "value": "[parameters('storageCount')]"
@@ -9564,9 +9323,9 @@
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('ControlPlane_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp')))]",
+        "[subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Network_ControlPlane_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Network_Hosts_{0}', parameters('timestamp')))]",
-        "[subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp')))]",
         "rgs"
       ]
     },
@@ -9597,13 +9356,13 @@
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp'))), '2022-09-01').outputs.artifactsUserAssignedIdentityResourceId.value]"
           },
           "automationAccountName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.automationAccountName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.automationAccountName]"
           },
           "availability": {
             "value": "[parameters('availability')]"
           },
           "availabilitySetNamePrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.availabilitySetNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.availabilitySetNamePrefix]"
           },
           "availabilitySetsCount": {
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp'))), '2022-09-01').outputs.availabilitySetsCount.value]"
@@ -9621,7 +9380,7 @@
             "value": "[parameters('avdAgentMsiName')]"
           },
           "dataCollectionRuleAssociationName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.dataCollectionRuleAssociationName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.dataCollectionRuleAssociationName]"
           },
           "dataCollectionRuleResourceId": {
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp'))), '2022-09-01').outputs.dataCollectionRuleResourceId.value]"
@@ -9633,7 +9392,7 @@
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp'))), '2022-09-01').outputs.diskEncryptionSetResourceId.value]"
           },
           "diskNamePrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.diskNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.diskNamePrefix]"
           },
           "diskSku": {
             "value": "[parameters('diskSku')]"
@@ -9666,7 +9425,7 @@
             "value": "[parameters('fslogixContainerType')]"
           },
           "hostPoolName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.hostPoolName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.hostPoolName]"
           },
           "hostPoolType": {
             "value": "[parameters('hostPoolType')]"
@@ -9690,7 +9449,7 @@
             "value": "[parameters('locationVirtualMachines')]"
           },
           "logAnalyticsWorkspaceName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.logAnalyticsWorkspaceName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.logAnalyticsWorkspaceName]"
           },
           "managementVirtualMachineName": {
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp'))), '2022-09-01').outputs.virtualMachineName.value]"
@@ -9703,10 +9462,10 @@
           },
           "netAppFileShares": "[if(reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp'))), '2022-09-01').outputs.fslogix.value, createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('FSLogix_{0}', parameters('timestamp'))), '2022-09-01').outputs.netAppShares.value), createObject('value', createArray('None')))]",
           "networkInterfaceNamePrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.networkInterfaceNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.networkInterfaceNamePrefix]"
           },
           "networkName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.networkName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.networkName.value]"
           },
           "organizationalUnitPath": {
             "value": "[parameters('organizationalUnitPath')]"
@@ -9715,16 +9474,16 @@
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp'))), '2022-09-01').outputs.pooledHostPool.value]"
           },
           "recoveryServicesVaultName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.recoveryServicesVaultName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.recoveryServicesVaultName]"
           },
           "resourceGroupControlPlane": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupControlPlane.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupControlPlane]"
           },
           "resourceGroupHosts": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupHosts.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupHosts]"
           },
           "resourceGroupManagement": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupManagement.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupManagement]"
           },
           "roleDefinitions": {
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp'))), '2022-09-01').outputs.roleDefinitions.value]"
@@ -9751,7 +9510,7 @@
             "value": "[parameters('securityLogAnalyticsWorkspaceResourceId')]"
           },
           "serviceName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.serviceName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.serviceName.value]"
           },
           "sessionHostBatchCount": {
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp'))), '2022-09-01').outputs.sessionHostBatchCount.value]"
@@ -9760,7 +9519,7 @@
             "value": "[parameters('sessionHostIndex')]"
           },
           "storageAccountPrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.storageAccountNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.storageAccountNamePrefix]"
           },
           "storageCount": {
             "value": "[parameters('storageCount')]"
@@ -9791,7 +9550,7 @@
             "value": "[parameters('virtualMachineMonitoringAgent')]"
           },
           "virtualMachineNamePrefix": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.virtualMachineNamePrefix.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.virtualMachineNamePrefix]"
           },
           "virtualMachinePassword": {
             "value": "[parameters('virtualMachinePassword')]"
@@ -11707,9 +11466,9 @@
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('FSLogix_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Logic_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp')))]",
+        "[subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Network_ControlPlane_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Network_Hosts_{0}', parameters('timestamp')))]",
-        "[subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp')))]",
         "rgs"
       ]
     },
@@ -11731,7 +11490,7 @@
             "value": "[parameters('locationVirtualMachines')]"
           },
           "resourceGroupManagement": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp'))), '2022-09-01').outputs.resourceGroupManagement.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp'))), '2022-09-01').outputs.resources.value.resourceGroupManagement]"
           },
           "scalingTool": {
             "value": "[parameters('scalingTool')]"
@@ -11873,7 +11632,7 @@
       "dependsOn": [
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('FSLogix_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Management_{0}', parameters('timestamp')))]",
-        "[subscriptionResourceId('Microsoft.Resources/deployments', format('ResourceNames_{0}', parameters('timestamp')))]",
+        "[subscriptionResourceId('Microsoft.Resources/deployments', format('Names_{0}', parameters('timestamp')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('SessionHosts_{0}', parameters('timestamp')))]"
       ]
     }


### PR DESCRIPTION
This required me to overhaul the resource names deployment since I hit a limit with outputs. There is a maximum limit of 64 outputs per deployment. So, to work around the issue, I put all the names into an object and passed that to one output.
