### PR TITLE
AVD Add-On: Added missing DNS Zone Group to Disk Access deployment

### DIFF
--- a/src/bicep/add-ons/azure-virtual-desktop/modules/management/diskAccess.bicep
+++ b/src/bicep/add-ons/azure-virtual-desktop/modules/management/diskAccess.bicep
@@ -1,3 +1,4 @@
+param azureBlobsPrivateDnsZoneResourceId string
 param hostPoolResourceId string
 param location string
 param mlzTags object
@@ -32,6 +33,21 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2023-04-01' = {
     subnet: {
       id: subnetResourceId
     }
+  }
+}
+
+resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2021-08-01' = {
+  parent: privateEndpoint
+  name: namingConvention.diskAccess
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          privateDnsZoneId: azureBlobsPrivateDnsZoneResourceId
+        }
+      }
+    ]
   }
 }
 

--- a/src/bicep/add-ons/azure-virtual-desktop/modules/management/management.bicep
+++ b/src/bicep/add-ons/azure-virtual-desktop/modules/management/management.bicep
@@ -137,6 +137,7 @@ module diskAccess 'diskAccess.bicep' = {
   scope: resourceGroup
   name: 'deploy-disk-access-${deploymentNameSuffix}'
   params: {
+    azureBlobsPrivateDnsZoneResourceId: '${privateDnsZoneResourceIdPrefix}${filter(privateDnsZones, name => contains(name, 'blob'))[0]}'
     hostPoolResourceId: hostPool.outputs.resourceId
     location: locationVirtualMachines
     mlzTags: mlzTags

--- a/src/bicep/add-ons/azure-virtual-desktop/solution.json
+++ b/src/bicep/add-ons/azure-virtual-desktop/solution.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "11919321452583755192"
+      "version": "0.34.1.11899",
+      "templateHash": "5543716735760956511"
     }
   },
   "parameters": {
@@ -779,8 +779,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "3340370223092056906"
+              "version": "0.34.1.11899",
+              "templateHash": "13830845035638702557"
             }
           },
           "parameters": {
@@ -1473,8 +1473,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "7122731762643979427"
+              "version": "0.34.1.11899",
+              "templateHash": "17722828064257467102"
             }
           },
           "parameters": {
@@ -1810,8 +1810,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "6049908398330959962"
+                      "version": "0.34.1.11899",
+                      "templateHash": "14057604418116946606"
                     }
                   },
                   "parameters": {
@@ -1890,8 +1890,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "3340370223092056906"
+                              "version": "0.34.1.11899",
+                              "templateHash": "13830845035638702557"
                             }
                           },
                           "parameters": {
@@ -2488,8 +2488,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "1959483107665952306"
+                              "version": "0.34.1.11899",
+                              "templateHash": "14031499182149463334"
                             }
                           },
                           "parameters": {
@@ -2628,8 +2628,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "13158109401467250998"
+                      "version": "0.34.1.11899",
+                      "templateHash": "10012010251915028125"
                     }
                   },
                   "parameters": {
@@ -2760,8 +2760,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "5699910770493601263"
+                      "version": "0.34.1.11899",
+                      "templateHash": "15996854755585226301"
                     }
                   },
                   "parameters": {
@@ -2902,8 +2902,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "2286050725148082731"
+                              "version": "0.34.1.11899",
+                              "templateHash": "6469422934578050435"
                             }
                           },
                           "parameters": {
@@ -3023,8 +3023,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "2197479355586796636"
+                                      "version": "0.34.1.11899",
+                                      "templateHash": "5845820532353190287"
                                     }
                                   },
                                   "parameters": {
@@ -3106,8 +3106,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "14322165813389637925"
+                                      "version": "0.34.1.11899",
+                                      "templateHash": "4737370172954646517"
                                     }
                                   },
                                   "parameters": {
@@ -3209,8 +3209,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "6544693908534760839"
+                                      "version": "0.34.1.11899",
+                                      "templateHash": "9711258169832271304"
                                     }
                                   },
                                   "parameters": {
@@ -3286,8 +3286,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "15898943496915761552"
+                                      "version": "0.34.1.11899",
+                                      "templateHash": "894224976141525614"
                                     }
                                   },
                                   "parameters": {
@@ -3427,8 +3427,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "10365342035466139193"
+                              "version": "0.34.1.11899",
+                              "templateHash": "3114441997750049853"
                             }
                           },
                           "parameters": {
@@ -3480,8 +3480,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "17770613472330861175"
+                                      "version": "0.34.1.11899",
+                                      "templateHash": "6875269073474439316"
                                     }
                                   },
                                   "parameters": {
@@ -3554,8 +3554,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "3614949858583199523"
+                              "version": "0.34.1.11899",
+                              "templateHash": "9201878059518260366"
                             }
                           },
                           "parameters": {
@@ -3607,8 +3607,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "17770613472330861175"
+                                      "version": "0.34.1.11899",
+                                      "templateHash": "6875269073474439316"
                                     }
                                   },
                                   "parameters": {
@@ -3712,8 +3712,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "11161371350834819427"
+                      "version": "0.34.1.11899",
+                      "templateHash": "17827386828044885045"
                     }
                   },
                   "parameters": {
@@ -3770,8 +3770,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "12315209925175936164"
+                              "version": "0.34.1.11899",
+                              "templateHash": "11375228970984740113"
                             }
                           },
                           "parameters": {
@@ -3873,8 +3873,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "368851020518209525"
+                      "version": "0.34.1.11899",
+                      "templateHash": "4058810009880979040"
                     }
                   },
                   "parameters": {
@@ -3962,8 +3962,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "13842310217075485111"
+                              "version": "0.34.1.11899",
+                              "templateHash": "2265253935022422475"
                             }
                           },
                           "parameters": {
@@ -4112,6 +4112,8 @@
                                 }
                               },
                               "dependsOn": [
+                                "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', variables('keyVaultPrivateEndpointName'), format('{0}{1}', parameters('resourceAbbreviations').keyVaults, uniqueString(replace(parameters('tier').namingConvention.keyVault, parameters('tokens').service, 'cmk'), resourceGroup().id)))]",
+                                "[resourceId('Microsoft.Network/privateEndpoints', variables('keyVaultPrivateEndpointName'))]",
                                 "[resourceId('Microsoft.KeyVault/vaults', format('{0}{1}', parameters('resourceAbbreviations').keyVaults, uniqueString(replace(parameters('tier').namingConvention.keyVault, parameters('tokens').service, 'cmk'), resourceGroup().id)))]"
                               ]
                             },
