### PR TITLE
AVD Updates: GPU VM sizes & agent name

### DIFF
--- a/src/bicep/add-ons/azureVirtualDesktop/uiDefinition.json
+++ b/src/bicep/add-ons/azureVirtualDesktop/uiDefinition.json
@@ -736,10 +736,20 @@
                   ],
                   "constraints": {
                     "allowedSizes": [
+                      "Standard_NC4as_T4_v3",
+                      "Standard_NC8as_T4_v3",
+                      "Standard_NC16as_T4_v3",
+                      "Standard_NC64as_T4_v3",
                       "Standard_NV4as_v4",
+                      "Standard_NV6ads_A10_v5",
                       "Standard_NV8as_v4",
+                      "Standard_NV12ads_A10_v5",
                       "Standard_NV16as_v4",
-                      "Standard_NV32as_v4"
+                      "Standard_NV18ads_A10_v5",
+                      "Standard_NV32as_v4",
+                      "Standard_NV36adms_A10_v5",
+                      "Standard_NV36ads_A10_v5",
+                      "Standard_NV72ads_A10_v5"
                     ],
                     "numAvailabilityZonesRequired": "[if(equals(steps('hosts').virtualMachine.availability, 'AvailabilityZones'), 3, 1)]"
                   },

--- a/src/bicep/add-ons/azureVirtualDesktop/uiDefinition.json
+++ b/src/bicep/add-ons/azureVirtualDesktop/uiDefinition.json
@@ -1504,7 +1504,7 @@
                   "name": "avdAgentMsiName",
                   "type": "Microsoft.Common.TextBox",
                   "label": "Azure Virtual Desktop Agent (.msi)",
-                  "defaultValue": "Microsoft.RDInfra.RDAgent.Installer-x64-1.0.7909.2600.msi",
+                  "defaultValue": "Microsoft.RDInfra.RDAgent.Installer-x64-1.0.8297.800.msi",
                   "toolTip": "Input the file / blob name for the AVD Agent installer.",
                   "placeholder": "",
                   "multiLine": false,


### PR DESCRIPTION
# Description

- Updated VM sizes for ArcGIS deployment on AVD based on ESRI recommendations
- Updated the default AVD agent name to match the latest version name

## Issue reference

Issues are linked.

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
