### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Our intent is to enable IT Admins to use this software to:
 
 - [ESRI ArcGIS Pro & Enterprise with AVD](./docs/esri.md)
 - [AVD (Azure Virtual Desktop)](./src/bicep/add-ons/azureVirtualDesktop/README.md)
-- [Zero Trust Imaging](./src/bicep/add-ons/Imaging/README.md)
+- [Zero Trust Imaging](./src/bicep/add-ons/imaging/README.md)
 
 ## What is a Landing Zone?
 


### PR DESCRIPTION
# Description

Fixed the broken Zero Trust Imaging link.

The issue was due to a typo: 'Imaging', instead of 'imaging'

## Issue reference

The issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
