### PR TITLE
Update defaults to enable defender for server and storage in allignme…

### DIFF
--- a/src/mlz.bicep
+++ b/src/mlz.bicep
@@ -102,7 +102,7 @@ param deployDefender bool = true
 // Allowed Values for paid workload protection Plans.  
 // Users must select a plan from portal ui def or manually specify any of the plans that are available in the desired cloud.  
 // The portal does not parse the allowed values field for arrays  correctly at this time.
-// As a default, the array is set to ['VirtualMachines'].
+// As a default, the array is set to ['VirtualMachines', 'StorageAccounts'].
 /*   'Api'
   'AppServices'
   'Arm'
@@ -119,8 +119,11 @@ param deployDefender bool = true
   'StorageAccounts'
   'VirtualMachine*/
 
-@description('The Paid Workload Protection plans for Defender for Cloud. Default value = "VirtualMachines". See the following URL for valid settings: https://learn.microsoft.com/rest/api/defenderforcloud-composite/pricings/update?view=rest-defenderforcloud-composite-latest&tabs=HTTP.')
-param deployDefenderPlans array = ['VirtualMachines']
+@description('The Paid Workload Protection plans for Defender for Cloud. Default value = "VirtualMachines, StorageAccounts". See the following URL for valid settings: https://learn.microsoft.com/rest/api/defenderforcloud-composite/pricings/update?view=rest-defenderforcloud-composite-latest&tabs=HTTP.')
+param deployDefenderPlans array = [
+  'VirtualMachines'
+  'StorageAccounts'
+]
 
 @description('Choose to deploy the identity resources. The identity resoures are not required if you plan to use cloud identities.')
 param deployIdentity bool = false
