### PR TITLE
Update esri.md

### DIFF
--- a/docs/esri.md
+++ b/docs/esri.md
@@ -37,10 +37,10 @@ If you already have an Azure Landing Zone, you can skip this step. For more on w
 
 ## Step 2
 
- :arrow_forward: The second step is to create the Windows image which will be used to create the Azure Virtual Desktops. This image will have ArcGIS Pro pre-installed when you use this template ->  [Zero Trust and Azure Imaging](https://github.com/Azure/missionlz/blob/main/src/bicep/add-ons/Imaging/README.md). Be sure to complete the necessary [prerequisites](https://github.com/Azure/missionlz/tree/main/src/bicep/add-ons/Imaging#prequisites).
+ :arrow_forward: The second step is to create the Windows image which will be used to create the Azure Virtual Desktops. This image will have ArcGIS Pro pre-installed when you use this template ->  [Zero Trust and Azure Imaging](https://github.com/Azure/missionlz/blob/main/src/bicep/add-ons/imaging/README.md). Be sure to complete the necessary [prerequisites](https://github.com/Azure/missionlz/tree/main/src/bicep/add-ons/imaging#prequisites).
 
 > [!WARNING]
-> Failure to complete the [prerequisites](https://github.com/Azure/missionlz/tree/main/src/bicep/add-ons/Imaging#prequisites) will result in an unsuccessful deployment.
+> Failure to complete the [prerequisites](https://github.com/Azure/missionlz/tree/main/src/bicep/add-ons/imaging#prequisites) will result in an unsuccessful deployment.
 
 ## Step 3
 


### PR DESCRIPTION
Update broken links for ZT imaging 

Blue button deployment is broken for ZTA imaging from the page ->      [missionlz/docs/esri.md at main · Azure/missionlz · GitHub](https://github.com/Azure/missionlz/blob/main/docs/esri.md)
 
All links related to Zero trust imaging  and perquisites are broken on the page  ->  [missionlz/docs/esri.md at main · Azure/missionlz · GitHub](https://github.com/Azure/missionlz/blob/main/docs/esri.md)

# Description

Update links and blue buttons with correct links for imaging vs Imaging 

## Issue reference

The issue this PR will close: #993 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [ ] All acceptance criteria in the backlog item are met
* [ ] The documentation is updated to cover any new or changed features
* [ ] Manual tests have passed
* [ ] Relevant issues are linked to this PR
