### PR TITLE
Update mlz.portal.json

### DIFF
--- a/src/bicep/form/mlz.portal.json
+++ b/src/bicep/form/mlz.portal.json
@@ -1265,7 +1265,7 @@
       "subscriptionId": "[steps('basics').hubSection.hubSubscriptionId]",
       "parameters": {
         "bastionHostSubnetAddressPrefix": "[steps('remoteAccess').azureBastionSection.bastionSubnetAddressCidrRange]",
-        "azureGateSubnetAddressPrefix": "[steps('remoteAccess').azureGatewaySubnetSection.azureGatewaySubnetAddressCidrRange]",
+        "azureGatewaySubnetAddressPrefix": "[steps('remoteAccess').azureGatewaySubnetSection.azureGatewaySubnetAddressCidrRange]",
         "defenderSkuTier": "[if(steps('compliance').defenderSection.deployDefender, 'Standard', 'Free')]",
         "deployDefenderPlans": "[steps('compliance').defenderSection.deployDefenderPlans]",
         "deployIdentity": "[steps('basics').identitySection.deployIdentity]",


### PR DESCRIPTION
# Description

Updated "azureGateSubnetAddressPrefix" in bicep/form/mlz.portal.json to say "azureGatewaySubnetAddressPrefix".  This enables users to deploy the template spec with other than default Gateway subnet settings, because it will error out otherwise, since the deployment will use the mlz.json setting for the Gateway Subnet and the mlz.portal.json entry won't match.

## Issue reference

The issue this PR will close: #1057

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