@@ -992,6 +995,8 @@ module monitoring 'modules/monitoring.bicep' = {
   params: {
     delimiter: networking.outputs.delimiter
     deploymentNameSuffix: deploymentNameSuffix
+    deployDefender: deployDefender
+    deployDefenderPlans: deployDefenderPlans
     deploySentinel: deploySentinel
     location: location
     logAnalyticsWorkspaceCappingDailyQuotaGb: logAnalyticsWorkspaceCappingDailyQuotaGb

--- a/src/mlz.json
+++ b/src/mlz.json
@@ -184,10 +184,11 @@
     "deployDefenderPlans": {
       "type": "array",
       "defaultValue": [
-        "VirtualMachines"
+        "VirtualMachines",
+        "StorageAccounts"
       ],
       "metadata": {
-        "description": "The Paid Workload Protection plans for Defender for Cloud. Default value = \"VirtualMachines\". See the following URL for valid settings: https://learn.microsoft.com/rest/api/defenderforcloud-composite/pricings/update?view=rest-defenderforcloud-composite-latest&tabs=HTTP."
+        "description": "The Paid Workload Protection plans for Defender for Cloud. Default value = \"VirtualMachines, StorageAccounts\". See the following URL for valid settings: https://learn.microsoft.com/rest/api/defenderforcloud-composite/pricings/update?view=rest-defenderforcloud-composite-latest&tabs=HTTP."
       }
     },
     "deployIdentity": {
@@ -4645,6 +4646,12 @@
           "deploymentNameSuffix": {
             "value": "[parameters('deploymentNameSuffix')]"
           },
+          "deployDefender": {
+            "value": "[parameters('deployDefender')]"
+          },
+          "deployDefenderPlans": {
+            "value": "[parameters('deployDefenderPlans')]"
+          },
           "deploySentinel": {
             "value": "[parameters('deploySentinel')]"
           },
@@ -4693,6 +4700,12 @@
             "deploymentNameSuffix": {
               "type": "string"
             },
+            "deployDefender": {
+              "type": "bool"
+            },
+            "deployDefenderPlans": {
+              "type": "array"
+            },
             "deploySentinel": {
               "type": "bool"
             },
@@ -4737,6 +4750,12 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
+                  "deployDefender": {
+                    "value": "[parameters('deployDefender')]"
+                  },
+                  "deployDefenderPlans": {
+                    "value": "[parameters('deployDefenderPlans')]"
+                  },
                   "deploySentinel": {
                     "value": "[parameters('deploySentinel')]"
                   },
@@ -4773,6 +4792,14 @@
                     }
                   },
                   "parameters": {
+                    "deployDefender": {
+                      "type": "bool",
+                      "defaultValue": false
+                    },
+                    "deployDefenderPlans": {
+                      "type": "array",
+                      "defaultValue": []
+                    },
                     "deploySentinel": {
                       "type": "bool",
                       "defaultValue": false
@@ -4819,35 +4846,35 @@
                         "promotionCode": ""
                       },
                       {
-                        "deploy": true,
+                        "deploy": "[and(parameters('deployDefender'), contains(parameters('deployDefenderPlans'), 'VirtualMachines'))]",
                         "name": "VMInsights",
                         "product": "OMSGallery/VMInsights",
                         "publisher": "Microsoft",
                         "promotionCode": ""
                       },
                       {
-                        "deploy": true,
+                        "deploy": "[and(parameters('deployDefender'), contains(parameters('deployDefenderPlans'), 'VirtualMachines'))]",
                         "name": "Security",
                         "product": "OMSGallery/Security",
                         "publisher": "Microsoft",
                         "promotionCode": ""
                       },
                       {
-                        "deploy": true,
+                        "deploy": "[and(parameters('deployDefender'), contains(parameters('deployDefenderPlans'), 'VirtualMachines'))]",
                         "name": "ServiceMap",
                         "publisher": "Microsoft",
                         "product": "OMSGallery/ServiceMap",
                         "promotionCode": ""
                       },
                       {
-                        "deploy": true,
+                        "deploy": "[and(parameters('deployDefender'), contains(parameters('deployDefenderPlans'), 'Containers'))]",
                         "name": "ContainerInsights",
                         "publisher": "Microsoft",
                         "product": "OMSGallery/ContainerInsights",
                         "promotionCode": ""
                       },
                       {
-                        "deploy": true,
+                        "deploy": "[and(parameters('deployDefender'), contains(parameters('deployDefenderPlans'), 'KeyVaults'))]",
                         "name": "KeyVaultAnalytics",
                         "publisher": "Microsoft",
                         "product": "OMSGallery/KeyVaultAnalytics",

--- a/src/mlz.json
+++ b/src/mlz.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "186370419513569005"
+      "templateHash": "7101226084940591179"
     }
   },
   "parameters": {
@@ -4690,7 +4690,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.39.26.7824",
-              "templateHash": "15569599574895730028"
+              "templateHash": "6933768782078636945"
             }
           },
           "parameters": {
@@ -4788,7 +4788,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.39.26.7824",
-                      "templateHash": "17606964580718569021"
+                      "templateHash": "10184423686401879984"
                     }
                   },
                   "parameters": {

--- a/src/mlz.uiDefinition.json
+++ b/src/mlz.uiDefinition.json
@@ -745,7 +745,7 @@
                   "name": "defenderSubscriptionDetailsText",
                   "type": "Microsoft.Common.TextBlock",
                   "options": {
-                    "text": "For further enhanced protection, MLZ has the option of activiating the paid features of Defender for Cloud, such as: Defender Cloud Security Posture Management (DCSPM) and workload protection plans for additional threat protection for resources, such as: servers, storage, and more."
+                    "text": "For further enhanced protection, MLZ has the option of activiating the paid features of Defender for Cloud, such as: Defender Cloud Security Posture Management (DCSPM) and workload protection plans for additional threat protection for resources, such as: servers, storage, and more. Default selections align with SCCA and BCAP recommended protections for servers and storage. Selected plans are paid Microsoft Defender for Cloud features and may incur additional Azure charges. Modify the selections to match your mission and compliance requirements."
                   }
                 },
                 {
@@ -760,6 +760,7 @@
                 {
                   "name": "deployDefender",
                   "type": "Microsoft.Common.CheckBox",
+                  "defaultValue": true,
                   "label": "Enable additional features for Microsoft Defender for Cloud?",
                   "toolTip": "Check here to enable additional paid features of Microsoft Defender for Cloud.",
                   "constraints": {
@@ -781,7 +782,14 @@
                   "type": "Microsoft.Common.DropDown",
                   "label": "Defender for Cloud Additional Features",
                   "placeholder": "",
-                  "defaultValue": "VirtualMachines",
+                  "defaultValue": [
+                    {
+                      "value": "VirtualMachines"
+                    },
+                    {
+                      "value": "StorageAccounts"
+                    }
+                  ],
                   "toolTip": "Check feature availability of paid Defender for Cloud features",
                   "multiselect": true,
                   "selectAll": false,
@@ -1631,7 +1639,8 @@
         "deployActiveDirectoryDomainServices": "[steps('identity').addsSection.deployADDS]",
         "deployAzureGatewaySubnet": "[steps('remoteAccess').azureGatewaySubnetSection.deployAzureGatewaySubnet]",
         "deployBastion": "[steps('remoteAccess').azureBastionSection.deployBastion]",
-        "deployDefenderPlans": "[steps('compliance').defenderSection.deployDefenderPlans]",
+        "deployDefender": "[steps('compliance').defenderSection.deployDefender]",
+        "deployDefenderPlans": "[if(steps('compliance').defenderSection.deployDefender, if(empty(steps('compliance').defenderSection.deployDefenderPlans), parse('[]'), steps('compliance').defenderSection.deployDefenderPlans), parse('[]'))]",
         "deployIdentity": "[steps('basics').identitySection.deployIdentity]",
         "deployLinuxVirtualMachine": "[steps('remoteAccess').linuxVmSection.deployLinuxVirtualMachine]",
         "deployNetworkWatcherTrafficAnalytics": "[steps('networking').flowLogsSection.deployTrafficAnalytics]",

--- a/src/modules/log-analytics-workspace.bicep
+++ b/src/modules/log-analytics-workspace.bicep
@@ -3,6 +3,8 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT License.
 */
 
+param deployDefender bool = false
+param deployDefenderPlans array = []
 param deploySentinel bool = false
 param location string
 param mlzTags object
@@ -29,35 +31,35 @@ var solutions = [
     promotionCode: ''
   }
   {
-    deploy: true
+    deploy: deployDefender && contains(deployDefenderPlans, 'VirtualMachines')
     name: 'VMInsights'
     product: 'OMSGallery/VMInsights'
     publisher: 'Microsoft'
     promotionCode: '' 
   }
   {
-    deploy: true
+    deploy: deployDefender && contains(deployDefenderPlans, 'VirtualMachines')
     name: 'Security'
     product: 'OMSGallery/Security'
     publisher: 'Microsoft'
     promotionCode: ''
   }
   {
-    deploy: true
+    deploy: deployDefender && contains(deployDefenderPlans, 'VirtualMachines')
     name: 'ServiceMap'
     publisher: 'Microsoft'
     product: 'OMSGallery/ServiceMap'
     promotionCode: ''
   }
   {
-    deploy: true
+    deploy: deployDefender && contains(deployDefenderPlans, 'Containers')
     name: 'ContainerInsights'
     publisher: 'Microsoft'
     product: 'OMSGallery/ContainerInsights'
     promotionCode: ''
   }
   {
-    deploy: true
+    deploy: deployDefender && contains(deployDefenderPlans, 'KeyVaults')
     name: 'KeyVaultAnalytics'
     publisher: 'Microsoft'
     product: 'OMSGallery/KeyVaultAnalytics'

--- a/src/modules/monitoring.bicep
+++ b/src/modules/monitoring.bicep
@@ -7,6 +7,8 @@ targetScope = 'subscription'
 
 param delimiter string
 param deploymentNameSuffix string
+param deployDefender bool
+param deployDefenderPlans array
 param deploySentinel bool
 param location string
 param logAnalyticsWorkspaceCappingDailyQuotaGb int
@@ -22,6 +24,8 @@ module logAnalyticsWorkspace 'log-analytics-workspace.bicep' = {
   name: 'deploy-law-${deploymentNameSuffix}'
   scope: resourceGroup(tier.subscriptionId, tier.resourceGroupName)
   params: {
+    deployDefender: deployDefender
+    deployDefenderPlans: deployDefenderPlans
     deploySentinel: deploySentinel
     location: location
     mlzTags: mlzTags


### PR DESCRIPTION
…nt with SCCA requirements VDMS 2.1.3.1, VDMS 2.1.3.2, and BCAP 2.1.1.1.7 and updated tooltip in template

# Description

Adjusted Defender for Server and Defender for Storage to be on by default in alignment with VDMS 2.1.3.1, VDMS 2.1.3.2, and BCAP 2.1.1.1.7.

## Issue reference

The issue this PR will close: #[issue number]

Not aligned with an outstanding issue.

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [ ] All acceptance criteria in the backlog item are met
* [ X] The documentation is updated to cover any new or changed features (updated documentation and tooltips to reflect change)
* [ ] Manual tests have passed
* [ ] Relevant issues are linked to this PR