@@ -4150,6 +4152,8 @@
                                 }
                               },
                               "dependsOn": [
+                                "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', variables('keyVaultPrivateEndpointName'), format('{0}{1}', parameters('resourceAbbreviations').keyVaults, uniqueString(replace(parameters('tier').namingConvention.keyVault, parameters('tokens').service, 'cmk'), resourceGroup().id)))]",
+                                "[resourceId('Microsoft.Network/privateEndpoints', variables('keyVaultPrivateEndpointName'))]",
                                 "[resourceId('Microsoft.KeyVault/vaults', format('{0}{1}', parameters('resourceAbbreviations').keyVaults, uniqueString(replace(parameters('tier').namingConvention.keyVault, parameters('tokens').service, 'cmk'), resourceGroup().id)))]"
                               ]
                             }
@@ -4226,8 +4230,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "4892072138782221114"
+                              "version": "0.34.1.11899",
+                              "templateHash": "7083436688077119956"
                             }
                           },
                           "parameters": {
@@ -4306,8 +4310,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "16049255483101382387"
+                                      "version": "0.34.1.11899",
+                                      "templateHash": "14751272044154264187"
                                     }
                                   },
                                   "parameters": {
@@ -4401,8 +4405,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "2463677115445458253"
+                              "version": "0.34.1.11899",
+                              "templateHash": "7456262167517611373"
                             }
                           },
                           "parameters": {
@@ -4565,8 +4569,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "3595773587717469175"
+                      "version": "0.34.1.11899",
+                      "templateHash": "2114276080325792765"
                     }
                   },
                   "parameters": {
@@ -4681,8 +4685,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "11494522993374716339"
+                              "version": "0.34.1.11899",
+                              "templateHash": "6334828117479522135"
                             }
                           },
                           "parameters": {
@@ -4994,8 +4998,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "14720377481988404066"
+                      "version": "0.34.1.11899",
+                      "templateHash": "17392827842829061741"
                     }
                   },
                   "parameters": {
@@ -5090,8 +5094,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "9926516440124754027"
+                              "version": "0.34.1.11899",
+                              "templateHash": "9052835531115096126"
                             }
                           },
                           "parameters": {
@@ -5101,7 +5105,7 @@
                           },
                           "resources": [
                             {
-                              "type": "Microsoft.Insights/diagnosticSettings",
+                              "type": "microsoft.insights/diagnosticSettings",
                               "apiVersion": "2017-05-01-preview",
                               "name": "[format('diag-activity-log-{0}', subscription().subscriptionId)]",
                               "properties": {
@@ -5183,8 +5187,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "7917619042339714964"
+                              "version": "0.34.1.11899",
+                              "templateHash": "15144108493217984038"
                             }
                           },
                           "parameters": {
@@ -5209,7 +5213,7 @@
                           },
                           "resources": [
                             {
-                              "type": "Microsoft.Insights/diagnosticSettings",
+                              "type": "microsoft.insights/diagnosticSettings",
                               "apiVersion": "2017-05-01-preview",
                               "scope": "[format('Microsoft.KeyVault/vaults/{0}', parameters('keyVaultName'))]",
                               "name": "[parameters('keyVaultDiagnosticSettingName')]",
@@ -5282,8 +5286,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "12450943368298134389"
+                              "version": "0.34.1.11899",
+                              "templateHash": "7714133251615165071"
                             }
                           },
                           "parameters": {
@@ -5335,7 +5339,7 @@
                           },
                           "resources": [
                             {
-                              "type": "Microsoft.Insights/diagnosticSettings",
+                              "type": "microsoft.insights/diagnosticSettings",
                               "apiVersion": "2017-05-01-preview",
                               "scope": "[format('Microsoft.Network/networkSecurityGroups/{0}', parameters('networkSecurityGroupName'))]",
                               "name": "[parameters('networkSecurityGroupDiagnosticSettingName')]",
@@ -5390,8 +5394,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "9862576446266869939"
+                                      "version": "0.34.1.11899",
+                                      "templateHash": "2612114996615637949"
                                     }
                                   },
                                   "parameters": {
@@ -5515,8 +5519,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "1459088614317417940"
+                              "version": "0.34.1.11899",
+                              "templateHash": "11261372971830305610"
                             }
                           },
                           "parameters": {
@@ -5577,7 +5581,7 @@
                           },
                           "resources": [
                             {
-                              "type": "Microsoft.Insights/diagnosticSettings",
+                              "type": "microsoft.insights/diagnosticSettings",
                               "apiVersion": "2017-05-01-preview",
                               "scope": "[format('Microsoft.Network/virtualNetworks/{0}', parameters('virtualNetworkName'))]",
                               "name": "[parameters('virtualNetworkDiagnosticSettingName')]",
@@ -5632,8 +5636,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "9862576446266869939"
+                                      "version": "0.34.1.11899",
+                                      "templateHash": "2612114996615637949"
                                     }
                                   },
                                   "parameters": {
@@ -5739,8 +5743,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "3394006715565931478"
+                              "version": "0.34.1.11899",
+                              "templateHash": "7129328730167817953"
                             }
                           },
                           "parameters": {
@@ -5770,7 +5774,7 @@
                           },
                           "resources": [
                             {
-                              "type": "Microsoft.Insights/diagnosticSettings",
+                              "type": "microsoft.insights/diagnosticSettings",
                               "apiVersion": "2017-05-01-preview",
                               "scope": "[format('Microsoft.Network/networkInterfaces/{0}', split(parameters('networkInterfaceResourceId'), '/')[8])]",
                               "name": "[variables('networkInterfaceDiagnosticSettingName')]",
@@ -5841,8 +5845,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "17659470587883886364"
+                      "version": "0.34.1.11899",
+                      "templateHash": "16859922847667031950"
                     }
                   },
                   "parameters": {
@@ -5911,8 +5915,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "14343664420377969832"
+                              "version": "0.34.1.11899",
+                              "templateHash": "8924282358047525589"
                             }
                           },
                           "parameters": {
@@ -6075,8 +6079,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "16049255483101382387"
+                                      "version": "0.34.1.11899",
+                                      "templateHash": "14751272044154264187"
                                     }
                                   },
                                   "parameters": {
@@ -6157,8 +6161,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "5325637338183897217"
+                      "version": "0.34.1.11899",
+                      "templateHash": "11433912083772044204"
                     }
                   },
                   "parameters": {
@@ -6595,8 +6599,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "9383652191641831528"
+              "version": "0.34.1.11899",
+              "templateHash": "12399992938872708177"
             }
           },
           "parameters": {
@@ -6832,8 +6836,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "2334232117024809252"
+                      "version": "0.34.1.11899",
+                      "templateHash": "14926382700516108428"
                     }
                   },
                   "parameters": {
@@ -7019,8 +7023,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "2543636189786771622"
+                              "version": "0.34.1.11899",
+                              "templateHash": "11415007834860518992"
                             }
                           },
                           "parameters": {
@@ -7101,8 +7105,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "2543636189786771622"
+                              "version": "0.34.1.11899",
+                              "templateHash": "11415007834860518992"
                             }
                           },
                           "parameters": {
@@ -7277,8 +7281,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "16291744115203797055"
+                      "version": "0.34.1.11899",
+                      "templateHash": "3126494724423110713"
                     }
                   },
                   "parameters": {
@@ -7488,6 +7492,9 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
+                  "azureBlobsPrivateDnsZoneResourceId": {
+                    "value": "[format('{0}{1}', parameters('privateDnsZoneResourceIdPrefix'), filter(parameters('privateDnsZones'), lambda('name', contains(lambdaVariables('name'), 'blob')))[0])]"
+                  },
                   "hostPoolResourceId": {
                     "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('deploy-vdpool-{0}', parameters('deploymentNameSuffix'))), '2022-09-01').outputs.resourceId.value]"
                   },
@@ -7513,11 +7520,14 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "13224111647741044672"
+                      "version": "0.34.1.11899",
+                      "templateHash": "16259179113250600822"
                     }
                   },
                   "parameters": {
+                    "azureBlobsPrivateDnsZoneResourceId": {
+                      "type": "string"
+                    },
                     "hostPoolResourceId": {
                       "type": "string"
                     },
@@ -7572,6 +7582,24 @@
                       "dependsOn": [
                         "[resourceId('Microsoft.Compute/diskAccesses', parameters('namingConvention').diskAccess)]"
                       ]
+                    },
+                    {
+                      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                      "apiVersion": "2021-08-01",
+                      "name": "[format('{0}/{1}', parameters('namingConvention').diskAccessPrivateEndpoint, parameters('namingConvention').diskAccess)]",
+                      "properties": {
+                        "privateDnsZoneConfigs": [
+                          {
+                            "name": "ipconfig1",
+                            "properties": {
+                              "privateDnsZoneId": "[parameters('azureBlobsPrivateDnsZoneResourceId')]"
+                            }
+                          }
+                        ]
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/privateEndpoints', parameters('namingConvention').diskAccessPrivateEndpoint)]"
+                      ]
                     }
                   ],
                   "outputs": {
@@ -7614,8 +7642,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "14571299723796855163"
+                      "version": "0.34.1.11899",
+                      "templateHash": "6206699697126316424"
                     }
                   },
                   "parameters": {
@@ -7695,8 +7723,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "6996777683199613501"
+                              "version": "0.34.1.11899",
+                              "templateHash": "17581780906100195806"
                             }
                           },
                           "parameters": {
@@ -7783,8 +7811,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "1933651504498121622"
+                      "version": "0.34.1.11899",
+                      "templateHash": "5953822691115636856"
                     }
                   },
                   "parameters": {
@@ -7855,8 +7883,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "8849155191857852408"
+                      "version": "0.34.1.11899",
+                      "templateHash": "15779562775451031754"
                     }
                   },
                   "parameters": {
@@ -7961,8 +7989,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "7203095478533433707"
+                      "version": "0.34.1.11899",
+                      "templateHash": "2725968523855082120"
                     }
                   },
                   "parameters": {
@@ -8299,8 +8327,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "5524152351844635809"
+                      "version": "0.34.1.11899",
+                      "templateHash": "184571667696457679"
                     }
                   },
                   "parameters": {
@@ -8431,8 +8459,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "10151057342046048139"
+                              "version": "0.34.1.11899",
+                              "templateHash": "1685632920010747671"
                             }
                           },
                           "parameters": {
@@ -8564,8 +8592,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "9372668790437275988"
+                      "version": "0.34.1.11899",
+                      "templateHash": "9688408431205286784"
                     }
                   },
                   "parameters": {
@@ -8837,8 +8865,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "3764029471326746076"
+                      "version": "0.34.1.11899",
+                      "templateHash": "1769314533337485753"
                     }
                   },
                   "parameters": {
@@ -9209,7 +9237,7 @@
                     },
                     {
                       "condition": "[parameters('enableApplicationInsights')]",
-                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "type": "microsoft.insights/diagnosticSettings",
                       "apiVersion": "2017-05-01-preview",
                       "scope": "[format('Microsoft.Storage/storageAccounts/{0}/blobServices/{1}', uniqueString(replace(parameters('namingConvention').storageAccount, parameters('serviceToken'), variables('service')), resourceGroup().id), 'default')]",
                       "name": "[replace(parameters('namingConvention').storageAccountDiagnosticSetting, format('{0}-{1}', parameters('serviceToken'), parameters('resourceAbbreviations').storageAccounts), format('blob-{0}-scale', parameters('resourceAbbreviations').storageAccounts))]",
@@ -9400,8 +9428,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "2543636189786771622"
+                              "version": "0.34.1.11899",
+                              "templateHash": "11415007834860518992"
                             }
                           },
                           "parameters": {
@@ -9485,8 +9513,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "1711449174033960437"
+                              "version": "0.34.1.11899",
+                              "templateHash": "11499834779329225922"
                             }
                           },
                           "parameters": {
@@ -9551,8 +9579,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "14605925531137835605"
+                              "version": "0.34.1.11899",
+                              "templateHash": "6142840177472827902"
                             }
                           },
                           "parameters": {
@@ -9790,8 +9818,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "17615243235627750369"
+              "version": "0.34.1.11899",
+              "templateHash": "16670797709428408730"
             }
           },
           "parameters": {
@@ -9918,8 +9946,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "13158109401467250998"
+                      "version": "0.34.1.11899",
+                      "templateHash": "10012010251915028125"
                     }
                   },
                   "parameters": {
@@ -10006,8 +10034,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "17168145641757378904"
+                      "version": "0.34.1.11899",
+                      "templateHash": "777789742046511985"
                     }
                   },
                   "parameters": {
@@ -10126,8 +10154,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "13158109401467250998"
+                      "version": "0.34.1.11899",
+                      "templateHash": "10012010251915028125"
                     }
                   },
                   "parameters": {
@@ -10208,8 +10236,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "8849155191857852408"
+                      "version": "0.34.1.11899",
+                      "templateHash": "15779562775451031754"
                     }
                   },
                   "parameters": {
@@ -10269,8 +10297,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "8849155191857852408"
+                      "version": "0.34.1.11899",
+                      "templateHash": "15779562775451031754"
                     }
                   },
                   "parameters": {
@@ -10383,8 +10411,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "126663344650872049"
+                      "version": "0.34.1.11899",
+                      "templateHash": "13137443848405418360"
                     }
                   },
                   "parameters": {
@@ -10591,8 +10619,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "10151057342046048139"
+                              "version": "0.34.1.11899",
+                              "templateHash": "1685632920010747671"
                             }
                           },
                           "parameters": {
@@ -10800,8 +10828,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "10945394099093057615"
+              "version": "0.34.1.11899",
+              "templateHash": "17595190410899639692"
             }
           },
           "parameters": {
@@ -10965,8 +10993,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "8849155191857852408"
+                      "version": "0.34.1.11899",
+                      "templateHash": "15779562775451031754"
                     }
                   },
                   "parameters": {
@@ -11026,8 +11054,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "8849155191857852408"
+                      "version": "0.34.1.11899",
+                      "templateHash": "15779562775451031754"
                     }
                   },
                   "parameters": {
@@ -11141,8 +11169,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "11485314396300231285"
+                      "version": "0.34.1.11899",
+                      "templateHash": "2014560709383495142"
                     }
                   },
                   "parameters": {
@@ -11343,8 +11371,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "11878019647178454311"
+                              "version": "0.34.1.11899",
+                              "templateHash": "7744366408172607759"
                             }
                           },
                           "parameters": {
@@ -11535,8 +11563,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "5309767814758748872"
+                      "version": "0.34.1.11899",
+                      "templateHash": "9231305048869280881"
                     }
                   },
                   "parameters": {
@@ -11839,8 +11867,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "9655434265407476220"
+                              "version": "0.34.1.11899",
+                              "templateHash": "7336851739426166507"
                             }
                           },
                           "parameters": {
@@ -11980,8 +12008,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "11878019647178454311"
+                              "version": "0.34.1.11899",
+                              "templateHash": "7744366408172607759"
                             }
                           },
                           "parameters": {
@@ -12092,8 +12120,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "9898786582710350827"
+                              "version": "0.34.1.11899",
+                              "templateHash": "10052156350004931187"
                             }
                           },
                           "parameters": {
@@ -12179,8 +12207,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "2147725329924878551"
+                                      "version": "0.34.1.11899",
+                                      "templateHash": "7586579032800302632"
                                     }
                                   },
                                   "parameters": {
@@ -12478,8 +12506,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "12102397646009247151"
+              "version": "0.34.1.11899",
+              "templateHash": "5373830296761167880"
             }
           },
           "parameters": {
@@ -12731,8 +12759,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "6996777683199613501"
+                      "version": "0.34.1.11899",
+                      "templateHash": "17581780906100195806"
                     }
                   },
                   "parameters": {
@@ -12808,8 +12836,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "5983368263339613077"
+                      "version": "0.34.1.11899",
+                      "templateHash": "12389721382694893559"
                     }
                   },
                   "parameters": {
@@ -12887,8 +12915,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "8849155191857852408"
+                      "version": "0.34.1.11899",
+                      "templateHash": "15779562775451031754"
                     }
                   },
                   "parameters": {
@@ -12981,8 +13009,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "10151057342046048139"
+                      "version": "0.34.1.11899",
+                      "templateHash": "1685632920010747671"
                     }
                   },
                   "parameters": {
@@ -13096,8 +13124,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "10151057342046048139"
+                      "version": "0.34.1.11899",
+                      "templateHash": "1685632920010747671"
                     }
                   },
                   "parameters": {
@@ -13316,8 +13344,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "13325705085166385063"
+                      "version": "0.34.1.11899",
+                      "templateHash": "850091205163526018"
                     }
                   },
                   "parameters": {
@@ -13962,8 +13990,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "10151057342046048139"
+                              "version": "0.34.1.11899",
+                              "templateHash": "1685632920010747671"
                             }
                           },
                           "parameters": {
@@ -14097,8 +14125,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "10151057342046048139"
+                              "version": "0.34.1.11899",
+                              "templateHash": "1685632920010747671"
                             }
                           },
                           "parameters": {
@@ -14218,8 +14246,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "2666190338120011793"
+                      "version": "0.34.1.11899",
+                      "templateHash": "96008223799401807"
                     }
                   },
                   "parameters": {
@@ -14304,8 +14332,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "15539616720755784365"
+                              "version": "0.34.1.11899",
+                              "templateHash": "7734276502019640484"
                             }
                           },
                           "parameters": {
@@ -14427,8 +14455,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "5410711218090059193"
+                      "version": "0.34.1.11899",
+                      "templateHash": "8068334909403399577"
                     }
                   },
                   "parameters": {
@@ -14672,8 +14700,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "18345392855057711544"
+              "version": "0.34.1.11899",
+              "templateHash": "355004101154503691"
             }
           },
           "parameters": {
@@ -14756,8 +14784,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "10151057342046048139"
+                      "version": "0.34.1.11899",
+                      "templateHash": "1685632920010747671"
                     }
                   },
                   "parameters": {


### PR DESCRIPTION
# Description

Added the DNS zone group to the Disk Access deployment to ensure the private IP is added to the private DNS zone.

## Issue reference

The issue this PR will close: #1170 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR

Test Deployment Confirmation

![image](https://github.com/user-attachments/assets/7f31aae2-c157-45c8-8a0e-a0ec3da299c0)

