### PR TITLE
OnboardingStates API Usage to Properly Onboard Microsoft Sentinel

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -19,7 +19,7 @@ jobs:
     name: lint-codebase
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:          
           fetch-depth: 0 # Full git history is needed to get a proper list of changed files within `super-linter`
       - uses: github/super-linter/slim@v7 # use the slim linter since we don't use rust, dotenv, armttk, pwsh, or c#

--- a/.github/workflows/validate-build-bicep.yml
+++ b/.github/workflows/validate-build-bicep.yml
@@ -28,7 +28,7 @@ jobs:
       security-events: write
       statuses: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: |


### PR DESCRIPTION
# Problem
When adding Microsoft Sentinel via MissionLZ, the API connection will fail as it is not onboarded. Citing ALZ with a similar problem, the issue is that there is a new OnboardingAPI that is required since July 2024. See the following quote from that PR:

> This PR includes a call to the OnboardingStates API for correctly onboarding Sentinel. The simple deployment of the "SecurityInsights" solution is considered deprecated since July 1st. Source: https://techcommunity.microsoft.com/t5/microsoft-sentinel-blog/what-s-new-azure-sentinel-new-onboarding-offboarding-api/bc-p/3671438 and mail from MS linked in the issue https://github.com/Azure/Azure-Landing-Zones/issues/2659.


> Why is the SecurityInsights solution still deployed and not removed? The onboardingStates API doesn't allow setting the SKU for Sentinel. Since this is an option within this template, I've left the deployment as is.

# Solution
Add a call to the Microsoft Sentinel OnboardingStates API in log-analytics-workspace.bicep to properly onboard Sentinel workspaces. This addresses the deprecation of the simple SecurityInsights solution deployment method that became effective July 1st, 2024.

The SecurityInsights solution deployment will be retained alongside the new onboarding API call because:

The OnboardingStates API does not support SKU configuration
MissionLZ templates provide SKU selection options that must be preserved
Both resources can coexist to maintain full functionality
# Changes
Add a new Microsoft.SecurityInsights/onboardingStates resource to log-analytics-workspace.bicep that:

- Deploys when deploySentinel parameter is true
- Depends on the Log Analytics workspace and SecurityInsights solution
- Uses the name format: {workspaceName}/default
- Properly onboards Sentinel via the supported API

This follows the same pattern implemented in ALZ-Bicep PR Azure/ALZ-Bicep#811.