### PR TITLE
Removed condition for friendly names

### DIFF
--- a/src/bicep/add-ons/azure-virtual-desktop/uiDefinition.json
+++ b/src/bicep/add-ons/azure-virtual-desktop/uiDefinition.json
@@ -517,7 +517,7 @@
               "name": "friendlyNames",
               "type": "Microsoft.Common.Section",
               "label": "Friendly Names for AVD Client",
-              "visible": "[not(equals(steps('basics').scenario.profile, 'arcGisPro'))]",
+              "visible": true,
               "elements": [
                 {
                   "name": "custom",


### PR DESCRIPTION
# Description

Removed condition for friendly names so the ArcGIS profile can create custom friendly names for the workspace and the desktop app.

## Issue reference

The issue this PR will close: #1042 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
