### PR TITLE
committed by tim sweatman

### DIFF
--- a/docs/deployment-guide-templatespec.md
+++ b/docs/deployment-guide-templatespec.md
@@ -9,7 +9,7 @@ To mimic the Quickstart experience of an Azure Commercial or Azure Government ML
 - [MLZ-Core resources deployed](#mlz-core-resources-deployed)
 - [See Also](#see-also)
 
-This guide describes how to create an Azure TemplateSpecFile. The TemplateSpecFile is used to execute a user-friendly MLZ deployment GUI.  This GUI is the same Quickstart experience available in Azure Commercial and Azure Government. The TemplateSpec File is created via Powershell and requires only 2 files, [src/bicep/mlz.json](../src/bicep/mlz.json) and [src/bicep/form/mlz.portal.json](../src/bicep/form/mlz.json).
+This guide describes how to create an Azure TemplateSpecFile. The TemplateSpecFile is used to execute a user-friendly MLZ deployment GUI.  This GUI is the same Quickstart experience available in Azure Commercial and Azure Government. The TemplateSpec File is created via Powershell and requires only 2 files, [src/bicep/mlz.json](../src/bicep/mlz.json) and [src/bicep/form/mlz.portal.json](../src/bicep/form/mlz.portal.json).
 
 The TemplateSpecFile is created and deployed using the Azure Portal in Azure Secret and Azure Top Secret environments.
 

--- a/docs/deployment-guide-walkthrough.md
+++ b/docs/deployment-guide-walkthrough.md
@@ -114,10 +114,10 @@ If you wish to remotely access the network and the resources you've deployed you
 
 You will see check boxes for:
 
-Azure Bastion
-Azure Gateway Subnet
-Windows Virtual Machine
-Linux Virtual Machine
+- Azure Bastion
+- Azure Gateway Subnet
+- Windows Virtual Machine
+- Linux Virtual Machine
 
 Any or all 4 resources may be deployed.  See below for options for each resource.
 
@@ -127,14 +127,19 @@ Any or all 4 resources may be deployed.  See below for options for each resource
 >Note: GatewaySubnet is a reserved name in Azure and is required only if you plan to implement a Site-to-Site or ExpressRoute VPN.
 
 3. Windows VM:
+      1. Windows Server Version
+      1. VM size selector
       1. Username
-      2. Password
-      3. Password confirmation
-      4. Option for Hybrid Use Benefit for Windows [Azure Hybrid Benefit](https://learn.microsoft.com/en-us/windows-server/get-started/azure-hybrid-benefit?tabs=azure)
-4. Linux VM:
+      1. Password
+      1. Password confirmation
+      1. Option for Hybrid Use Benefit for Windows [Azure Hybrid Benefit](https://learn.microsoft.com/en-us/windows-server/get-started/azure-hybrid-benefit?tabs=azure)
+1. Linux VM:
+      1. Linux Image Publisher.  MLZ offers 3 Linux distributions; Ubuntu, RHEL, and Debian
+      1. Linux Image Offer.
+      1. Linux Image SKU.  *Note, some distributions of Linux have additional license fees.*
       1. Username
-      2. Password
-      3. Password confirmation
+      1. Password
+      1. Password confirmation
 
 Click the 'Next' button.
 

--- a/src/bicep/mlz.bicep
+++ b/src/bicep/mlz.bicep
@@ -696,6 +696,7 @@ module remoteAccess 'modules/remote-access.bicep' = {
       windowsVmSku: windowsVmSku
       windowsVmStorageAccountType: windowsVmStorageAccountType
       windowsVmVersion: windowsVmVersion
+      supportedClouds: supportedClouds
     }
     dependsOn: [
       monitoring

--- a/src/bicep/mlz.json
+++ b/src/bicep/mlz.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "14639382000576629473"
+      "version": "0.30.23.60470",
+      "templateHash": "4892862183602644778"
     }
   },
   "parameters": {
@@ -870,8 +870,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "17469290750660856958"
+              "version": "0.30.23.60470",
+              "templateHash": "14117250595774333622"
             }
           },
           "parameters": {
@@ -1426,8 +1426,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "3285265744534691733"
+                      "version": "0.30.23.60470",
+                      "templateHash": "16713240921630404332"
                     }
                   },
                   "parameters": {
@@ -1619,8 +1619,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "8260962618264109260"
+              "version": "0.30.23.60470",
+              "templateHash": "11616529434755756375"
             }
           },
           "parameters": {
@@ -1679,8 +1679,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "5234750876173141008"
+                      "version": "0.30.23.60470",
+                      "templateHash": "10109660736443081073"
                     }
                   },
                   "parameters": {
@@ -1820,8 +1820,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "2037199422160470107"
+              "version": "0.30.23.60470",
+              "templateHash": "4809808047082142014"
             }
           },
           "parameters": {
@@ -1997,8 +1997,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "14054160995340796296"
+                      "version": "0.30.23.60470",
+                      "templateHash": "246030726359755329"
                     }
                   },
                   "parameters": {
@@ -2265,8 +2265,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "17808155300289173522"
+                              "version": "0.30.23.60470",
+                              "templateHash": "6722359274420487391"
                             }
                           },
                           "parameters": {
@@ -2344,8 +2344,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "17808155300289173522"
+                              "version": "0.30.23.60470",
+                              "templateHash": "6722359274420487391"
                             }
                           },
                           "parameters": {
@@ -2425,8 +2425,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "14183263367109373810"
+                              "version": "0.30.23.60470",
+                              "templateHash": "12652296496577802490"
                             }
                           },
                           "parameters": {
@@ -2526,8 +2526,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "10414727145294879682"
+                              "version": "0.30.23.60470",
+                              "templateHash": "17592952825859536181"
                             }
                           },
                           "parameters": {
@@ -2595,8 +2595,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "17796159396533379538"
+                              "version": "0.30.23.60470",
+                              "templateHash": "7007835755326231171"
                             }
                           },
                           "parameters": {
@@ -2709,8 +2709,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "11047891281373657997"
+                              "version": "0.30.23.60470",
+                              "templateHash": "13031612584115851814"
                             }
                           },
                           "parameters": {
@@ -2799,8 +2799,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "11047891281373657997"
+                              "version": "0.30.23.60470",
+                              "templateHash": "13031612584115851814"
                             }
                           },
                           "parameters": {
@@ -2913,8 +2913,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "12686852917100824321"
+                              "version": "0.30.23.60470",
+                              "templateHash": "16308694041027148637"
                             }
                           },
                           "parameters": {
@@ -3314,8 +3314,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "6762829727523882200"
+                      "version": "0.30.23.60470",
+                      "templateHash": "11477260196395935688"
                     }
                   },
                   "parameters": {
@@ -3422,8 +3422,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "17808155300289173522"
+                              "version": "0.30.23.60470",
+                              "templateHash": "6722359274420487391"
                             }
                           },
                           "parameters": {
@@ -3505,8 +3505,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "14183263367109373810"
+                              "version": "0.30.23.60470",
+                              "templateHash": "12652296496577802490"
                             }
                           },
                           "parameters": {
@@ -3608,8 +3608,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "10414727145294879682"
+                              "version": "0.30.23.60470",
+                              "templateHash": "17592952825859536181"
                             }
                           },
                           "parameters": {
@@ -3685,8 +3685,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "17796159396533379538"
+                              "version": "0.30.23.60470",
+                              "templateHash": "7007835755326231171"
                             }
                           },
                           "parameters": {
@@ -3841,8 +3841,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "6626549726744561716"
+                      "version": "0.30.23.60470",
+                      "templateHash": "9502319494004310539"
                     }
                   },
                   "parameters": {
@@ -3894,8 +3894,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "6494272065213199360"
+                              "version": "0.30.23.60470",
+                              "templateHash": "2015499370398293300"
                             }
                           },
                           "parameters": {
@@ -3973,8 +3973,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "14391533606363017348"
+                      "version": "0.30.23.60470",
+                      "templateHash": "3832300165614083813"
                     }
                   },
                   "parameters": {
@@ -4026,8 +4026,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "6494272065213199360"
+                              "version": "0.30.23.60470",
+                              "templateHash": "2015499370398293300"
                             }
                           },
                           "parameters": {
@@ -4103,8 +4103,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "3133950788039401016"
+                      "version": "0.30.23.60470",
+                      "templateHash": "1136616241283939780"
                     }
                   },
                   "parameters": {
@@ -4180,8 +4180,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "6638338816646420429"
+                              "version": "0.30.23.60470",
+                              "templateHash": "2757774880390840506"
                             }
                           },
                           "parameters": {
@@ -4340,8 +4340,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "3164647736851795292"
+              "version": "0.30.23.60470",
+              "templateHash": "9357061110012098845"
             }
           },
           "parameters": {
@@ -4420,8 +4420,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "13329202385555792471"
+                      "version": "0.30.23.60470",
+                      "templateHash": "6048031664390946407"
                     }
                   },
                   "parameters": {
@@ -4671,8 +4671,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "14213851547349403574"
+                      "version": "0.30.23.60470",
+                      "templateHash": "17613382135787640077"
                     }
                   },
                   "parameters": {
@@ -4751,8 +4751,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "2709473749440196253"
+                              "version": "0.30.23.60470",
+                              "templateHash": "8372265102618018066"
                             }
                           },
                           "parameters": {
@@ -4846,8 +4846,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "7977802807183279972"
+                      "version": "0.30.23.60470",
+                      "templateHash": "6675708379514380442"
                     }
                   },
                   "parameters": {
@@ -4991,8 +4991,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "7280642304101909780"
+              "version": "0.30.23.60470",
+              "templateHash": "12909131647419502129"
             }
           },
           "parameters": {
@@ -5077,8 +5077,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "11282262359705918017"
+                      "version": "0.30.23.60470",
+                      "templateHash": "15985115749591574535"
                     }
                   },
                   "parameters": {
@@ -5245,8 +5245,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "17283694990791079299"
+                      "version": "0.30.23.60470",
+                      "templateHash": "4040791601769189381"
                     }
                   },
                   "parameters": {
@@ -5373,8 +5373,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "2426516581268538018"
+                      "version": "0.30.23.60470",
+                      "templateHash": "9321128177359823831"
                     }
                   },
                   "parameters": {
@@ -5586,6 +5586,9 @@
           },
           "windowsVmVersion": {
             "value": "[parameters('windowsVmVersion')]"
+          },
+          "supportedClouds": {
+            "value": "[parameters('supportedClouds')]"
           }
         },
         "template": {
@@ -5594,8 +5597,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "1691042747811391446"
+              "version": "0.30.23.60470",
+              "templateHash": "10003024423688333359"
             }
           },
           "parameters": {
@@ -5718,6 +5721,9 @@
             },
             "windowsVmVersion": {
               "type": "string"
+            },
+            "supportedClouds": {
+              "type": "array"
             }
           },
           "resources": [
@@ -5768,8 +5774,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "17140969170087199259"
+                      "version": "0.30.23.60470",
+                      "templateHash": "3093428281213661074"
                     }
                   },
                   "parameters": {
@@ -5906,6 +5912,9 @@
                   "tags": {
                     "value": "[parameters('tags')]"
                   },
+                  "supportedClouds": {
+                    "value": "[parameters('supportedClouds')]"
+                  },
                   "vmImagePublisher": {
                     "value": "[parameters('linuxVmImagePublisher')]"
                   },
@@ -5925,8 +5934,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "9946343440416011781"
+                      "version": "0.30.23.60470",
+                      "templateHash": "14634910200279952023"
                     }
                   },
                   "parameters": {
@@ -5994,6 +6003,9 @@
                     },
                     "vmSize": {
                       "type": "string"
+                    },
+                    "supportedClouds": {
+                      "type": "array"
                     }
                   },
                   "variables": {
@@ -6015,7 +6027,7 @@
                       "apiVersion": "2021-04-01",
                       "name": "[parameters('name')]",
                       "location": "[parameters('location')]",
-                      "tags": "[union(if(contains(parameters('tags'), 'Microsoft.Compute/virtualMachines'), parameters('tags')['Microsoft.Compute/virtualMachines'], createObject()), parameters('mlzTags'))]",
+                      "tags": "[parameters('tags')]",
                       "properties": {
                         "diagnosticsProfile": {
                           "bootDiagnostics": {
@@ -6081,11 +6093,13 @@
                       "apiVersion": "2021-03-01",
                       "name": "[format('{0}/{1}', parameters('name'), 'GuestAttestation')]",
                       "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
                       "properties": {
                         "publisher": "Microsoft.Azure.Security.LinuxAttestation",
                         "type": "GuestAttestation",
                         "typeHandlerVersion": "1.0",
                         "autoUpgradeMinorVersion": true,
+                        "enableAutomaticUpgrade": true,
                         "settings": {
                           "AttestationConfig": {
                             "MaaSettings": {
@@ -6110,6 +6124,7 @@
                       "apiVersion": "2021-04-01",
                       "name": "[format('{0}/{1}', parameters('name'), 'AzurePolicyforLinux')]",
                       "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
                       "properties": {
                         "publisher": "Microsoft.GuestConfiguration",
                         "type": "ConfigurationforLinux",
@@ -6129,7 +6144,9 @@
                       "properties": {
                         "publisher": "Microsoft.Azure.NetworkWatcher",
                         "type": "NetworkWatcherAgentLinux",
-                        "typeHandlerVersion": "1.4"
+                        "typeHandlerVersion": "1.4",
+                        "autoUpgradeMinorVersion": true,
+                        "enableAutomaticUpgrade": true
                       },
                       "dependsOn": [
                         "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('name'), 'AzurePolicyforLinux')]",
@@ -6137,6 +6154,29 @@
                       ]
                     },
                     {
+                      "condition": "[contains(parameters('supportedClouds'), environment().name)]",
+                      "type": "Microsoft.Compute/virtualMachines/extensions",
+                      "apiVersion": "2021-11-01",
+                      "name": "[format('{0}/{1}', parameters('name'), 'AzureMonitorLinuxAgent')]",
+                      "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "publisher": "Microsoft.Azure.Monitor",
+                        "type": "AzureMonitorLinuxAgent",
+                        "typeHandlerVersion": "1.21",
+                        "autoUpgradeMinorVersion": true,
+                        "enableAutomaticUpgrade": true,
+                        "settings": {
+                          "stopOnMultipleConnections": true
+                        }
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('name'), 'Microsoft.Azure.NetworkWatcher')]",
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('name'))]"
+                      ]
+                    },
+                    {
+                      "condition": "[not(contains(parameters('supportedClouds'), environment().name))]",
                       "type": "Microsoft.Compute/virtualMachines/extensions",
                       "apiVersion": "2020-06-01",
                       "name": "[format('{0}/{1}', parameters('name'), 'OMSExtension')]",
@@ -6159,6 +6199,7 @@
                       ]
                     },
                     {
+                      "condition": "[not(contains(parameters('supportedClouds'), environment().name))]",
                       "type": "Microsoft.Compute/virtualMachines/extensions",
                       "apiVersion": "2021-04-01",
                       "name": "[format('{0}/{1}', parameters('name'), 'DependencyAgentLinux')]",
@@ -6212,8 +6253,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "14251781222961482383"
+                              "version": "0.30.23.60470",
+                              "templateHash": "6795024125500853154"
                             }
                           },
                           "parameters": {
@@ -6376,8 +6417,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "18032933125574793644"
+                      "version": "0.30.23.60470",
+                      "templateHash": "8382745830446158671"
                     }
                   },
                   "parameters": {
@@ -6655,8 +6696,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "14251781222961482383"
+                              "version": "0.30.23.60470",
+                              "templateHash": "6795024125500853154"
                             }
                           },
                           "parameters": {
@@ -6797,8 +6838,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "3636721938772489545"
+              "version": "0.30.23.60470",
+              "templateHash": "9702537094059628764"
             }
           },
           "parameters": {
@@ -6911,8 +6952,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "3275873970878681803"
+                      "version": "0.30.23.60470",
+                      "templateHash": "2605622138599057497"
                     }
                   },
                   "parameters": {
@@ -7170,8 +7211,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "7558548205011970878"
+              "version": "0.30.23.60470",
+              "templateHash": "10729991087464801816"
             }
           },
           "parameters": {
@@ -7253,8 +7294,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "12283647734355805914"
+                      "version": "0.30.23.60470",
+                      "templateHash": "8389358797157027271"
                     }
                   },
                   "parameters": {
@@ -7340,8 +7381,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "17680455217420763544"
+                      "version": "0.30.23.60470",
+                      "templateHash": "12994847648038282895"
                     }
                   },
                   "parameters": {
@@ -7422,8 +7463,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "5404623751544471689"
+                      "version": "0.30.23.60470",
+                      "templateHash": "9851134383266019486"
                     }
                   },
                   "parameters": {
@@ -7504,8 +7545,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "16786768982582775994"
+                      "version": "0.30.23.60470",
+                      "templateHash": "7358671180047253284"
                     }
                   },
                   "parameters": {
@@ -7586,8 +7627,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "8822339695468908903"
+                      "version": "0.30.23.60470",
+                      "templateHash": "17520636026466541947"
                     }
                   },
                   "parameters": {
@@ -7664,8 +7705,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "57495978054447496"
+                      "version": "0.30.23.60470",
+                      "templateHash": "16750249074235971016"
                     }
                   },
                   "parameters": {
@@ -7745,8 +7786,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "8093795796510715487"
+                      "version": "0.30.23.60470",
+                      "templateHash": "3320497816733398371"
                     }
                   },
                   "parameters": {
@@ -7831,8 +7872,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "16544710812353890275"
+              "version": "0.30.23.60470",
+              "templateHash": "7046499602359448652"
             }
           },
           "parameters": {
@@ -7888,8 +7929,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "10291402429548340342"
+                      "version": "0.30.23.60470",
+                      "templateHash": "16614224552992880134"
                     }
                   },
                   "parameters": {
@@ -7925,10 +7966,10 @@
                     }
                   },
                   "variables": {
-                    "$fxv#0": "    {\n        \"listOfMembersToExcludeFromWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"admin\"\n        },\n        \"listOfMembersToIncludeInWindowsVMAdministratorsGroup\": \n        {\n        \"value\": \"azureuser\"\n        },\n        \"logAnalyticsWorkspaceIdforVMReporting\": \n        {\n        \"value\": \"<LAWORKSPACE>\"\n        },\n        \"IncludeArcMachines\": \n        {\n            \"value\": \"true\"\n        },\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \n        {\n            \"value\": \"1.2\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \n        {\n            \"value\": \"Compliant\"\n        },\n        \"requiredRetentionDays\": \n        {\n            \"value\": \"365\"\n        },\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \n        {\n            \"value\": \"NetworkWatcherRG\"\n        }\n    }",
-                    "$fxv#1": "    {\n        \"IncludeArcMachines\": \n        {\n            \"value\": \"true\"\n        },\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \n        {\n            \"value\": \"1.2\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \n        {\n            \"value\": \"Compliant\"\n        },\n        \"requiredRetentionDays\": \n        {\n            \"value\": \"365\"\n        },\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \n        {\n            \"value\": \"NetworkWatcherRG\"\n        }\n    }",
-                    "$fxv#2": "{\n    \"IncludeArcMachines\" : { \n        \"value\" : \"false\"\n        },\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\" : { \n        \"value\" : \"Compliant\"\n        },\n        \"MinimumTLSVersionForWindowsServers\" : { \n        \"value\" : \"1.2\"\n        },\n        \"requiredRetentionDays\" : { \n        \"value\" : \"365\"\n        },\n        \"effect-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"audit\"\n        },\n        \"allowedContainerImagesRegex-febd0533-8e55-448f-b837-bd0e06f16469\" : { \n        \"value\" : \"^(.+){0}$\"\n        },\n        \"effect-95edb821-ddaf-4404-9732-666045e056b4\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-440b515e-a580-421e-abeb-b159a61ddcbc\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-233a2a17-77ca-4fb1-9b6b-69223d272a44\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"audit\"\n        },\n        \"cpuLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"memoryLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \n        \"value\" : \"0\"\n        },\n        \"effect-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"audit\"\n        },\n        \"runAsUserRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"MustRunAsNonRoot\"\n        },\n        \"runAsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"supplementalGroupsRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"fsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \n        \"value\" : \"RunAsAny\"\n        },\n        \"effect-1c6e92c9-99f0-4e55-9cf2-0c234dc48f99\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-47a1ee2f-2a2a-4576-bf2a-e0e36709c2b8\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-df49d893-a74c-421d-bc95-c663042e5b80\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-1a5b4dca-0b6f-4cf5-907c-56316bc1bf3d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-c26596ff-4d70-4e6a-9a30-c2506bd2f80c\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-511f5417-5d12-434d-ab2e-816901e72a5e\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-82985f06-dc18-4a48-bc1c-b9f4f0098cfe\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-098fc59e-46c7-4d99-9b16-64990e543d75\" : { \n        \"value\" : \"audit\"\n        },\n        \"NetworkWatcherResourceGroupName\" : { \n        \"value\" : \"NetworkWatcherRG\"\n        },\n        \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n        \"value\" : \"enabled\"\n        },\n        \"aadAuthenticationInServiceFabricMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-71ef260a-8f18-47b7-abcb-62d0673d94dc\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-862e97cf-49fc-4a5c-9de4-40d4e2e7c8eb\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d9da03a1-f3c3-412a-9709-947156872263\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-b4ac1030-89c5-4697-8e00-28b5ba6a8811\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-ea0dfaed-95fb-448c-934e-d6e713ce393d\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-41425d9f-d1a5-499a-9932-f8ed8453932c\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fc4d8e41-e223-45ea-9bf5-eada37891d87\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-86efb160-8de7-451d-bc08-5d475b0aadae\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-4ec52d6d-beb7-40c4-9a9e-fe753254690e\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-64d314f6-6062-4780-a861-c23e8951bee5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fd32ebd-e4c3-4e13-a54a-d7422d4d95f6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-fa298e57-9444-42ba-bf04-86e8470e32c7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f905d99-2ab7-462c-a6b0-f709acca6c8f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ba769a63-b8cc-4b2d-abf6-ac33c7204be8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0aa61e00-0a01-4a3c-9945-e93cffedf0e6\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-47031206-ce96-41f8-861b-6a915f3de284\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-51522a96-0869-4791-82f3-981000c2c67f\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-b5ec538c-daa0-4006-8596-35468b9148e8\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-56a5ee18-2ae6-4810-86f7-18e39ce5629b\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2e94d99a-8a36-4563-bc77-810d8893b671\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1fafeaf6-7927-4059-a50a-8eb2a7a6f2b5\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-99e9ccd8-3db9-4592-b0d1-14b1715a4d8a\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1f68a601-6e6d-4e42-babf-3f643a047ea2\" : { \n        \"value\" : \"audit\"\n        },\n        \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ca91455f-eace-4f96-be59-e6e2c35b4816\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-702dd420-7fcc-42c5-afe8-4026edd20fe0\" : { \n        \"value\" : \"Audit\"\n        },\n        \"diagnosticsLogsInRedisCacheMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"secureTransferToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-7d092e0a-7acd-40d2-a975-dca21cae48c4\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"disableUnrestrictedNetworkToStorageAccountMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-55615ac9-af46-4a59-874e-391cc3dfb490\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1b8ca024-1d5c-4dec-8995-b1a932b41780\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-53503636-bcc9-4748-9663-5348217f160f\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-40cec1dd-a100-4920-b15b-3024fe8901ab\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-a049bf77-880b-470f-ba6d-9f21c530cf83\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-ee980b6d-0eca-4501-8d54-f6290fd512c3\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-1d84d5fb-01f6-4d12-ba4f-4a26081d403d\" : { \n        \"value\" : \"Audit\"\n        },\n        \"effect-37e0d2fe-28a5-43d6-a273-67d37d1f5606\" : { \n        \"value\" : \"Audit\"\n        },\n        \"identityDesignateMoreThanOneOwnerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"diskEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"emailNotificationToSubscriptionOwnerHighSeverityAlertsEnabledEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlDbEncryptionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"aadAuthenticationInSqlServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssEndpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vmssOsVulnerabilitiesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"adaptiveApplicationControlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForPostgreSQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensureJavaVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityDesignateLessThanOwnersMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"securityContactEmailAddressForSubscriptionEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRestrictCORSAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"ensurePythonVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePHPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensurePythonVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForMySQLEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"systemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForWebAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForWritePermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForAPIAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureJavaVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"nextGenerationFirewallMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"useRbacRulesMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"webAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlServerAuditingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vnetEnableDDoSProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlServerAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"endpointProtectionMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"jitNetworkAccessMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppEnforceHttpsMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"geoRedundantStorageShouldBeEnabledForStorageAccountsEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"vmssSystemUpdatesMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"longtermGeoRedundantBackupEnabledAzureSQLDatabasesEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"systemConfigurationsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"ensureHTTPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityEnableMFAForReadPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"containerBenchmarkMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"apiAppDisableRemoteDebuggingMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"vulnerabilityAssessmentOnServerMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"webAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"functionAppRequireLatestTlsMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"kubernetesServiceVersionUpToDateMonitoringEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"sqlDbVulnerabilityAssesmentMonitoringEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        },\n        \"membersToIncludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"membersToExcludeInLocalAdministratorsGroup\" : { \n        \"value\" : \"\"\n        },\n        \"logAnalyticsWorkspaceIDForVMAgents\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n        },\n        \"PHPLatestVersionForAppServices\" : { \n        \"value\" : \"7.4\"\n        },\n        \"JavaLatestVersionForAppServices\" : { \n        \"value\" : \"11\"\n        },\n        \"WindowsPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.6\"\n        },\n        \"LinuxPythonLatestVersionForAppServices\" : { \n        \"value\" : \"3.9\"\n        },\n        \"ensureDotNetFrameworkLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"vulnerabilityAssessmentMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForWebAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"microsoftIaaSAntimalwareExtensionShouldBeDeployedOnWindowsServersEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityCenterStandardPricingTierShouldBeSelectedEffect\" : { \n        \"value\" : \"Audit\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachinesEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensurePHPVersionLatestForFunctionAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"securityContactPhoneNumberShouldBeProvidedForSubscriptionEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnManagedInstanceMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"ensureDotNetFrameworkLatestForAPIAppEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"threatDetectionTypesOnServerMonitoringEffect\" : { \n        \"value\" : \"Disabled\"\n        },\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachineScaleSetsEffect\" : { \n        \"value\" : \"AuditIfNotExists\"\n        }\n}",
-                    "$fxv#3": "{\n    \"logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917\" : { \n        \"value\" : \"<LAWORKSPACE>\"\n    },\n    \"effect-09024ccc-0c5f-475e-9457-b7c0d9ed487b\" : { \n        \"value\" : \"AuditIfNotExists\"\n    },\n    \"MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f\" :{\n        \"value\": \"\"\n    },\n    \"MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7\": {\n        \"value\": \"\"\n    },\n    \"effect-0961003e-5a0a-4549-abde-af6a37f2724d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b15565f-aa9e-48ba-8619-45960f2c314d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0e60b895-3786-45da-8377-9c6b4b6ac5f9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-17k78e20-9358-41c9-923c-fb736d382a12\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1bc1795e-d44a-4d48-9b3b-6fff0fd5f9ba\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"PHPLatestVersion\" : { \n    \"value\" : \"7.3\"\n    },\n    \"effect-22bee202-a82f-4305-9a2a-6d7f44d4dedb\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-26a828e1-e88f-464e-bbb3-c134a282b9de\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-34c877ad-507e-4c82-993e-3452a6e0ad3c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3c735d8a-a4ba-4a3a-b7cf-db7754cf57f4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-404c3081-a854-4457-ae30-26a93ef643f9\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-47a6b606-51aa-4496-8bb7-64b11cf66adc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-496223c3-ad65-4ecd-878a-bae78737e9ed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"JavaLatestVersion\" : { \n    \"value\" : \"11\"\n    },\n    \"effect-4f11b553-d42e-4e3a-89be-32ca364cad4c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4f4f78b8-e367-4b10-a341-d9a4ad5cf1c7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5c607a2e-c700-4744-8254-d77e7c9eb5e4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5f76cf89-fbf2-47fd-a3f4-b891fa780b60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6b1cbf55-e8b6-442f-ba4c-7246b6381474\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6d555dd1-86f2-4f1c-8ed7-5abae7c6cbab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7008174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"LinuxPythonLatestVersion\" : { \n    \"value\" : \"3.8\"\n    },\n    \"effect-7238174a-fd10-4ef0-817e-fc820a951d73\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7261b898-8a84-4db8-9e04-18527132abb3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-74c3584d-afae-46f7-a20a-6f8adba71a16\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-86b3d65f-7626-441e-b690-81a8b71cff60\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-88999f4c-376a-45c8-bcb3-4058f713cf39\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8c122334-9d20-4eb8-89ea-ac9a705b74ae\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-8cb6aa8b-9e41-4f4e-aa25-089a7ac2581e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9297c21d-2ed6-4474-b48f-163f75654ce3\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-991310cd-e9f3-47bc-b7b6-f57b557d07db\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9b597639-28e4-48eb-b506-56b05d366257\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9d0b6ea4-93e2-4578-bf2f-6bb17d22b4bc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-9daedab3-fb2d-461e-b861-71790eead4f6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a4af4a39-4135-47fb-b175-47fbdf85311d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \n    \"value\" : \"enabled\"\n    },\n    \"effect-a70ca396-0a34-413a-88e1-b956c1e683be\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-aa633080-8b72-40c4-a2d7-d00c03e80bed\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb4388-5bf4-4ad7-ba82-2cd2f41ceae9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-abfb7388-5bf4-4ad7-ba99-2cd2f41cebb9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-af6cd1bd-1635-48cb-bde7-5b15693900b9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\" : { \n    \"value\" : \"NetworkWatcherRG\"\n    },\n    \"effect-b7ddfbdc-1260-477d-91fd-98bd9be789a6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c3f317a7-a95c-4547-b7e7-11017ebdf2fe\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-cb510bfd-1cba-4d9f-a230-cb0976f4bb71\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e2c1c086-2d84-4019-bff3-c44ccd95113c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e3576e28-8b17-4677-84c3-db2990658d64\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e8cbc669-f12d-49eb-93e7-9273119e9933\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e9c8d085-d9cc-4b17-9cdc-059f1f01f19e\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ebb62a0c-3560-49e1-89ed-27e074e9f8ad\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-efbde977-ba53-4479-b8e9-10b957924fbf\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f0e6e85b-9b9f-4a4b-b67b-f730d42f1b0b\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f6de0be7-9a8a-4b8a-b349-43cf02d22f7c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f8456c1c-aa66-4dfb-861a-25d127b775c9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-f9d614c5-c173-4d56-95a7-b4437057d193\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-fb893a29-21bb-418c-a157-e99480ec364c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-feedbf84-6b99-488c-acc2-71c829aa5ffc\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-3b980d31-7904-4bb7-8575-5665739a8052\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-6e2593d9-add6-4083-9c9b-4b7d2188c899\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b607c5de-e7d9-4eee-9e5c-83f1bcee4fa0\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"modeRequirement-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \n    \"value\" : \"Detection\"\n    },\n    \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-013e242c-8828-4970-87b3-ab247555486d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d38fc420-0735-4ef3-ac11-c806f651a570\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-a1181c5f-672a-477a-979a-7d58aa086233\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-308fbb08-4ab8-4e67-9b29-592e93fb94fa\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-4da35fc9-c9e7-4960-aec9-797fe7d9051d\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-523b5cd1-3e23-492f-a539-13118b6d1e3a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7fe3b40f-802b-4cdd-8bd4-fd799c948cc2\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c25d9a16-bc35-4e15-a7e5-9db606bf9ed4\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b0f33259-77d7-4c9e-aac6-3aabcfae693c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-0820b7b9-23aa-4725-a1ce-ae4558f718e5\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fab\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-358c20a6-3f9e-4f0e-97ff-c6ce485e2aac\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-5744710e-cc2f-4ee8-8809-3b11e89f4bc9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ac4a19c2-fa67-49b4-8ae5-0b2e78c49457\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c9d007d0-c057-4772-b18c-01e546713bcd\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e372f825-a257-4fb8-9175-797a8a8627d6\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-d158790f-bfb0-486c-8631-2dc6b4e8e6af\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-e802a67a-daf5-4436-9ea6-f6d821dd0c5d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-a451c1ef-c6ca-483d-87ed-f49761e3ffb5\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftSql-servers-firewallRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-securityRules-delete\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ae89ebca-1c92-4898-ac2c-9f63decb045c\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-d26f7642-7545-4e18-9b75-8c9bbdee3a9a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-1a4e592a-6a6e-44a5-9814-e36264ca96e7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-7796937f-307b-4598-941c-67d3a05ebfe7\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-c5447c04-a4d7-4ba8-a263-c9ee321a6858\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-41388f1c-2db0-4c25-95b2-35d7f5ccbfa9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-b02aacc0-b073-424e-8298-42b22829ee0a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-057d6cfe-9c4f-4a6d-bc60-14420ea1f1a9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0ec47710-77ff-4a3d-9181-6aa50af424d0\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-48af4db5-9b8b-401c-8e74-076be876a430\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-82339799-d096-41ae-8538-b108becf0970\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1b7aa243-30e4-4c9e-bca8-d0d3022b634a\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-ef2a8f2a-b3d9-49cd-a8a8-9a3aaaf647d9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-bb91dfba-c30d-4263-9add-9c2384e659a6\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-e71308d3-144b-4262-b144-efdc3cc90517\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2bdd0062-9d75-436e-89df-487dd8e4b3c7\" : { \n    \"value\" : \"Disabled\"\n    },\n    \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-6fac406b-40ca-413b-bf8e-0bf964659c25\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-048248b0-55cd-46da-b1ff-39efd52db260\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0d134df8-db83-46fb-ad72-fe0c9428c8dd\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fb2\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \n    \"value\" : \"audit\"\n    },\n    \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-c43e4a30-77cb-48ab-a4dd-93f175c63b57\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \n    \"value\" : \"Audit\"\n    },\n    \"effect-1f314764-cb73-4fc9-b863-8eca98ac36e9\" : { \n    \"value\" : \"AuditIfNotExists\"\n    },\n    \"effect-123a3936-f020-408a-ba0c-47873faf1534\" : { \n    \"value\" : \"AuditIfNotExists\"\n    }\n}\n",
+                    "$fxv#0": "    {\r\n        \"listOfMembersToExcludeFromWindowsVMAdministratorsGroup\": \r\n        {\r\n        \"value\": \"admin\"\r\n        },\r\n        \"listOfMembersToIncludeInWindowsVMAdministratorsGroup\": \r\n        {\r\n        \"value\": \"azureuser\"\r\n        },\r\n        \"logAnalyticsWorkspaceIdforVMReporting\": \r\n        {\r\n        \"value\": \"<LAWORKSPACE>\"\r\n        },\r\n        \"IncludeArcMachines\": \r\n        {\r\n            \"value\": \"true\"\r\n        },\r\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \r\n        {\r\n            \"value\": \"1.2\"\r\n        },\r\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \r\n        {\r\n            \"value\": \"Compliant\"\r\n        },\r\n        \"requiredRetentionDays\": \r\n        {\r\n            \"value\": \"365\"\r\n        },\r\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \r\n        {\r\n            \"value\": \"NetworkWatcherRG\"\r\n        }\r\n    }",
+                    "$fxv#1": "    {\r\n        \"IncludeArcMachines\": \r\n        {\r\n            \"value\": \"true\"\r\n        },\r\n        \"MinimumTLSVersion-5752e6d6-1206-46d8-8ab1-ecc2f71a8112\": \r\n        {\r\n            \"value\": \"1.2\"\r\n        },\r\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\": \r\n        {\r\n            \"value\": \"Compliant\"\r\n        },\r\n        \"requiredRetentionDays\": \r\n        {\r\n            \"value\": \"365\"\r\n        },\r\n        \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\": \r\n        {\r\n            \"value\": \"NetworkWatcherRG\"\r\n        }\r\n    }",
+                    "$fxv#2": "{\r\n    \"IncludeArcMachines\" : { \r\n        \"value\" : \"false\"\r\n        },\r\n        \"NotAvailableMachineState-bed48b13-6647-468e-aa2f-1af1d3f4dd40\" : { \r\n        \"value\" : \"Compliant\"\r\n        },\r\n        \"MinimumTLSVersionForWindowsServers\" : { \r\n        \"value\" : \"1.2\"\r\n        },\r\n        \"requiredRetentionDays\" : { \r\n        \"value\" : \"365\"\r\n        },\r\n        \"effect-febd0533-8e55-448f-b837-bd0e06f16469\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"allowedContainerImagesRegex-febd0533-8e55-448f-b837-bd0e06f16469\" : { \r\n        \"value\" : \"^(.+){0}$\"\r\n        },\r\n        \"effect-95edb821-ddaf-4404-9732-666045e056b4\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-440b515e-a580-421e-abeb-b159a61ddcbc\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-233a2a17-77ca-4fb1-9b6b-69223d272a44\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"cpuLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \r\n        \"value\" : \"0\"\r\n        },\r\n        \"memoryLimit-e345eecc-fa47-480f-9e88-67dcc122b164\" : { \r\n        \"value\" : \"0\"\r\n        },\r\n        \"effect-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"runAsUserRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"MustRunAsNonRoot\"\r\n        },\r\n        \"runAsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"RunAsAny\"\r\n        },\r\n        \"supplementalGroupsRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"RunAsAny\"\r\n        },\r\n        \"fsGroupRule-f06ddb64-5fa3-4b77-b166-acb36f7f6042\" : { \r\n        \"value\" : \"RunAsAny\"\r\n        },\r\n        \"effect-1c6e92c9-99f0-4e55-9cf2-0c234dc48f99\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-47a1ee2f-2a2a-4576-bf2a-e0e36709c2b8\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-df49d893-a74c-421d-bc95-c663042e5b80\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-1a5b4dca-0b6f-4cf5-907c-56316bc1bf3d\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-c26596ff-4d70-4e6a-9a30-c2506bd2f80c\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-511f5417-5d12-434d-ab2e-816901e72a5e\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-82985f06-dc18-4a48-bc1c-b9f4f0098cfe\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-098fc59e-46c7-4d99-9b16-64990e543d75\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"NetworkWatcherResourceGroupName\" : { \r\n        \"value\" : \"NetworkWatcherRG\"\r\n        },\r\n        \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \r\n        \"value\" : \"enabled\"\r\n        },\r\n        \"aadAuthenticationInServiceFabricMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-71ef260a-8f18-47b7-abcb-62d0673d94dc\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-862e97cf-49fc-4a5c-9de4-40d4e2e7c8eb\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-d9da03a1-f3c3-412a-9709-947156872263\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-b4ac1030-89c5-4697-8e00-28b5ba6a8811\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-ea0dfaed-95fb-448c-934e-d6e713ce393d\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-41425d9f-d1a5-499a-9932-f8ed8453932c\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-fc4d8e41-e223-45ea-9bf5-eada37891d87\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-86efb160-8de7-451d-bc08-5d475b0aadae\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-4ec52d6d-beb7-40c4-9a9e-fe753254690e\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-64d314f6-6062-4780-a861-c23e8951bee5\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1fd32ebd-e4c3-4e13-a54a-d7422d4d95f6\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-fa298e57-9444-42ba-bf04-86e8470e32c7\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1f905d99-2ab7-462c-a6b0-f709acca6c8f\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-ba769a63-b8cc-4b2d-abf6-ac33c7204be8\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-0aa61e00-0a01-4a3c-9945-e93cffedf0e6\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-47031206-ce96-41f8-861b-6a915f3de284\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-51522a96-0869-4791-82f3-981000c2c67f\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-b5ec538c-daa0-4006-8596-35468b9148e8\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-56a5ee18-2ae6-4810-86f7-18e39ce5629b\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-2e94d99a-8a36-4563-bc77-810d8893b671\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1fafeaf6-7927-4059-a50a-8eb2a7a6f2b5\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-99e9ccd8-3db9-4592-b0d1-14b1715a4d8a\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1f68a601-6e6d-4e42-babf-3f643a047ea2\" : { \r\n        \"value\" : \"audit\"\r\n        },\r\n        \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-ca91455f-eace-4f96-be59-e6e2c35b4816\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-702dd420-7fcc-42c5-afe8-4026edd20fe0\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"diagnosticsLogsInRedisCacheMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"secureTransferToStorageAccountMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-7d092e0a-7acd-40d2-a975-dca21cae48c4\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"disableUnrestrictedNetworkToStorageAccountMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-55615ac9-af46-4a59-874e-391cc3dfb490\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1b8ca024-1d5c-4dec-8995-b1a932b41780\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-53503636-bcc9-4748-9663-5348217f160f\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-40cec1dd-a100-4920-b15b-3024fe8901ab\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-a049bf77-880b-470f-ba6d-9f21c530cf83\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-ee980b6d-0eca-4501-8d54-f6290fd512c3\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-1d84d5fb-01f6-4d12-ba4f-4a26081d403d\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"effect-37e0d2fe-28a5-43d6-a273-67d37d1f5606\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"identityDesignateMoreThanOneOwnerMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"diskEncryptionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"emailNotificationToSubscriptionOwnerHighSeverityAlertsEnabledEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"functionAppDisableRemoteDebuggingMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"sqlDbEncryptionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vulnerabilityAssessmentOnManagedInstanceMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensurePHPVersionLatestForAPIAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"aadAuthenticationInSqlServerMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vmssEndpointProtectionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vmssOsVulnerabilitiesMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"adaptiveApplicationControlsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForPostgreSQLEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"ensureJavaVersionLatestForWebAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityDesignateLessThanOwnersMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"securityContactEmailAddressForSubscriptionEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"webAppRestrictCORSAccessMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveDeprecatedAccountMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"functionAppEnforceHttpsMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"ensurePythonVersionLatestForWebAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensurePythonVersionLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensurePHPVersionLatestForWebAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensurePythonVersionLatestForAPIAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"geoRedundantBackupShouldBeEnabledForAzureDatabaseForMySQLEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"systemUpdatesMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureJavaVersionLatestForAPIAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureHTTPVersionLatestForWebAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"apiAppRequireLatestTlsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityEnableMFAForWritePermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureHTTPVersionLatestForAPIAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureJavaVersionLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"nextGenerationFirewallMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"useRbacRulesMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"webAppEnforceHttpsMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"sqlServerAuditingMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vnetEnableDDoSProtectionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityEnableMFAForOwnerPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"sqlServerAdvancedDataSecurityMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"sqlManagedInstanceAdvancedDataSecurityMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"endpointProtectionMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"jitNetworkAccessMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"apiAppEnforceHttpsMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"geoRedundantStorageShouldBeEnabledForStorageAccountsEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"vmssSystemUpdatesMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"webAppDisableRemoteDebuggingMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"longtermGeoRedundantBackupEnabledAzureSQLDatabasesEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"systemConfigurationsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"ensureHTTPVersionLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityEnableMFAForReadPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"containerBenchmarkMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"apiAppDisableRemoteDebuggingMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"vulnerabilityAssessmentOnServerMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"webAppRequireLatestTlsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"functionAppRequireLatestTlsMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"kubernetesServiceVersionUpToDateMonitoringEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"sqlDbVulnerabilityAssesmentMonitoringEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        },\r\n        \"membersToIncludeInLocalAdministratorsGroup\" : { \r\n        \"value\" : \"\"\r\n        },\r\n        \"membersToExcludeInLocalAdministratorsGroup\" : { \r\n        \"value\" : \"\"\r\n        },\r\n        \"logAnalyticsWorkspaceIDForVMAgents\" : { \r\n        \"value\" : \"<LAWORKSPACE>\"\r\n        },\r\n        \"PHPLatestVersionForAppServices\" : { \r\n        \"value\" : \"7.4\"\r\n        },\r\n        \"JavaLatestVersionForAppServices\" : { \r\n        \"value\" : \"11\"\r\n        },\r\n        \"WindowsPythonLatestVersionForAppServices\" : { \r\n        \"value\" : \"3.6\"\r\n        },\r\n        \"LinuxPythonLatestVersionForAppServices\" : { \r\n        \"value\" : \"3.9\"\r\n        },\r\n        \"ensureDotNetFrameworkLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"vulnerabilityAssessmentMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"ensureDotNetFrameworkLatestForWebAppEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"sqlServerAdvancedDataSecurityEmailsMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"microsoftIaaSAntimalwareExtensionShouldBeDeployedOnWindowsServersEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"securityCenterStandardPricingTierShouldBeSelectedEffect\" : { \r\n        \"value\" : \"Audit\"\r\n        },\r\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachinesEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"ensurePHPVersionLatestForFunctionAppEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"securityContactPhoneNumberShouldBeProvidedForSubscriptionEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"threatDetectionTypesOnManagedInstanceMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"ensureDotNetFrameworkLatestForAPIAppEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"threatDetectionTypesOnServerMonitoringEffect\" : { \r\n        \"value\" : \"Disabled\"\r\n        },\r\n        \"theLogAnalyticsAgentShouldBeInstalledOnVirtualMachineScaleSetsEffect\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n        }\r\n}",
+                    "$fxv#3": "{\r\n    \"logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917\" : { \r\n        \"value\" : \"<LAWORKSPACE>\"\r\n    },\r\n    \"effect-09024ccc-0c5f-475e-9457-b7c0d9ed487b\" : { \r\n        \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f\" :{\r\n        \"value\": \"\"\r\n    },\r\n    \"MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7\": {\r\n        \"value\": \"\"\r\n    },\r\n    \"effect-0961003e-5a0a-4549-abde-af6a37f2724d\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0b15565f-aa9e-48ba-8619-45960f2c314d\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0e60b895-3786-45da-8377-9c6b4b6ac5f9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-17k78e20-9358-41c9-923c-fb736d382a12\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-1bc1795e-d44a-4d48-9b3b-6fff0fd5f9ba\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"PHPLatestVersion\" : { \r\n    \"value\" : \"7.3\"\r\n    },\r\n    \"effect-22bee202-a82f-4305-9a2a-6d7f44d4dedb\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-26a828e1-e88f-464e-bbb3-c134a282b9de\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-34c877ad-507e-4c82-993e-3452a6e0ad3c\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-3c735d8a-a4ba-4a3a-b7cf-db7754cf57f4\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-404c3081-a854-4457-ae30-26a93ef643f9\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-47a6b606-51aa-4496-8bb7-64b11cf66adc\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-496223c3-ad65-4ecd-878a-bae78737e9ed\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"JavaLatestVersion\" : { \r\n    \"value\" : \"11\"\r\n    },\r\n    \"effect-4f11b553-d42e-4e3a-89be-32ca364cad4c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-4f4f78b8-e367-4b10-a341-d9a4ad5cf1c7\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-5c607a2e-c700-4744-8254-d77e7c9eb5e4\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-5f76cf89-fbf2-47fd-a3f4-b891fa780b60\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-6b1cbf55-e8b6-442f-ba4c-7246b6381474\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-6d555dd1-86f2-4f1c-8ed7-5abae7c6cbab\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-7008174a-fd10-4ef0-817e-fc820a951d73\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"LinuxPythonLatestVersion\" : { \r\n    \"value\" : \"3.8\"\r\n    },\r\n    \"effect-7238174a-fd10-4ef0-817e-fc820a951d73\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-7261b898-8a84-4db8-9e04-18527132abb3\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-74c3584d-afae-46f7-a20a-6f8adba71a16\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-86b3d65f-7626-441e-b690-81a8b71cff60\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-88999f4c-376a-45c8-bcb3-4058f713cf39\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-8c122334-9d20-4eb8-89ea-ac9a705b74ae\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-8cb6aa8b-9e41-4f4e-aa25-089a7ac2581e\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-9297c21d-2ed6-4474-b48f-163f75654ce3\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-991310cd-e9f3-47bc-b7b6-f57b557d07db\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-9b597639-28e4-48eb-b506-56b05d366257\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-9d0b6ea4-93e2-4578-bf2f-6bb17d22b4bc\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-9daedab3-fb2d-461e-b861-71790eead4f6\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-a4af4a39-4135-47fb-b175-47fbdf85311d\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"setting-a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9\" : { \r\n    \"value\" : \"enabled\"\r\n    },\r\n    \"effect-a70ca396-0a34-413a-88e1-b956c1e683be\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-aa633080-8b72-40c4-a2d7-d00c03e80bed\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-abfb4388-5bf4-4ad7-ba82-2cd2f41ceae9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-abfb7388-5bf4-4ad7-ba99-2cd2f41cebb9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-af6cd1bd-1635-48cb-bde7-5b15693900b9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"resourceGroupName-b6e2945c-0b7b-40f5-9233-7a5323b5cdc6\" : { \r\n    \"value\" : \"NetworkWatcherRG\"\r\n    },\r\n    \"effect-b7ddfbdc-1260-477d-91fd-98bd9be789a6\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-c3f317a7-a95c-4547-b7e7-11017ebdf2fe\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-cb510bfd-1cba-4d9f-a230-cb0976f4bb71\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e2c1c086-2d84-4019-bff3-c44ccd95113c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e3576e28-8b17-4677-84c3-db2990658d64\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e8cbc669-f12d-49eb-93e7-9273119e9933\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e9c8d085-d9cc-4b17-9cdc-059f1f01f19e\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-ebb62a0c-3560-49e1-89ed-27e074e9f8ad\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-efbde977-ba53-4479-b8e9-10b957924fbf\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-f0e6e85b-9b9f-4a4b-b67b-f730d42f1b0b\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-f6de0be7-9a8a-4b8a-b349-43cf02d22f7c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-f8456c1c-aa66-4dfb-861a-25d127b775c9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-f9d614c5-c173-4d56-95a7-b4437057d193\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-fb893a29-21bb-418c-a157-e99480ec364c\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-feedbf84-6b99-488c-acc2-71c829aa5ffc\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-3b980d31-7904-4bb7-8575-5665739a8052\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-6e2593d9-add6-4083-9c9b-4b7d2188c899\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b607c5de-e7d9-4eee-9e5c-83f1bcee4fa0\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"modeRequirement-12430be1-6cc8-4527-a9a8-e3d38f250096\" : { \r\n    \"value\" : \"Detection\"\r\n    },\r\n    \"effect-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"modeRequirement-425bea59-a659-4cbb-8d31-34499bd030b8\" : { \r\n    \"value\" : \"Detection\"\r\n    },\r\n    \"effect-564feb30-bf6a-4854-b4bb-0d2d2d1e6c66\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-055aa869-bc98-4af8-bafc-23f1ab6ffe2c\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-013e242c-8828-4970-87b3-ab247555486d\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-d38fc420-0735-4ef3-ac11-c806f651a570\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-a1181c5f-672a-477a-979a-7d58aa086233\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-308fbb08-4ab8-4e67-9b29-592e93fb94fa\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-4da35fc9-c9e7-4960-aec9-797fe7d9051d\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-523b5cd1-3e23-492f-a539-13118b6d1e3a\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-7fe3b40f-802b-4cdd-8bd4-fd799c948cc2\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-c25d9a16-bc35-4e15-a7e5-9db606bf9ed4\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b0f33259-77d7-4c9e-aac6-3aabcfae693c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-037eea7a-bd0a-46c5-9a66-03aea78705d3\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-0725b4dd-7e76-479c-a735-68e7ee23d5ca\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-0820b7b9-23aa-4725-a1ce-ae4558f718e5\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fab\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-358c20a6-3f9e-4f0e-97ff-c6ce485e2aac\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-5744710e-cc2f-4ee8-8809-3b11e89f4bc9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-ac4a19c2-fa67-49b4-8ae5-0b2e78c49457\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-c9d007d0-c057-4772-b18c-01e546713bcd\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-d0793b48-0edc-4296-a390-4c75d1bdfd71\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-e372f825-a257-4fb8-9175-797a8a8627d6\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-d158790f-bfb0-486c-8631-2dc6b4e8e6af\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-e802a67a-daf5-4436-9ea6-f6d821dd0c5d\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-a451c1ef-c6ca-483d-87ed-f49761e3ffb5\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftSql-servers-firewallRules-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftNetwork-networkSecurityGroups-securityRules-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b954148f-4c11-4c38-8221-be76711e194a-MicrosoftClassicNetwork-networkSecurityGroups-securityRules-delete\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-ae89ebca-1c92-4898-ac2c-9f63decb045c\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-d26f7642-7545-4e18-9b75-8c9bbdee3a9a\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-1a4e592a-6a6e-44a5-9814-e36264ca96e7\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-7796937f-307b-4598-941c-67d3a05ebfe7\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-c5447c04-a4d7-4ba8-a263-c9ee321a6858\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-41388f1c-2db0-4c25-95b2-35d7f5ccbfa9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-b02aacc0-b073-424e-8298-42b22829ee0a\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-057d6cfe-9c4f-4a6d-bc60-14420ea1f1a9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0ec47710-77ff-4a3d-9181-6aa50af424d0\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-48af4db5-9b8b-401c-8e74-076be876a430\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-82339799-d096-41ae-8538-b108becf0970\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-1b7aa243-30e4-4c9e-bca8-d0d3022b634a\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-ef2a8f2a-b3d9-49cd-a8a8-9a3aaaf647d9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-bb91dfba-c30d-4263-9add-9c2384e659a6\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-e71308d3-144b-4262-b144-efdc3cc90517\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-2bdd0062-9d75-436e-89df-487dd8e4b3c7\" : { \r\n    \"value\" : \"Disabled\"\r\n    },\r\n    \"effect-4733ea7b-a883-42fe-8cac-97454c2a9e4a\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-67121cc7-ff39-4ab8-b7e3-95b84dab487d\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-6fac406b-40ca-413b-bf8e-0bf964659c25\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-81e74cea-30fd-40d5-802f-d72103c2aaaa\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-c349d81b-9985-44ae-a8da-ff98d108ede8\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-f4b53539-8df9-40e4-86c6-6b607703bd4e\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-ec068d99-e9c7-401f-8cef-5bdde4e6ccf1\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-048248b0-55cd-46da-b1ff-39efd52db260\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0d134df8-db83-46fb-ad72-fe0c9428c8dd\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-2c89a2e5-7285-40fe-afe0-ae8654b92fb2\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-3657f5a0-770e-44a3-b44e-9431ba1e9735\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-5b9159ae-1701-4a6f-9a7a-aa9c8ddd0580\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-617c02be-7f02-4efd-8836-3180d47b6c68\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-7d7be79c-23ba-4033-84dd-45e2a5ccdd67\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-87ba29ef-1ab3-4d82-b763-87fcd4f531f7\" : { \r\n    \"value\" : \"audit\"\r\n    },\r\n    \"effect-f7d52b2d-e161-4dfa-a82b-55e564167385\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-c43e4a30-77cb-48ab-a4dd-93f175c63b57\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-0b60c0b2-2dc2-4e1c-b5c9-abbed971de53\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d\" : { \r\n    \"value\" : \"Audit\"\r\n    },\r\n    \"effect-1f314764-cb73-4fc9-b863-8eca98ac36e9\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    },\r\n    \"effect-123a3936-f020-408a-ba0c-47873faf1534\" : { \r\n    \"value\" : \"AuditIfNotExists\"\r\n    }\r\n}\r\n",
                     "modifiedAssignment": "[if(and(equals(toLower(environment().name), toLower('AzureCloud')), equals(toLower(parameters('builtInAssignment')), toLower('IL5'))), 'NISTRev4', parameters('builtInAssignment'))]",
                     "assignmentName": "[format('{0} {1}', variables('modifiedAssignment'), resourceGroup().name)]",
                     "agentVmssAssignmentName": "[format('Deploy VMSS Agents {0}', resourceGroup().name)]",
@@ -8064,8 +8105,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "2709473749440196253"
+                              "version": "0.30.23.60470",
+                              "templateHash": "8372265102618018066"
                             }
                           },
                           "parameters": {
@@ -8162,8 +8203,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "4276675887884807292"
+              "version": "0.30.23.60470",
+              "templateHash": "3268860743787686"
             }
           },
           "parameters": {
@@ -8226,8 +8267,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "9328080537587895542"
+                      "version": "0.30.23.60470",
+                      "templateHash": "3588347827815061814"
                     }
                   },
                   "parameters": {

--- a/src/bicep/modules/remote-access.bicep
+++ b/src/bicep/modules/remote-access.bicep
@@ -51,6 +51,7 @@ param windowsVmSize string
 param windowsVmSku string
 param windowsVmStorageAccountType string
 param windowsVmVersion string
+param supportedClouds array
 
 module bastionHost '../modules/bastion-host.bicep' =
   if (deployBastion) {
@@ -68,7 +69,7 @@ module bastionHost '../modules/bastion-host.bicep' =
       tags: tags
     }
   }
-
+  
 module linuxVirtualMachine '../modules/linux-virtual-machine.bicep' =
   if (deployLinuxVirtualMachine) {
     name: 'remoteAccess-linuxVirtualMachine'
@@ -90,6 +91,7 @@ module linuxVirtualMachine '../modules/linux-virtual-machine.bicep' =
       privateIPAddressAllocationMethod: linuxNetworkInterfacePrivateIPAddressAllocationMethod
       subnetResourceId: hubSubnetResourceId
       tags: tags
+      supportedClouds: supportedClouds
       vmImagePublisher: linuxVmImagePublisher
       vmImageOffer: linuxVmImageOffer
       vmImageSku: linuxVmImageSku


### PR DESCRIPTION
# Description

Edited code to allow AMA linux VM extension for MAC and MAG and OMS extension to remain for SEC and NAT.
Fixed broken link for issue # 1097.
Updated the Remote-Access tab section of the MLZ deployment walkthrough document to reflect changes for available Linux and Windows VM distributions. issue # 1078
Edited code to automatically update and enable Linux VM extensions for NetworkWatcher and GuestAttestation.  Issue # 1100


## Issue reference

The issue this PR will close: #1078 #1100 #1097 #1073

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
